### PR TITLE
def.bzl: fix extra_args.

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -49,8 +49,10 @@ def _gazelle_runner_impl(ctx):
       runfiles = runfiles,
       executable = out_file,
   )]
-
+  
+  
 _gazelle_runner = rule(
+    implementation = _gazelle_runner_impl,
     attrs = {
         "gazelle": attr.label(
             default = "@bazel_gazelle//cmd/gazelle",
@@ -58,26 +60,16 @@ _gazelle_runner = rule(
             cfg = "host",
         ),
         "command": attr.string(
-            values = [
-                "update",
-                "fix",
-            ],
+            values = ["update", "fix"],
             default = "update",
         ),
         "mode": attr.string(
-            values = [
-                "print",
-                "fix",
-                "diff",
-            ],
-            default = "fix",
+            values = ["print", "fix", "diff"],
+            default="fix"
         ),
         "external": attr.string(
-            values = [
-                "external",
-                "vendored",
-            ],
-            default = "external",
+            values = ["external", "vendored"],
+            default="external",
         ),
         "build_tags": attr.string_list(),
         "prefix": attr.string(),
@@ -88,12 +80,11 @@ _gazelle_runner = rule(
             cfg = "data",
         ),
         "_template": attr.label(
-            default = "@bazel_gazelle//internal:gazelle.bash.in",
-            allow_single_file = True,
+            default="@bazel_gazelle//internal:gazelle.bash.in",
+            allow_single_file=True,
         ),
     },
     executable = True,
-    implementation = _gazelle_runner_impl,
 )
 
 def gazelle(name, **kwargs):

--- a/def.bzl
+++ b/def.bzl
@@ -24,7 +24,7 @@ def _gazelle_runner_impl(ctx):
     args.extend(["-go_prefix", ctx.attr.prefix])
   if ctx.attr.build_tags:
     args.extend(["-build_tags", ",".join(ctx.attr.build_tags)])
-  args.extend(ctx.attr.args)
+  args.extend(ctx.attr.extra_args)
 
   out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
   substitutions = {
@@ -49,10 +49,8 @@ def _gazelle_runner_impl(ctx):
       runfiles = runfiles,
       executable = out_file,
   )]
-  
-  
+
 _gazelle_runner = rule(
-    implementation = _gazelle_runner_impl,
     attrs = {
         "gazelle": attr.label(
             default = "@bazel_gazelle//cmd/gazelle",
@@ -60,16 +58,26 @@ _gazelle_runner = rule(
             cfg = "host",
         ),
         "command": attr.string(
-            values = ["update", "fix"],
+            values = [
+                "update",
+                "fix",
+            ],
             default = "update",
         ),
         "mode": attr.string(
-            values = ["print", "fix", "diff"],
-            default="fix"
+            values = [
+                "print",
+                "fix",
+                "diff",
+            ],
+            default = "fix",
         ),
         "external": attr.string(
-            values = ["external", "vendored"],
-            default="external",
+            values = [
+                "external",
+                "vendored",
+            ],
+            default = "external",
         ),
         "build_tags": attr.string_list(),
         "prefix": attr.string(),
@@ -80,11 +88,12 @@ _gazelle_runner = rule(
             cfg = "data",
         ),
         "_template": attr.label(
-            default="@bazel_gazelle//internal:gazelle.bash.in",
-            allow_single_file=True,
+            default = "@bazel_gazelle//internal:gazelle.bash.in",
+            allow_single_file = True,
         ),
     },
     executable = True,
+    implementation = _gazelle_runner_impl,
 )
 
 def gazelle(name, **kwargs):


### PR DESCRIPTION
The extra_args (and args, via the fallback logic) are no longer being
added to the generated bash script.