### PR TITLE
cmd/gazelle: add -experimental_out_dir flag

### DIFF
--- a/cmd/gazelle/diff.go
+++ b/cmd/gazelle/diff.go
@@ -25,7 +25,7 @@ import (
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
-func diffFile(c *config.Config, file *bf.File) error {
+func diffFile(c *config.Config, file *bf.File, path string) error {
 	oldContents, err := ioutil.ReadFile(file.Path)
 	if err != nil {
 		oldContents = nil
@@ -43,7 +43,7 @@ func diffFile(c *config.Config, file *bf.File) error {
 	if err := ioutil.WriteFile(f.Name(), newContents, 0666); err != nil {
 		return err
 	}
-	cmd := exec.Command("diff", "-u", "--new-file", file.Path, f.Name())
+	cmd := exec.Command("diff", "-u", "--new-file", path, f.Name())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()

--- a/cmd/gazelle/fix.go
+++ b/cmd/gazelle/fix.go
@@ -17,13 +17,18 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
-func fixFile(c *config.Config, file *bf.File) error {
-	if err := ioutil.WriteFile(file.Path, bf.Format(file), 0644); err != nil {
+func fixFile(c *config.Config, file *bf.File, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(path, bf.Format(file), 0666); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
@@ -62,12 +63,9 @@ func TestFixFile(t *testing.T) {
 			},
 		},
 	}
+	c := &config.Config{}
 
-	c, _, err := newFixUpdateConfiguration(defaultArgs(dir))
-	if err != nil {
-		t.Fatalf("newFixUpdateConfiguration faied with %v; want success", err)
-	}
-	if err := fixFile(c, stubFile); err != nil {
+	if err := fixFile(c, stubFile, stubFile.Path); err != nil {
 		t.Errorf("fixFile(%#v) failed with %v; want success", stubFile, err)
 		return
 	}

--- a/cmd/gazelle/print.go
+++ b/cmd/gazelle/print.go
@@ -22,7 +22,7 @@ import (
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
-func printFile(c *config.Config, f *bf.File) error {
+func printFile(c *config.Config, f *bf.File, _ string) error {
 	_, err := os.Stdout.Write(bf.Format(f))
 	return err
 }


### PR DESCRIPTION
This flag allows users to specify a directory where build files will
be written. There is also -experimental_out_suffix, which adds a
suffix to generated build file names.

This will be used for experimenting with new repository rules. The
flags will be removed at some point, but the functionality will
remain.