### PR TITLE
generator: don't generate importpath attributes for go_binary or go_test

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -51,73 +51,95 @@ var (
 )
 
 func init() {
-	goKinds := []string{
-		"go_library",
-		"go_binary",
-		"go_test",
-		"go_proto_library",
-	}
-	allKinds := append(goKinds, "proto_library")
-
-	preResolveCommonAttrs := []string{"srcs"}
-	preResolveGoAttrs := []string{
-		"cgo",
-		"clinkopts",
-		"copts",
-		"embed",
-		"importpath",
-	}
-	preResolveGoProtoAttrs := []string{
-		"compilers",
-		"proto",
-	}
-
 	PreResolveAttrs = make(MergeableAttrs)
-	for _, kind := range allKinds {
-		PreResolveAttrs[kind] = make(map[string]bool)
-		for _, attr := range preResolveCommonAttrs {
-			PreResolveAttrs[kind][attr] = true
-		}
-	}
-	for _, kind := range goKinds {
-		for _, attr := range preResolveGoAttrs {
-			PreResolveAttrs[kind][attr] = true
-		}
-	}
-	for _, attr := range preResolveGoProtoAttrs {
-		PreResolveAttrs["go_proto_library"][attr] = true
-	}
-
-	postResolveCommonAttrs := []string{
-		"deps",
-		config.GazelleImportsKey,
-	}
-
 	PostResolveAttrs = make(MergeableAttrs)
-	for _, kind := range allKinds {
-		PostResolveAttrs[kind] = make(map[string]bool)
-		for _, attr := range postResolveCommonAttrs {
-			PostResolveAttrs[kind][attr] = true
-		}
-	}
-
-	repoKinds := []string{"go_repository"}
-	repoCommonAttrs := []string{
-		"commit",
-		"importpath",
-		"remote",
-		"sha256",
-		"strip_prefix",
-		"tag",
-		"type",
-		"urls",
-		"vcs",
-	}
 	RepoAttrs = make(MergeableAttrs)
-	for _, kind := range repoKinds {
-		RepoAttrs[kind] = make(map[string]bool)
-		for _, attr := range repoCommonAttrs {
-			RepoAttrs[kind][attr] = true
+	for _, set := range []struct {
+		mergeableAttrs MergeableAttrs
+		kinds, attrs   []string
+	}{
+		{
+			mergeableAttrs: PreResolveAttrs,
+			kinds: []string{
+				"go_library",
+				"go_binary",
+				"go_test",
+				"go_proto_library",
+				"proto_library",
+			},
+			attrs: []string{
+				"srcs",
+			},
+		}, {
+			mergeableAttrs: PreResolveAttrs,
+			kinds: []string{
+				"go_library",
+				"go_proto_library",
+			},
+			attrs: []string{
+				"importpath",
+			},
+		}, {
+			mergeableAttrs: PreResolveAttrs,
+			kinds: []string{
+				"go_library",
+				"go_binary",
+				"go_test",
+				"go_proto_library",
+			},
+			attrs: []string{
+				"cgo",
+				"clinkopts",
+				"copts",
+				"embed",
+			},
+		}, {
+			mergeableAttrs: PreResolveAttrs,
+			kinds: []string{
+				"go_proto_library",
+			},
+			attrs: []string{
+				"compilers",
+				"proto",
+			},
+		}, {
+			mergeableAttrs: PostResolveAttrs,
+			kinds: []string{
+				"go_library",
+				"go_binary",
+				"go_test",
+				"go_proto_library",
+				"proto_library",
+			},
+			attrs: []string{
+				"deps",
+				config.GazelleImportsKey,
+			},
+		}, {
+			mergeableAttrs: RepoAttrs,
+			kinds: []string{
+				"go_repository",
+			},
+			attrs: []string{
+				"commit",
+				"importpath",
+				"remote",
+				"sha256",
+				"strip_prefix",
+				"tag",
+				"type",
+				"urls",
+				"vcs",
+			},
+		},
+	} {
+		for _, kind := range set.kinds {
+			if set.mergeableAttrs[kind] == nil {
+				set.mergeableAttrs[kind] = make(map[string]bool)
+			}
+			for _, attr := range set.attrs {
+				set.mergeableAttrs[kind][attr] = true
+			}
 		}
 	}
 }

--- a/internal/rules/generator.go
+++ b/internal/rules/generator.go
@@ -142,9 +142,6 @@ func (g *Generator) generateBin(pkg *packages.Package, library string) bf.Expr {
 	}
 	visibility := checkInternalVisibility(pkg.Rel, "//visibility:public")
 	attrs := g.commonAttrs(pkg.Rel, name, visibility, pkg.Binary)
-	// TODO(jayconrod): don't add importpath if it can be inherited from library.
-	// This is blocked by bazelbuild/bazel#3575.
-	attrs = append(attrs, KeyValue{"importpath", pkg.ImportPath})
 	if library != "" {
 		attrs = append(attrs, KeyValue{"embed", []string{":" + library}})
 	}
@@ -205,18 +202,13 @@ func checkInternalVisibility(rel, visibility string) string {
 func (g *Generator) generateTest(pkg *packages.Package, library string, isXTest bool) bf.Expr {
 	name := g.l.TestLabel(pkg.Rel, isXTest).Name
 	target := pkg.Test
-	importpath := pkg.ImportPath
 	if isXTest {
 		target = pkg.XTest
-		importpath += "_test"
 	}
 	if !target.HasGo() {
 		return EmptyRule("go_test", name)
 	}
 	attrs := g.commonAttrs(pkg.Rel, name, "", target)
-	// TODO(jayconrod): don't add importpath if it can be inherited from library.
-	// This is blocked by bazelbuild/bazel#3575.
-	attrs = append(attrs, KeyValue{"importpath", importpath})
 	if library != "" {
 		attrs = append(attrs, KeyValue{"embed", []string{":" + library}})
 	}

--- a/internal/rules/testdata/repo/allcgolib/BUILD.want
+++ b/internal/rules/testdata/repo/allcgolib/BUILD.want
@@ -20,5 +20,4 @@ go_test(
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/allcgolib",
 )

--- a/internal/rules/testdata/repo/bin/BUILD.want
+++ b/internal/rules/testdata/repo/bin/BUILD.want
@@ -14,6 +14,5 @@ go_library(
 go_binary(
     name = "bin",
     embed = [":go_default_library"],
-    importpath = "example.com/repo/bin",
     visibility = ["//visibility:public"],
 )

--- a/internal/rules/testdata/repo/bin_with_tests/BUILD.want
+++ b/internal/rules/testdata/repo/bin_with_tests/BUILD.want
@@ -14,7 +14,6 @@ go_library(
 go_binary(
     name = "bin_with_tests",
     embed = [":go_default_library"],
-    importpath = "example.com/repo/bin_with_tests",
     visibility = ["//visibility:public"],
 )
 
@@ -23,5 +22,4 @@ go_test(
     srcs = ["bin_test.go"],
     _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/bin_with_tests",
 )

--- a/internal/rules/testdata/repo/cgolib/BUILD.want
+++ b/internal/rules/testdata/repo/cgolib/BUILD.want
@@ -29,5 +29,4 @@ go_test(
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/cgolib",
 )

--- a/internal/rules/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/internal/rules/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -127,5 +127,4 @@ go_test(
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/cgolib_with_build_tags",
 )

--- a/internal/rules/testdata/repo/default_visibility/BUILD.want
+++ b/internal/rules/testdata/repo/default_visibility/BUILD.want
@@ -23,5 +23,4 @@ go_test(
     name = "go_default_test",
     srcs = ["a_test.go"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/default_visibility",
 )

--- a/internal/rules/testdata/repo/default_visibility/cmd/BUILD.want
+++ b/internal/rules/testdata/repo/default_visibility/cmd/BUILD.want
@@ -9,5 +9,4 @@ go_library(
 go_binary(
     name = "cmd",
     embed = [":go_default_library"],
-    importpath = "example.com/repo/default_visibility/cmd",
 )

--- a/internal/rules/testdata/repo/lib/BUILD.want
+++ b/internal/rules/testdata/repo/lib/BUILD.want
@@ -23,7 +23,6 @@ go_test(
     srcs = ["lib_test.go"],
     _gazelle_imports = ["testing"],
     embed = [":go_default_library"],
-    importpath = "example.com/repo/lib",
 )
 
 go_test(
@@ -33,5 +32,4 @@ go_test(
         "example.com/repo/lib",
         "testing",
     ],
-    importpath = "example.com/repo/lib_test",
 )

--- a/internal/rules/testdata/repo/main_test_only/BUILD.want
+++ b/internal/rules/testdata/repo/main_test_only/BUILD.want
@@ -3,5 +3,4 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["foo_test.go"],
-    importpath = "example.com/repo/main_test_only",
 )

--- a/internal/rules/testdata/repo/platforms/BUILD.want
+++ b/internal/rules/testdata/repo/platforms/BUILD.want
@@ -64,5 +64,4 @@ go_test(
         ],
         "//conditions:default": [],
     }),
-    importpath = "example.com/repo/platforms_test",
 )

--- a/internal/rules/testdata/repo/tests_import_testdata/BUILD.want
+++ b/internal/rules/testdata/repo/tests_import_testdata/BUILD.want
@@ -7,7 +7,6 @@ go_test(
         "example.com/repo/tests_import_testdata/testdata",
         "testing",
     ],
-    importpath = "example.com/repo/tests_import_testdata",
 )
 
 go_test(
@@ -17,5 +16,4 @@ go_test(
         "example.com/repo/tests_import_testdata/testdata",
         "testing",
     ],
-    importpath = "example.com/repo/tests_import_testdata_test",
 )

--- a/internal/rules/testdata/repo/tests_with_testdata/BUILD.want
+++ b/internal/rules/testdata/repo/tests_with_testdata/BUILD.want
@@ -5,7 +5,6 @@ go_test(
     srcs = ["internal_test.go"],
     _gazelle_imports = ["testing"],
     data = glob(["testdata/**"]),
-    importpath = "example.com/repo/tests_with_testdata",
 )
 
 go_test(
@@ -13,5 +12,4 @@ go_test(
     srcs = ["external_test.go"],
     _gazelle_imports = ["testing"],
     data = glob(["testdata/**"]),
-    importpath = "example.com/repo/tests_with_testdata_test",
 )


### PR DESCRIPTION
importpath is optional for these rules. Gazelle won't generate it, but
it won't remove importpath from existing rules (for now).

Also: rewrote merger init function for MergeableAttrs to be more declarative