### PR TITLE
resolve: add rules to index after pre-resolve merge

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -91,13 +91,11 @@ func runFixUpdate(cmd command, args []string) error {
 		// Fix any problems in the file.
 		if file != nil {
 			file = merger.FixFileMinor(c, file)
+			fixedFile := merger.FixFile(c, file)
 			if cmd == fixCmd {
-				file = merger.FixFile(c, file)
-			} else {
-				fixedFile := merger.FixFile(c, file)
-				if fixedFile != file {
-					log.Printf("%s: warning: file contains rules whose structure is out of date. Consider running 'gazelle fix'.", file.Path)
-				}
+				file = fixedFile
+			} else if fixedFile != file {
+				log.Printf("%s: warning: file contains rules whose structure is out of date. Consider running 'gazelle fix'.", file.Path)
 			}
 		}
 

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -79,31 +79,31 @@ func runFixUpdate(cmd command, args []string) error {
 
 	// Visit all directories in the repository.
 	packages.Walk(c, c.RepoRoot, func(rel string, c *config.Config, pkg *packages.Package, file *bf.File, isUpdateDir bool) {
-		if file != nil {
-			// Fix files in update directories.
-			if isUpdateDir {
-				file = merger.FixFileMinor(c, file)
-				if cmd == fixCmd {
-					file = merger.FixFile(c, file)
-				} else {
-					fixedFile := merger.FixFile(c, file)
-					if fixedFile != file {
-						log.Printf("%s: warning: file contains rules whose structure is out of date. Consider running 'gazelle fix'.", file.Path)
-					}
-				}
-			}
-
-			// Index existing rules.
-			ruleIndex.AddRulesFromFile(c, file)
-		}
-
-		// TODO(#939): delete rules in directories where pkg == nil (no buildable
-		// Go code).
+		// If this file is ignored or if Gazelle was not asked to update this
+		// directory, just index the build file and move on.
 		if !isUpdateDir {
+			if file != nil {
+				ruleIndex.AddRulesFromFile(c, file)
+			}
 			return
 		}
 
-		// Generate rules.
+		// Fix any problems in the file.
+		if file != nil {
+			file = merger.FixFileMinor(c, file)
+			if cmd == fixCmd {
+				file = merger.FixFile(c, file)
+			} else {
+				fixedFile := merger.FixFile(c, file)
+				if fixedFile != file {
+					log.Printf("%s: warning: file contains rules whose structure is out of date. Consider running 'gazelle fix'.", file.Path)
+				}
+			}
+		}
+
+		// Generate new rules and merge them into the existing file (if present).
+		// TODO(#61): delete rules in directories where pkg == nil (no buildable
+		// Go code).
 		if pkg != nil {
 			g := rules.NewGenerator(c, l, file)
 			rules, empty, err := g.GenerateRules(pkg)
@@ -111,20 +111,25 @@ func runFixUpdate(cmd command, args []string) error {
 				log.Print(err)
 				return
 			}
-			file, rules = merger.MergeFile(rules, empty, file, merger.PreResolveAttrs)
 			if file == nil {
-				return
+				file = &bf.File{
+					Path: filepath.Join(c.RepoRoot, filepath.FromSlash(rel), c.DefaultBuildFileName()),
+					Stmt: rules,
+				}
+			} else {
+				file, rules = merger.MergeFile(rules, empty, file, merger.PreResolveAttrs)
 			}
-			if file.Path == "" {
-				file.Path = filepath.Join(c.RepoRoot, filepath.FromSlash(rel), c.DefaultBuildFileName())
-			}
-			ruleIndex.AddGeneratedRules(c, rel, rules)
 			visits = append(visits, visitRecord{
 				pkgRel: rel,
 				rules:  rules,
 				empty:  empty,
 				file:   file,
 			})
+		}
+
+		// Add library rules to the dependency resolution table.
+		if file != nil {
+			ruleIndex.AddRulesFromFile(c, file)
 		}
 	})
 

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -128,13 +128,6 @@ func init() {
 // are empty after merging. attrs is the set of attributes to merge. Attributes
 // not in this set will be left alone if they already exist.
 func MergeFile(genRules []bf.Expr, empty []bf.Expr, oldFile *bf.File, attrs MergeableAttrs) (mergedFile *bf.File, mergedRules []bf.Expr) {
-	if oldFile == nil {
-		return &bf.File{Stmt: genRules}, genRules
-	}
-	if shouldIgnore(oldFile) {
-		return nil, nil
-	}
-
 	mergedFile = new(bf.File)
 	*mergedFile = *oldFile
 	mergedFile.Stmt = make([]bf.Expr, 0, len(oldFile.Stmt))
@@ -584,18 +577,6 @@ func dictEntryKeyValue(e bf.Expr) (string, *bf.ListExpr, error) {
 		return "", nil, fmt.Errorf("dict value was not list: %#v", kv.Value)
 	}
 	return k.Value, v, nil
-}
-
-// shouldIgnore checks whether "gazelle:ignore" appears at the beginning of
-// a comment before or after any top-level statement in the file.
-func shouldIgnore(oldFile *bf.File) bool {
-	directives := config.ParseDirectives(oldFile)
-	for _, d := range directives {
-		if d.Key == "ignore" {
-			return true
-		}
-	}
-	return false
 }
 
 // shouldKeep returns whether an expression from the original file should be

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -105,36 +105,7 @@ go_test(
     data = glob(["testdata/*"]),
     embed = [":go_default_library"],
 )
-`},
-	{
-		desc: "ignore top",
-		previous: `# gazelle:ignore
-
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-
-go_library(
-    name = "go_default_library",
-    srcs = [
-        "lex.go",
-        "print.go",
-    ],
-)
-`,
-		ignore: true,
-	}, {
-		desc: "ignore before first",
-		previous: `
-# gazelle:ignore
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-`,
-		ignore: true,
-	}, {
-		desc: "ignore after last",
-		previous: `
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-# gazelle:ignore`,
-		ignore: true,
-	}, {
+`}, {
 		desc: "merge dicts",
 		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library")

--- a/internal/packages/walk.go
+++ b/internal/packages/walk.go
@@ -139,9 +139,13 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 		}
 		c = config.InferProtoMode(c, oldFile, directives)
 
+		var ignore bool
 		for _, d := range directives {
-			if d.Key == "exclude" {
+			switch d.Key {
+			case "exclude":
 				excluded = append(excluded, d.Value)
+			case "ignore":
+				ignore = true
 			}
 		}
 
@@ -187,8 +191,8 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 		}
 
 		hasPackage := subdirHasPackage || oldFile != nil
-		if haveError || !isUpdateDir {
-			f(rel, c, nil, oldFile, isUpdateDir)
+		if haveError || !isUpdateDir || ignore {
+			f(rel, c, nil, oldFile, false)
 			return hasPackage
 		}
 
@@ -198,7 +202,7 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 			genFiles = findGenFiles(oldFile, excluded)
 		}
 		pkg := buildPackage(c, dir, rel, pkgFiles, otherFiles, genFiles, hasTestdata)
-		f(rel, c, pkg, oldFile, isUpdateDir)
+		f(rel, c, pkg, oldFile, true)
 		return hasPackage || pkg != nil
 	}
 

--- a/internal/packages/walk_test.go
+++ b/internal/packages/walk_test.go
@@ -529,6 +529,34 @@ import "github.com/jr_hacker/stuff"
 	checkFiles(t, files, "example.com/repo", want)
 }
 
+func TestIgnore(t *testing.T) {
+	files := []fileSpec{
+		{
+			path: "BUILD",
+			content: "# gazelle:ignore",
+		}, {
+			path: "foo.go",
+			content: "package foo",
+		}, {
+			path: "bar/bar.go",
+			content: "package bar",
+		},
+	}
+	want := []*packages.Package{
+		{
+			Name: "bar",
+			Rel: "bar",
+			ImportPath: "example.com/repo/bar",
+			Library: packages.GoTarget{
+			Sources: packages.PlatformStrings{
+				Generic: []string{"bar.go"},
+			},
+			},
+		},
+	}
+	checkFiles(t, files, "example.com/repo", want)
+}
+
 func TestExcluded(t *testing.T) {
 	files := []fileSpec{
 		{


### PR DESCRIPTION
runFixUpdate now merges generated rules into existing build files
before adding the rules in the merged file to the library index with
AddRulesFromFile. This avoids the need to add existing and generated
rules to the index separately. It also simplifies the index, since we
don't need to track generated and replaced rules.

Also: the '# gazelle:ignore' directive is now handled earlier in
packages.Walk instead of merger.MergeFile. This avoids extra work and
spurious error messages.

Fixes #67