### PR TITLE
Switch to normal vendoring for go-toml

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -22,10 +22,11 @@ def gazelle_dependencies():
   )
 
   # TODO(jayconrod): restore when gazelle is no longer built for go_repository.
-  _maybe(native.local_repository,
-      name = "com_github_pelletier_go_toml", # v1.0.1 as of 2017-12-19
-      path = "vendor/github.com/pelletier/go-toml",
-  )
+  # _maybe(go_repository,
+  #     name = "com_github_pelletier_go_toml",
+  #     importpath = "github.com/pelletier/go-toml",
+  #     commit = "16398bac157da96aa88f98a2df640c7f32af1da2", # v1.0.1 as of 2017-12-19
+  # )
 
 def _maybe(repo_rule, name, **kwargs):
   if name not in native.existing_rules():

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
     deps = [
         "//internal/resolve:go_default_library",
         "//internal/rules:go_default_library",
+        "//vendor/github.com/pelletier/go-toml:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
-        "@com_github_pelletier_go_toml//:go_default_library",
     ],
 )
 

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -1,1 +1,0 @@
-# gazelle:exclude github.com/pelletier/go-toml

--- a/vendor/github.com/pelletier/go-toml/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/BUILD.bazel
@@ -1,5 +1,3 @@
-# gazelle:prefix github.com/pelletier/go-toml
-
 # Exclude test files, since they pull in additional dependencies
 # gazelle:exclude benchmark_test.go
 # gazelle:exclude cmd/tomljson/main_test.go

--- a/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["test_program.go"],
     importpath = "github.com/pelletier/go-toml/cmd",
     visibility = ["//visibility:private"],
-    deps = ["//:go_default_library"],
+    deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],
 )
 
 go_binary(

--- a/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/pelletier/go-toml/cmd/tomljson",
     visibility = ["//visibility:private"],
-    deps = ["//:go_default_library"],
+    deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],
 )
 
 go_binary(

--- a/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/pelletier/go-toml/cmd/tomll",
     visibility = ["//visibility:private"],
-    deps = ["//:go_default_library"],
+    deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],
 )
 
 go_binary(

--- a/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
@@ -12,5 +12,5 @@ go_library(
     ],
     importpath = "github.com/pelletier/go-toml/query",
     visibility = ["//visibility:public"],
-    deps = ["//:go_default_library"],
+    deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],
 )


### PR DESCRIPTION
local_repository paths are relative to the directory containing the
main WORKSPACE file. Gazelle declared a local_repository in the
gazelle_dependencies macro for go-toml with a relative path pointing
to the vendor directory. This works inside the bazel_gazelle
workspace, but it breaks other repositories that import and use the
gazelle_dependencies macro.