### PR TITLE
Migrate go_grpc_library to go_proto_library with compilers

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -788,7 +788,7 @@ service {}
 		path: config.DefaultValidBuildFileNames[0],
 		content: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "repo_proto",
@@ -796,17 +796,18 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
+go_proto_library(
+    name = "repo_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "example.com/repo",
+    proto = ":repo_proto",
+    visibility = ["//visibility:public"],
+)
+
 go_library(
     name = "go_default_library",
     embed = [":repo_go_proto"],
     importpath = "example.com/repo",
-    visibility = ["//visibility:public"],
-)
-
-go_grpc_library(
-    name = "repo_go_proto",
-    importpath = "example.com/repo",
-    proto = ":repo_proto",
     visibility = ["//visibility:public"],
 )
 `,

--- a/config/constants.go
+++ b/config/constants.go
@@ -35,6 +35,10 @@ const (
 	// DefaultCgoLibName is the name of the default cgo_library rule in a Go package directory.
 	DefaultCgoLibName = "cgo_default_library"
 
+	// GrpcCompilerLabel is the label for the gRPC compiler plugin, used in the
+	// "compilers" attribute of go_proto_library rules.
+	GrpcCompilerLabel = "@io_bazel_rules_go//proto:go_grpc"
+
 	// WellKnownTypesProtoRepo is the repository containing proto_library rules
 	// for the Well Known Types.
 	WellKnownTypesProtoRepo = "com_google_protobuf"

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -18,8 +18,8 @@ package merger
 import (
 	"testing"
 
-	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/bazel-gazelle/config"
+	bf "github.com/bazelbuild/buildtools/build"
 )
 
 type fixTestCase struct {
@@ -246,6 +246,41 @@ go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
     embed = [":go_default_library"],
+)
+`,
+		},
+		// migrateGrpcCompilers tests
+		{
+			desc: "go_grpc_library migrated to compilers",
+			old: `load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_grpc_library(
+    name = "foo_go_proto",
+    importpath = "example.com/repo",
+    proto = ":foo_proto",
+    visibility = ["//visibility:public"],
+)
+`,
+			want: `load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "foo_go_proto",
+    importpath = "example.com/repo",
+    proto = ":foo_proto",
+    visibility = ["//visibility:public"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
 )
 `,
 		},

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -55,13 +55,8 @@ func init() {
 		"go_binary",
 		"go_test",
 		"go_proto_library",
-		"go_grpc_library",
 	}
-	goProtoKinds := []string{
-		"go_proto_library",
-		"go_grpc_library",
-	}
-	allKinds := append(append(goKinds, goProtoKinds...), "proto_library")
+	allKinds := append(goKinds, "proto_library")
 
 	preResolveCommonAttrs := []string{"srcs"}
 	preResolveGoAttrs := []string{
@@ -71,7 +66,10 @@ func init() {
 		"embed",
 		"importpath",
 	}
-	preResolveGoProtoAttrs := []string{"proto"}
+	preResolveGoProtoAttrs := []string{
+		"compilers",
+		"proto",
+	}
 
 	PreResolveAttrs = make(MergeableAttrs)
 	for _, kind := range allKinds {
@@ -85,10 +83,8 @@ func init() {
 			PreResolveAttrs[kind][attr] = true
 		}
 	}
-	for _, kind := range goProtoKinds {
-		for _, attr := range preResolveGoProtoAttrs {
-			PreResolveAttrs[kind][attr] = true
-		}
+	for _, attr := range preResolveGoProtoAttrs {
+		PreResolveAttrs["go_proto_library"][attr] = true
 	}
 
 	postResolveCommonAttrs := []string{

--- a/rules/generator_test.go
+++ b/rules/generator_test.go
@@ -21,12 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	bf "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/merger"
 	"github.com/bazelbuild/bazel-gazelle/packages"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rules"
+	bf "github.com/bazelbuild/buildtools/build"
 )
 
 func testConfig(repoRoot, goPrefix string) *config.Config {
@@ -115,8 +115,6 @@ func TestGeneratorEmpty(t *testing.T) {
 proto_library(name = "foo_proto")
 
 go_proto_library(name = "foo_go_proto")
-
-go_grpc_library(name = "foo_go_proto")
 
 go_library(name = "go_default_library")
 

--- a/testdata/repo/service/BUILD.want
+++ b/testdata/repo/service/BUILD.want
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "service_proto",
@@ -11,12 +11,13 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-go_grpc_library(
+go_proto_library(
     name = "service_go_proto",
     _gazelle_imports = [
         "google/protobuf/any.proto",
         "service/sub/sub.proto",
     ],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
* If a .proto file has a service definition, we will now generate a
  go_proto_library rule with a compilers dependency on
  "@io_bazel_rules_go//proto:go_grpc" instead of a go_grpc_library.
* Existing go_grpc_library rules will be fixed. This is a minor fix,
  since it doesn't rename, move, or delete rules, so it will run in
  update mode.

Fixes #8