### PR TITLE
Rewrite packages.PlatformStrings (again)

### DIFF
--- a/config/platform.go
+++ b/config/platform.go
@@ -96,14 +96,24 @@ var (
 
 	// KnownArchSet is the set of architectures that Go supports.
 	KnownArchSet map[string]bool
+
+	// KnownOSArchs is a map from OS to the archictures they run on.
+	KnownOSArchs map[string][]string
+
+	// KnownArchOSs is a map from architectures to that OSs that run on them.
+	KnownArchOSs map[string][]string
 )
 
 func init() {
 	KnownOSSet = make(map[string]bool)
 	KnownArchSet = make(map[string]bool)
+	KnownOSArchs = make(map[string][]string)
+	KnownArchOSs = make(map[string][]string)
 	for _, p := range KnownPlatforms {
 		KnownOSSet[p.OS] = true
 		KnownArchSet[p.Arch] = true
+		KnownOSArchs[p.OS] = append(KnownOSArchs[p.OS], p.Arch)
+		KnownArchOSs[p.Arch] = append(KnownArchOSs[p.Arch], p.OS)
 	}
 	KnownOSs = make([]string, 0, len(KnownOSSet))
 	KnownArchs = make([]string, 0, len(KnownArchSet))

--- a/packages/fileinfo_go.go
+++ b/packages/fileinfo_go.go
@@ -143,13 +143,14 @@ func saveCgo(info *fileInfo, cg *ast.CommentGroup) error {
 			}
 			opts[i] = opt
 		}
+		joinedStr := strings.Join(opts, OptSeparator)
 
 		// Add tags to appropriate list.
 		switch verb {
 		case "CFLAGS", "CPPFLAGS", "CXXFLAGS":
-			info.copts = append(info.copts, taggedOpts{tags, opts})
+			info.copts = append(info.copts, taggedOpts{tags, joinedStr})
 		case "LDFLAGS":
-			info.clinkopts = append(info.clinkopts, taggedOpts{tags, opts})
+			info.clinkopts = append(info.clinkopts, taggedOpts{tags, joinedStr})
 		case "pkg-config":
 			return fmt.Errorf("%s: pkg-config not supported: %s", info.path, orig)
 		default:

--- a/packages/fileinfo_go_test.go
+++ b/packages/fileinfo_go_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -225,12 +226,12 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
-					{opts: []string{"-O1"}},
-					{opts: []string{"-O2"}},
+					{opts: "-O0"},
+					{opts: "-O1"},
+					{opts: "-O2"},
 				},
 				clinkopts: []taggedOpts{
-					{opts: []string{"-O3", "-O4"}},
+					{opts: strings.Join([]string{"-O3", "-O4"}, OptSeparator)},
 				},
 			},
 		},
@@ -248,7 +249,7 @@ import "C"
 				copts: []taggedOpts{
 					{
 						tags: tagLine{{"foo"}, {"bar", "!baz"}},
-						opts: []string{"-O0"},
+						opts: "-O0",
 					},
 				},
 			},
@@ -264,8 +265,8 @@ import "C"
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
-					{opts: []string{"-O1"}},
+					{opts: "-O0"},
+					{opts: "-O1"},
 				},
 			},
 		},
@@ -281,7 +282,7 @@ import ("C")
 			fileInfo{
 				isCgo: true,
 				copts: []taggedOpts{
-					{opts: []string{"-O0"}},
+					{opts: "-O0"},
 				},
 			},
 		},
@@ -367,7 +368,7 @@ import "C"
 				Generic: []string{"sub.go"},
 			},
 			COpts: PlatformStrings{
-				Generic: []string{"-Isub/..", optSeparator},
+				Generic: []string{"-Isub/.."},
 			},
 			Cgo: true,
 		},

--- a/packages/fileinfo_test.go
+++ b/packages/fileinfo_test.go
@@ -280,30 +280,6 @@ func TestFileNameInfo(t *testing.T) {
 	}
 }
 
-func TestJoinOptions(t *testing.T) {
-	for _, tc := range []struct {
-		opts, want []string
-	}{
-		{
-			opts: nil,
-			want: nil,
-		}, {
-			opts: []string{"a", "b", optSeparator},
-			want: []string{"a b"},
-		}, {
-			opts: []string{`a\`, `b'`, `c"`, `d `, optSeparator},
-			want: []string{`a\\ b\' c\" d\ `},
-		}, {
-			opts: []string{"a", "b", optSeparator, "c", optSeparator},
-			want: []string{"a b", "c"},
-		},
-	} {
-		if got := JoinOptions(tc.opts); !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("JoinOptions(%#v): got %#v ; want %#v", tc.opts, got, tc.want)
-		}
-	}
-}
-
 func TestReadTags(t *testing.T) {
 	for _, tc := range []struct {
 		desc, source string

--- a/packages/walk_test.go
+++ b/packages/walk_test.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/packages"
+	bf "github.com/bazelbuild/buildtools/build"
 )
 
 func tempDir() (string, error) {
@@ -431,7 +431,7 @@ import "github.com/jr_hacker/stuff"
 			Rel:  "gen",
 			Library: packages.GoTarget{
 				Sources: packages.PlatformStrings{
-					Generic: []string{"foo.go", "bar.go", "y.s", "baz.go"},
+					Generic: []string{"bar.go", "baz.go", "foo.go", "y.s"},
 				},
 				Imports: packages.PlatformStrings{
 					Generic: []string{"github.com/jr_hacker/stuff"},
@@ -474,7 +474,7 @@ import "github.com/jr_hacker/stuff"
 			Rel:  "gen",
 			Library: packages.GoTarget{
 				Sources: packages.PlatformStrings{
-					Generic: []string{"foo.go", "bar.go", "x.c", "y.s", "z.S", "baz.go"},
+					Generic: []string{"bar.go", "baz.go", "foo.go", "x.c", "y.s", "z.S"},
 				},
 				Imports: packages.PlatformStrings{
 					Generic: []string{"github.com/jr_hacker/stuff"},
@@ -671,7 +671,7 @@ func TestMalformedGoFile(t *testing.T) {
 			Name: "foo",
 			Library: packages.GoTarget{
 				Sources: packages.PlatformStrings{
-					Generic: []string{"b.go", "a.go"},
+					Generic: []string{"a.go", "b.go"},
 				},
 			},
 		},

--- a/testdata/repo/cgolib/BUILD.want
+++ b/testdata/repo/cgolib/BUILD.want
@@ -17,8 +17,8 @@ go_library(
     cgo = True,
     clinkopts = ["-lweird"],
     copts = [
-        "-I/weird/path -Icgolib/sub",
         "-I cgolib/sub -iquote cgolib/sub",
+        "-I/weird/path -Icgolib/sub",
     ],
     importpath = "example.com/repo/cgolib",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
PackageStrings needed a new invariant: strings must not be duplicated
across sets. For example, the same string cannot be OS-specific and
platform-specific. Bazel rejects build files where this is the case
for deps.

This change introduces platformStringsBuilder. Strings are added to
sets, and information is stored about which set each string belongs
to. The Map and Clean methods are removed; when PlatformStrings is
built, it is already clean.

This affects option strings somewhat. Unprocessed groups of options
are stored as strings with OptSeparator between each option. rules is
now responsible for splitting and quoting these.

This means order is no longer preserved for option strings (they will
be sorted when PlatformStrings is built). We couldn't actually
guarantee order before: for example, if a file contained an
arch-specific #cgo directive, followed by an OS-specific #cgo
directive, they would already appear in the wrong order.

Fixes #28