### PR TITLE
internal/label: move Label and Labeler into new package

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
         "//internal/repos:go_default_library",

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/merger"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
 	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
@@ -86,7 +87,7 @@ func runFixUpdate(cmd command, args []string) error {
 		checkRulesGoVersion(uc.c.RepoRoot)
 	}
 
-	l := resolve.NewLabeler(uc.c)
+	l := label.NewLabeler(uc.c)
 	ruleIndex := resolve.NewRuleIndex()
 
 	var visits []visitRecord

--- a/internal/label/BUILD.bazel
+++ b/internal/label/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "label.go",
+        "labeler.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-gazelle/internal/label",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/config:go_default_library",
+        "//internal/pathtools:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "label_test.go",
+        "labeler_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["//internal/config:go_default_library"],
+)

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -31,6 +31,10 @@ type Label struct {
 	Relative        bool
 }
 
+func New(repo, pkg, name string) Label {
+	return Label{Repo: repo, Pkg: pkg, Name: name}
+}
+
 // NoLabel is the nil value of Label. It is not a valid label and may be
 // returned when an error occurs.
 var NoLabel = Label{}
@@ -41,9 +45,9 @@ var (
 	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
 )
 
-// ParseLabel reads a label from a string.
+// Parse reads a label from a string.
 // See https://docs.bazel.build/versions/master/build-ref.html#lexi.
-func ParseLabel(s string) (Label, error) {
+func Parse(s string) (Label, error) {
 	origStr := s
 
 	relative := true
@@ -130,13 +134,17 @@ func (l Label) Equal(other Label) bool {
 		l.Relative == other.Relative
 }
 
-// PackageContains tests whether a label is contained within a given repository
-// and package. The label must not be relative.
-func PackageContains(repo, pkg string, label Label) bool {
-	if label.Relative {
-		log.Panicf("label must not be relative: %s", label)
+// Contains returns whether other is contained by the package of l or a
+// sub-package. Neither label may be relative.
+func (l Label) Contains(other Label) bool {
+	if l.Relative {
+		log.Panicf("l must not be relative: %s", l)
 	}
-	return repo == label.Repo && pathtools.HasPrefix(label.Pkg, pkg)
+	if other.Relative {
+		log.Panicf("other must not be relative: %s", other)
+	}
+	result := l.Repo == other.Repo && pathtools.HasPrefix(other.Pkg, l.Pkg)
+	return result
 }
 
 // ImportPathToBazelRepoName converts a Go import path into a bazel repo name

--- a/internal/label/label_test.go
+++ b/internal/label/label_test.go
@@ -51,7 +51,7 @@ func TestLabelString(t *testing.T) {
 	}
 }
 
-func TestParseLabel(t *testing.T) {
+func TestParse(t *testing.T) {
 	for _, tc := range []struct {
 		str     string
 		want    Label
@@ -69,7 +69,7 @@ func TestParseLabel(t *testing.T) {
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
 	} {
-		got, err := ParseLabel(tc.str)
+		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {
 			t.Errorf("for string %q: got error %s ; want success", tc.str, err)
 			continue

--- a/internal/label/label_test.go
+++ b/internal/label/label_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resolve
+package label
 
 import (
 	"reflect"

--- a/internal/label/labeler.go
+++ b/internal/label/labeler.go
@@ -13,13 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resolve
+package label
 
 import (
-	"path"
-	"path/filepath"
-
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 )
 
 // Labeler generates Bazel labels for rules, based on their locations
@@ -47,7 +45,7 @@ func (l *Labeler) TestLabel(rel string, isXTest bool) Label {
 }
 
 func (l *Labeler) BinaryLabel(rel string) Label {
-	name := relBaseName(l.c, rel)
+	name := pathtools.RelBaseName(rel, l.c.GoPrefix, l.c.RepoRoot)
 	return Label{Pkg: rel, Name: name}
 }
 
@@ -57,18 +55,4 @@ func (l *Labeler) ProtoLabel(rel, name string) Label {
 
 func (l *Labeler) GoProtoLabel(rel, name string) Label {
 	return Label{Pkg: rel, Name: name + "_go_proto"}
-}
-
-func relBaseName(c *config.Config, rel string) string {
-	base := path.Base(rel)
-	if base == "." || base == "/" {
-		base = path.Base(c.GoPrefix)
-	}
-	if base == "." || base == "/" {
-		base = filepath.Base(c.RepoRoot)
-	}
-	if base == "." || base == "/" {
-		base = "root"
-	}
-	return base
 }

--- a/internal/label/labeler_test.go
+++ b/internal/label/labeler_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resolve
+package label
 
 import (
 	"testing"

--- a/internal/merger/BUILD.bazel
+++ b/internal/merger/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
-        "//internal/resolve:go_default_library",
+        "//internal/label:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
 )

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
-	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
@@ -357,7 +357,7 @@ func extractPlatformStringsExprs(expr bf.Expr) (platformStringsExprs, error) {
 				if k.Value == "//conditions:default" {
 					continue
 				}
-				key, err := resolve.ParseLabel(k.Value)
+				key, err := label.ParseLabel(k.Value)
 				if err != nil {
 					return platformStringsExprs{}, fmt.Errorf("expression could not be matched: dict key is not label: %q", k.Value)
 				}

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -357,7 +357,7 @@ func extractPlatformStringsExprs(expr bf.Expr) (platformStringsExprs, error) {
 				if k.Value == "//conditions:default" {
 					continue
 				}
-				key, err := label.ParseLabel(k.Value)
+				key, err := label.Parse(k.Value)
 				if err != nil {
 					return platformStringsExprs{}, fmt.Errorf("expression could not be matched: dict key is not label: %q", k.Value)
 				}

--- a/internal/pathtools/path.go
+++ b/internal/pathtools/path.go
@@ -15,7 +15,11 @@ limitations under the License.
 
 package pathtools
 
-import "strings"
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
 
 // HasPrefix returns whether the slash-separated path p has the given
 // prefix. Unlike strings.HasPrefix, this function respects component
@@ -37,4 +41,23 @@ func TrimPrefix(p, prefix string) string {
 		return ""
 	}
 	return strings.TrimPrefix(p, prefix+"/")
+}
+
+// RelBaseName returns the base name for rel, a slash-separated path relative
+// to the repository root. If rel is empty, RelBaseName returns the base name
+// of prefix. If prefix is empty, RelBaseName returns the base name of root,
+// the absolute file path of the repository root directory. If that's empty
+// to, then RelBaseName returns "root".
+func RelBaseName(rel, prefix, root string) string {
+	base := path.Base(rel)
+	if base == "." || base == "/" {
+		base = path.Base(prefix)
+	}
+	if base == "." || base == "/" {
+		base = filepath.Base(root)
+	}
+	if base == "." || base == "/" {
+		base = "root"
+	}
+	return base
 }

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/repos",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/resolve:go_default_library",
+        "//internal/label:go_default_library",
         "//internal/rules:go_default_library",
         "//vendor/github.com/pelletier/go-toml:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",

--- a/internal/repos/dep.go
+++ b/internal/repos/dep.go
@@ -18,7 +18,7 @@ package repos
 import (
 	"io/ioutil"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	toml "github.com/pelletier/go-toml"
 )
 
@@ -44,9 +44,8 @@ func importRepoRulesDep(filename string) ([]repo, error) {
 
 	var repos []repo
 	for _, p := range file.Projects {
-
 		repos = append(repos, repo{
-			name:       resolve.ImportPathToBazelRepoName(p.Name),
+			name:       label.ImportPathToBazelRepoName(p.Name),
 			importPath: p.Name,
 			commit:     p.Revision,
 			remote:     p.Source,

--- a/internal/resolve/BUILD.bazel
+++ b/internal/resolve/BUILD.bazel
@@ -4,8 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "index.go",
-        "label.go",
-        "labeler.go",
         "resolve.go",
         "resolve_external.go",
         "resolve_vendored.go",
@@ -15,7 +13,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
         "//internal/pathtools:go_default_library",
+        "//internal/repos:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
@@ -25,8 +25,6 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
-        "label_test.go",
-        "labeler_test.go",
         "resolve_external_test.go",
         "resolve_test.go",
     ],
@@ -34,6 +32,8 @@ go_test(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/resolve",
     deps = [
         "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
+        "//internal/repos:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],

--- a/internal/resolve/index.go
+++ b/internal/resolve/index.go
@@ -80,7 +80,7 @@ func (ix *RuleIndex) addRule(call *bf.CallExpr, goPrefix, buildRel string) {
 	rule := bf.Rule{Call: call}
 	record := &ruleRecord{
 		rule:  rule,
-		label: label.Label{Pkg: buildRel, Name: rule.Name()},
+		label: label.New("", buildRel, rule.Name()),
 	}
 
 	if _, ok := ix.labelMap[record.label]; ok {
@@ -141,7 +141,7 @@ func (ix *RuleIndex) skipGoEmbds() {
 				if !ok {
 					continue
 				}
-				embedLabel, err := label.ParseLabel(embedStr.Value)
+				embedLabel, err := label.Parse(embedStr.Value)
 				if err != nil {
 					continue
 				}
@@ -149,7 +149,7 @@ func (ix *RuleIndex) skipGoEmbds() {
 			}
 		}
 		if libraryStr, ok := r.rule.Attr("library").(*bf.StringExpr); ok {
-			if libraryLabel, err := label.ParseLabel(libraryStr.Value); err == nil {
+			if libraryLabel, err := label.Parse(libraryStr.Value); err == nil {
 				embedLabels = append(embedLabels, libraryLabel)
 			}
 		}
@@ -247,7 +247,7 @@ func (ix *RuleIndex) findRuleByImport(imp importSpec, lang config.Language, from
 					break
 				}
 			}
-			if isVendored && !label.PackageContains(m.label.Repo, vendorRoot, from) {
+			if isVendored && !label.New(m.label.Repo, vendorRoot, "").Contains(from) {
 				// vendor directory not visible
 				continue
 			}
@@ -301,7 +301,7 @@ func (ix *RuleIndex) findLabelByImport(imp importSpec, lang config.Language, fro
 }
 
 func findGoProtoSources(ix *RuleIndex, r *ruleRecord) []importSpec {
-	protoLabel, err := label.ParseLabel(r.rule.AttrString("proto"))
+	protoLabel, err := label.Parse(r.rule.AttrString("proto"))
 	if err != nil {
 		return nil
 	}
@@ -328,7 +328,7 @@ func findSources(r bf.Rule, buildRel, ext string) []string {
 		if !ok {
 			continue
 		}
-		label, err := label.ParseLabel(src.Value)
+		label, err := label.Parse(src.Value)
 		if err != nil || !label.Relative || !strings.HasSuffix(label.Name, ext) {
 			continue
 		}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -72,7 +72,7 @@ func (r *Resolver) ResolveRule(e bf.Expr, pkgRel string) bf.Expr {
 		return e
 	}
 	rule := bf.Rule{Call: call}
-	from := label.Label{Pkg: pkgRel, Name: rule.Name()}
+	from := label.New("", pkgRel, rule.Name())
 
 	var resolve func(imp string, from label.Label) (label.Label, error)
 	switch rule.Kind() {
@@ -216,13 +216,13 @@ func (r *Resolver) resolveGo(imp string, from label.Label) (label.Label, error) 
 	if build.IsLocalImport(imp) {
 		cleanRel := path.Clean(path.Join(from.Pkg, imp))
 		if build.IsLocalImport(cleanRel) {
-			return label.Label{}, fmt.Errorf("relative import path %q from %q points outside of repository", imp, from.Pkg)
+			return label.NoLabel, fmt.Errorf("relative import path %q from %q points outside of repository", imp, from.Pkg)
 		}
 		imp = path.Join(r.c.GoPrefix, cleanRel)
 	}
 
 	if IsStandard(imp) {
-		return label.Label{}, standardImportError{imp}
+		return label.NoLabel, standardImportError{imp}
 	}
 
 	if l, err := r.ix.findLabelByImport(importSpec{config.GoLang, imp}, config.GoLang, from); err != nil {
@@ -250,11 +250,11 @@ const (
 // for a proto_library rule.
 func (r *Resolver) resolveProto(imp string, from label.Label) (label.Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
-		return label.Label{}, fmt.Errorf("can't import non-proto: %q", imp)
+		return label.NoLabel, fmt.Errorf("can't import non-proto: %q", imp)
 	}
 	if isWellKnown(imp) {
 		name := path.Base(imp[:len(imp)-len(".proto")]) + "_proto"
-		return label.Label{Repo: config.WellKnownTypesProtoRepo, Name: name}, nil
+		return label.New(config.WellKnownTypesProtoRepo, "", name), nil
 	}
 
 	if l, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.ProtoLang, from); err != nil {
@@ -277,7 +277,7 @@ func (r *Resolver) resolveProto(imp string, from label.Label) (label.Label, erro
 // label for a go_library rule that embeds the corresponding go_proto_library.
 func (r *Resolver) resolveGoProto(imp string, from label.Label) (label.Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
-		return label.Label{}, fmt.Errorf("can't import non-proto: %q", imp)
+		return label.NoLabel, fmt.Errorf("can't import non-proto: %q", imp)
 	}
 	stem := imp[:len(imp)-len(".proto")]
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	bf "github.com/bazelbuild/buildtools/build"
 )
@@ -31,7 +32,7 @@ import (
 // import statements in protos) into Bazel labels.
 type Resolver struct {
 	c        *config.Config
-	l        *Labeler
+	l        *label.Labeler
 	ix       *RuleIndex
 	external nonlocalResolver
 }
@@ -40,10 +41,10 @@ type Resolver struct {
 // prefix. Once we have smarter import path resolution, this shouldn't
 // be necessary, and we can remove this abstraction.
 type nonlocalResolver interface {
-	resolve(imp string) (Label, error)
+	resolve(imp string) (label.Label, error)
 }
 
-func NewResolver(c *config.Config, l *Labeler, ix *RuleIndex) *Resolver {
+func NewResolver(c *config.Config, l *label.Labeler, ix *RuleIndex) *Resolver {
 	var e nonlocalResolver
 	switch c.DepMode {
 	case config.ExternalMode:
@@ -71,9 +72,9 @@ func (r *Resolver) ResolveRule(e bf.Expr, pkgRel string) bf.Expr {
 		return e
 	}
 	rule := bf.Rule{Call: call}
-	from := Label{Pkg: pkgRel, Name: rule.Name()}
+	from := label.Label{Pkg: pkgRel, Name: rule.Name()}
 
-	var resolve func(imp string, from Label) (Label, error)
+	var resolve func(imp string, from label.Label) (label.Label, error)
 	switch rule.Kind() {
 	case "go_library", "go_binary", "go_test":
 		resolve = r.resolveGo
@@ -211,25 +212,25 @@ func mapExprStrings(e bf.Expr, f func(string) string) bf.Expr {
 // resolveGo resolves an import path from a Go source file to a label.
 // pkgRel is the path to the Go package relative to the repository root; it
 // is used to resolve relative imports.
-func (r *Resolver) resolveGo(imp string, from Label) (Label, error) {
+func (r *Resolver) resolveGo(imp string, from label.Label) (label.Label, error) {
 	if build.IsLocalImport(imp) {
 		cleanRel := path.Clean(path.Join(from.Pkg, imp))
 		if build.IsLocalImport(cleanRel) {
-			return Label{}, fmt.Errorf("relative import path %q from %q points outside of repository", imp, from.Pkg)
+			return label.Label{}, fmt.Errorf("relative import path %q from %q points outside of repository", imp, from.Pkg)
 		}
 		imp = path.Join(r.c.GoPrefix, cleanRel)
 	}
 
 	if IsStandard(imp) {
-		return Label{}, standardImportError{imp}
+		return label.Label{}, standardImportError{imp}
 	}
 
-	if label, err := r.ix.findLabelByImport(importSpec{config.GoLang, imp}, config.GoLang, from); err != nil {
+	if l, err := r.ix.findLabelByImport(importSpec{config.GoLang, imp}, config.GoLang, from); err != nil {
 		if _, ok := err.(ruleNotFoundError); !ok {
-			return NoLabel, err
+			return label.NoLabel, err
 		}
 	} else {
-		return label, nil
+		return l, nil
 	}
 
 	if pathtools.HasPrefix(imp, r.c.GoPrefix) {
@@ -247,36 +248,36 @@ const (
 
 // resolveProto resolves an import statement in a .proto file to a label
 // for a proto_library rule.
-func (r *Resolver) resolveProto(imp string, from Label) (Label, error) {
+func (r *Resolver) resolveProto(imp string, from label.Label) (label.Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
-		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
+		return label.Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}
 	if isWellKnown(imp) {
 		name := path.Base(imp[:len(imp)-len(".proto")]) + "_proto"
-		return Label{Repo: config.WellKnownTypesProtoRepo, Name: name}, nil
+		return label.Label{Repo: config.WellKnownTypesProtoRepo, Name: name}, nil
 	}
 
-	if label, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.ProtoLang, from); err != nil {
+	if l, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.ProtoLang, from); err != nil {
 		if _, ok := err.(ruleNotFoundError); !ok {
-			return NoLabel, err
+			return label.NoLabel, err
 		}
 	} else {
-		return label, nil
+		return l, nil
 	}
 
 	rel := path.Dir(imp)
 	if rel == "." {
 		rel = ""
 	}
-	name := relBaseName(r.c, rel)
+	name := pathtools.RelBaseName(rel, r.c.GoPrefix, r.c.RepoRoot)
 	return r.l.ProtoLabel(rel, name), nil
 }
 
 // resolveGoProto resolves an import statement in a .proto file to a
 // label for a go_library rule that embeds the corresponding go_proto_library.
-func (r *Resolver) resolveGoProto(imp string, from Label) (Label, error) {
+func (r *Resolver) resolveGoProto(imp string, from label.Label) (label.Label, error) {
 	if !strings.HasSuffix(imp, ".proto") {
-		return Label{}, fmt.Errorf("can't import non-proto: %q", imp)
+		return label.Label{}, fmt.Errorf("can't import non-proto: %q", imp)
 	}
 	stem := imp[:len(imp)-len(".proto")]
 
@@ -316,12 +317,12 @@ func (r *Resolver) resolveGoProto(imp string, from Label) (Label, error) {
 		}
 	}
 
-	if label, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.GoLang, from); err != nil {
+	if l, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.GoLang, from); err != nil {
 		if _, ok := err.(ruleNotFoundError); !ok {
-			return NoLabel, err
+			return label.NoLabel, err
 		}
 	} else {
-		return label, err
+		return l, err
 	}
 
 	// As a fallback, guess the label based on the proto file name. We assume

--- a/internal/resolve/resolve_external.go
+++ b/internal/resolve/resolve_external.go
@@ -74,7 +74,7 @@ func newExternalResolver(l *label.Labeler, extraKnownImports []string) *external
 func (r *externalResolver) resolve(importpath string) (label.Label, error) {
 	prefix, err := r.lookupPrefix(importpath)
 	if err != nil {
-		return label.Label{}, err
+		return label.NoLabel, err
 	}
 
 	var pkg string

--- a/internal/resolve/resolve_external.go
+++ b/internal/resolve/resolve_external.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"path"
 	"regexp"
-	"strings"
 
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	"golang.org/x/tools/go/vcs"
 )
@@ -32,7 +32,7 @@ import (
 // guidelines in http://bazel.io/docs/be/functions.html#workspace. The remaining
 // portion of the import path is treated as the package name.
 type externalResolver struct {
-	l *Labeler
+	l *label.Labeler
 
 	// repoRootForImportPath is vcs.RepoRootForImportPath by default. It may
 	// be overridden by tests.
@@ -45,7 +45,7 @@ type externalResolver struct {
 
 var _ nonlocalResolver = (*externalResolver)(nil)
 
-func newExternalResolver(l *Labeler, extraKnownImports []string) *externalResolver {
+func newExternalResolver(l *label.Labeler, extraKnownImports []string) *externalResolver {
 	cache := make(map[string]repoRootCacheEntry)
 	for _, e := range []repoRootCacheEntry{
 		{prefix: "golang.org/x", missing: 1},
@@ -71,10 +71,10 @@ func newExternalResolver(l *Labeler, extraKnownImports []string) *externalResolv
 // external repository. It also assumes that the external repository follows the
 // recommended reverse-DNS form of workspace name as described in
 // http://bazel.io/docs/be/functions.html#workspace.
-func (r *externalResolver) resolve(importpath string) (Label, error) {
+func (r *externalResolver) resolve(importpath string) (label.Label, error) {
 	prefix, err := r.lookupPrefix(importpath)
 	if err != nil {
-		return Label{}, err
+		return label.Label{}, err
 	}
 
 	var pkg string
@@ -82,9 +82,9 @@ func (r *externalResolver) resolve(importpath string) (Label, error) {
 		pkg = pathtools.TrimPrefix(importpath, prefix)
 	}
 
-	label := r.l.LibraryLabel(pkg)
-	label.Repo = ImportPathToBazelRepoName(prefix)
-	return label, nil
+	l := r.l.LibraryLabel(pkg)
+	l.Repo = label.ImportPathToBazelRepoName(prefix)
+	return l, nil
 }
 
 var gopkginPattern = regexp.MustCompile("^(gopkg.in/(?:[^/]+/)?[^/]+\\.v\\d+)(?:/|$)")
@@ -135,21 +135,6 @@ func (r *externalResolver) lookupPrefix(importpath string) (string, error) {
 	prefix = root.Root
 	r.cache[prefix] = repoRootCacheEntry{prefix: prefix}
 	return prefix, nil
-}
-
-// ImportPathToBazelRepoName converts a Go import path into a bazel repo name
-// following the guidelines in http://bazel.io/docs/be/functions.html#workspace
-func ImportPathToBazelRepoName(importpath string) string {
-	importpath = strings.ToLower(importpath)
-	components := strings.Split(importpath, "/")
-	labels := strings.Split(components[0], ".")
-	var reversed []string
-	for i := range labels {
-		l := labels[len(labels)-i-1]
-		reversed = append(reversed, l)
-	}
-	repo := strings.Join(append(reversed, components[1:]...), "_")
-	return strings.NewReplacer("-", "_", ".", "_").Replace(repo)
 }
 
 type repoRootCacheEntry struct {

--- a/internal/resolve/resolve_external_test.go
+++ b/internal/resolve/resolve_external_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"golang.org/x/tools/go/vcs"
 )
 
@@ -69,18 +70,18 @@ func TestExternalResolver(t *testing.T) {
 	r := newStubExternalResolver(nil)
 	for _, spec := range []struct {
 		importpath string
-		want       Label
+		want       label.Label
 	}{
 		{
 			importpath: "example.com/repo",
-			want: Label{
+			want: label.Label{
 				Repo: "com_example_repo",
 				Name: config.DefaultLibName,
 			},
 		},
 		{
 			importpath: "example.com/repo/lib",
-			want: Label{
+			want: label.Label{
 				Repo: "com_example_repo",
 				Pkg:  "lib",
 				Name: config.DefaultLibName,
@@ -88,7 +89,7 @@ func TestExternalResolver(t *testing.T) {
 		},
 		{
 			importpath: "example.com/repo.git/lib",
-			want: Label{
+			want: label.Label{
 				Repo: "com_example_repo_git",
 				Pkg:  "lib",
 				Name: config.DefaultLibName,
@@ -96,7 +97,7 @@ func TestExternalResolver(t *testing.T) {
 		},
 		{
 			importpath: "example.com/lib",
-			want: Label{
+			want: label.Label{
 				Repo: "com_example",
 				Pkg:  "lib",
 				Name: config.DefaultLibName,
@@ -115,7 +116,7 @@ func TestExternalResolver(t *testing.T) {
 }
 
 func newStubExternalResolver(extraKnown []string) *externalResolver {
-	l := NewLabeler(&config.Config{})
+	l := label.NewLabeler(&config.Config{})
 	r := newExternalResolver(l, extraKnown)
 	r.repoRootForImportPath = stubRepoRootForImportPath
 	return r

--- a/internal/resolve/resolve_external_test.go
+++ b/internal/resolve/resolve_external_test.go
@@ -74,34 +74,19 @@ func TestExternalResolver(t *testing.T) {
 	}{
 		{
 			importpath: "example.com/repo",
-			want: label.Label{
-				Repo: "com_example_repo",
-				Name: config.DefaultLibName,
-			},
+			want:       label.New("com_example_repo", "", config.DefaultLibName),
 		},
 		{
 			importpath: "example.com/repo/lib",
-			want: label.Label{
-				Repo: "com_example_repo",
-				Pkg:  "lib",
-				Name: config.DefaultLibName,
-			},
+			want:       label.New("com_example_repo", "lib", config.DefaultLibName),
 		},
 		{
 			importpath: "example.com/repo.git/lib",
-			want: label.Label{
-				Repo: "com_example_repo_git",
-				Pkg:  "lib",
-				Name: config.DefaultLibName,
-			},
+			want:       label.New("com_example_repo_git", "lib", config.DefaultLibName),
 		},
 		{
 			importpath: "example.com/lib",
-			want: label.Label{
-				Repo: "com_example",
-				Pkg:  "lib",
-				Name: config.DefaultLibName,
-			},
+			want:       label.New("com_example", "lib", config.DefaultLibName),
 		},
 	} {
 		l, err := r.resolve(spec.importpath)

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -50,7 +50,7 @@ func TestResolveGoIndex(t *testing.T) {
 			desc: "no_match",
 			imp:  "example.com/foo",
 			// fall back to external resolver
-			want: label.Label{Pkg: "vendor/example.com/foo", Name: config.DefaultLibName},
+			want: label.New("", "vendor/example.com/foo", config.DefaultLibName),
 		}, {
 			desc: "simple",
 			buildFiles: []fileSpec{{
@@ -62,7 +62,7 @@ go_library(
 )
 `}},
 			imp:  "example.com/foo",
-			want: label.Label{Pkg: "foo", Name: "go_default_library"},
+			want: label.New("", "foo", "go_default_library"),
 		}, {
 			desc: "test_and_library_not_indexed",
 			buildFiles: []fileSpec{{
@@ -81,7 +81,7 @@ go_binary(
 			}},
 			imp: "example.com/foo",
 			// fall back to external resolver
-			want: label.Label{Pkg: "vendor/example.com/foo", Name: config.DefaultLibName},
+			want: label.New("", "vendor/example.com/foo", config.DefaultLibName),
 		}, {
 			desc: "multiple_rules_ambiguous",
 			buildFiles: []fileSpec{{
@@ -122,8 +122,8 @@ go_library(
 				},
 			},
 			imp:  "example.com/foo",
-			from: label.Label{Pkg: "b", Name: "b"},
-			want: label.Label{Name: "root"},
+			from: label.New("", "b", "b"),
+			want: label.New("", "", "root"),
 		}, {
 			desc: "vendor_supercedes_nonvendor",
 			buildFiles: []fileSpec{
@@ -146,8 +146,8 @@ go_library(
 				},
 			},
 			imp:  "example.com/foo",
-			from: label.Label{Pkg: "sub", Name: "sub"},
-			want: label.Label{Pkg: "vendor/foo", Name: "vendored"},
+			from: label.New("", "sub", "sub"),
+			want: label.New("", "vendor/foo", "vendored"),
 		}, {
 			desc: "deep_vendor_shallow_vendor",
 			buildFiles: []fileSpec{
@@ -170,8 +170,8 @@ go_library(
 				},
 			},
 			imp:  "example.com/foo",
-			from: label.Label{Pkg: "shallow/deep", Name: "deep"},
-			want: label.Label{Pkg: "shallow/deep/vendor", Name: "deep"},
+			from: label.New("", "shallow/deep", "deep"),
+			want: label.New("", "shallow/deep/vendor", "deep"),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -242,24 +242,24 @@ go_library(
 	ix.Finish()
 	r := NewResolver(c, l, ix)
 
-	wantProto := label.Label{Pkg: "sub", Name: "foo_proto"}
-	if got, err := r.resolveProto("sub/bar.proto", label.Label{Pkg: "baz", Name: "baz"}); err != nil {
+	wantProto := label.New("", "sub", "foo_proto")
+	if got, err := r.resolveProto("sub/bar.proto", label.New("", "baz", "baz")); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(got, wantProto) {
 		t.Errorf("resolveProto: got %s ; want %s", got, wantProto)
 	}
-	_, err = r.resolveProto("sub/bar.proto", label.Label{Pkg: "sub", Name: "foo_proto"})
+	_, err = r.resolveProto("sub/bar.proto", label.New("", "sub", "foo_proto"))
 	if _, ok := err.(selfImportError); !ok {
 		t.Errorf("resolveProto: got %v ; want selfImportError", err)
 	}
 
-	wantGoProto := label.Label{Pkg: "sub", Name: "embed"}
-	if got, err := r.resolveGoProto("sub/bar.proto", label.Label{Pkg: "baz", Name: "baz"}); err != nil {
+	wantGoProto := label.New("", "sub", "embed")
+	if got, err := r.resolveGoProto("sub/bar.proto", label.New("", "baz", "baz")); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(got, wantGoProto) {
 		t.Errorf("resolveGoProto: got %s ; want %s", got, wantGoProto)
 	}
-	_, err = r.resolveGoProto("sub/bar.proto", label.Label{Pkg: "sub", Name: "foo_go_proto"})
+	_, err = r.resolveGoProto("sub/bar.proto", label.New("", "sub", "foo_go_proto"))
 	if _, ok := err.(selfImportError); !ok {
 		t.Errorf("resolveGoProto: got %v ; want selfImportError", err)
 	}
@@ -272,26 +272,26 @@ func TestResolveGoLocal(t *testing.T) {
 	}{
 		{
 			importpath: "example.com/repo",
-			want:       label.Label{Name: config.DefaultLibName},
+			want:       label.New("", "", config.DefaultLibName),
 		}, {
 			importpath: "example.com/repo/lib",
-			want:       label.Label{Pkg: "lib", Name: config.DefaultLibName},
+			want:       label.New("", "lib", config.DefaultLibName),
 		}, {
 			importpath: "example.com/repo/another",
-			want:       label.Label{Pkg: "another", Name: config.DefaultLibName},
+			want:       label.New("", "another", config.DefaultLibName),
 		}, {
 			importpath: "example.com/repo",
-			want:       label.Label{Name: config.DefaultLibName},
+			want:       label.New("", "", config.DefaultLibName),
 		}, {
 			importpath: "example.com/repo/lib/sub",
-			want:       label.Label{Pkg: "lib/sub", Name: config.DefaultLibName},
+			want:       label.New("", "lib/sub", config.DefaultLibName),
 		}, {
 			importpath: "example.com/repo/another",
-			want:       label.Label{Pkg: "another", Name: config.DefaultLibName},
+			want:       label.New("", "another", config.DefaultLibName),
 		}, {
 			importpath: "../y",
-			from:       label.Label{Pkg: "x", Name: "x"},
-			want:       label.Label{Pkg: "y", Name: config.DefaultLibName},
+			from:       label.New("", "x", "x"),
+			want:       label.New("", "y", config.DefaultLibName),
 		},
 	} {
 		c := &config.Config{GoPrefix: "example.com/repo"}
@@ -338,7 +338,7 @@ func TestResolveGoEmptyPrefix(t *testing.T) {
 	r := NewResolver(c, l, ix)
 
 	imp := "foo"
-	want := label.Label{Pkg: "foo", Name: config.DefaultLibName}
+	want := label.New("", "foo", config.DefaultLibName)
 	if got, err := r.resolveGo(imp, label.NoLabel); err != nil {
 		t.Errorf("r.resolveGo(%q) failed with %v; want success", imp, err)
 	} else if !reflect.DeepEqual(got, want) {
@@ -362,42 +362,42 @@ func TestResolveProto(t *testing.T) {
 		{
 			desc:        "root",
 			imp:         "foo.proto",
-			wantProto:   label.Label{Name: "repo_proto"},
-			wantGoProto: label.Label{Name: config.DefaultLibName},
+			wantProto:   label.New("", "", "repo_proto"),
+			wantGoProto: label.New("", "", config.DefaultLibName),
 		}, {
 			desc:        "sub",
 			imp:         "foo/bar/bar.proto",
-			wantProto:   label.Label{Pkg: "foo/bar", Name: "bar_proto"},
-			wantGoProto: label.Label{Pkg: "foo/bar", Name: config.DefaultLibName},
+			wantProto:   label.New("", "foo/bar", "bar_proto"),
+			wantGoProto: label.New("", "foo/bar", config.DefaultLibName),
 		}, {
 			desc:        "vendor",
 			depMode:     config.VendorMode,
 			imp:         "foo/bar/bar.proto",
-			from:        label.Label{Pkg: "vendor"},
-			wantProto:   label.Label{Pkg: "foo/bar", Name: "bar_proto"},
-			wantGoProto: label.Label{Pkg: "vendor/foo/bar", Name: config.DefaultLibName},
+			from:        label.New("", "vendor", ""),
+			wantProto:   label.New("", "foo/bar", "bar_proto"),
+			wantGoProto: label.New("", "vendor/foo/bar", config.DefaultLibName),
 		}, {
 			desc:        "well known",
 			imp:         "google/protobuf/any.proto",
-			wantProto:   label.Label{Repo: "com_google_protobuf", Name: "any_proto"},
-			wantGoProto: label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/any", Name: config.DefaultLibName},
+			wantProto:   label.New("com_google_protobuf", "", "any_proto"),
+			wantGoProto: label.New("com_github_golang_protobuf", "ptypes/any", config.DefaultLibName),
 		}, {
 			desc:        "well known vendor",
 			depMode:     config.VendorMode,
 			imp:         "google/protobuf/any.proto",
-			wantProto:   label.Label{Repo: "com_google_protobuf", Name: "any_proto"},
-			wantGoProto: label.Label{Pkg: "vendor/github.com/golang/protobuf/ptypes/any", Name: config.DefaultLibName},
+			wantProto:   label.New("com_google_protobuf", "", "any_proto"),
+			wantGoProto: label.New("", "vendor/github.com/golang/protobuf/ptypes/any", config.DefaultLibName),
 		}, {
 			desc:        "descriptor",
 			imp:         "google/protobuf/descriptor.proto",
-			wantProto:   label.Label{Repo: "com_google_protobuf", Name: "descriptor_proto"},
-			wantGoProto: label.Label{Repo: "com_github_golang_protobuf", Pkg: "protoc-gen-go/descriptor", Name: config.DefaultLibName},
+			wantProto:   label.New("com_google_protobuf", "", "descriptor_proto"),
+			wantGoProto: label.New("com_github_golang_protobuf", "protoc-gen-go/descriptor", config.DefaultLibName),
 		}, {
 			desc:        "descriptor vendor",
 			depMode:     config.VendorMode,
 			imp:         "google/protobuf/descriptor.proto",
-			wantProto:   label.Label{Repo: "com_google_protobuf", Name: "descriptor_proto"},
-			wantGoProto: label.Label{Pkg: "vendor/github.com/golang/protobuf/protoc-gen-go/descriptor", Name: config.DefaultLibName},
+			wantProto:   label.New("com_google_protobuf", "", "descriptor_proto"),
+			wantGoProto: label.New("", "vendor/github.com/golang/protobuf/protoc-gen-go/descriptor", config.DefaultLibName),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/resolve/resolve_vendored.go
+++ b/internal/resolve/resolve_vendored.go
@@ -15,17 +15,21 @@ limitations under the License.
 
 package resolve
 
+import (
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
+)
+
 // vendoredResolver resolves external packages as packages in vendor/.
 type vendoredResolver struct {
-	l *Labeler
+	l *label.Labeler
 }
 
 var _ nonlocalResolver = (*vendoredResolver)(nil)
 
-func newVendoredResolver(l *Labeler) *vendoredResolver {
+func newVendoredResolver(l *label.Labeler) *vendoredResolver {
 	return &vendoredResolver{l}
 }
 
-func (v *vendoredResolver) resolve(importpath string) (Label, error) {
+func (v *vendoredResolver) resolve(importpath string) (label.Label, error) {
 	return v.l.LibraryLabel("vendor/" + importpath), nil
 }

--- a/internal/rules/BUILD.bazel
+++ b/internal/rules/BUILD.bazel
@@ -14,8 +14,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
         "//internal/packages:go_default_library",
-        "//internal/resolve:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_bazelbuild_buildtools//tables:go_default_library",
     ],
@@ -30,9 +30,9 @@ go_test(
     deps = [
         ":go_default_library",
         "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
-        "//internal/resolve:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
 )

--- a/internal/rules/generator.go
+++ b/internal/rules/generator.go
@@ -22,14 +22,14 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
-	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
 // NewGenerator returns a new instance of Generator.
 // "oldFile" is the existing build file. May be nil.
-func NewGenerator(c *config.Config, l *resolve.Labeler, oldFile *bf.File) *Generator {
+func NewGenerator(c *config.Config, l *label.Labeler, oldFile *bf.File) *Generator {
 	shouldSetVisibility := oldFile == nil || !hasDefaultVisibility(oldFile)
 	return &Generator{c: c, l: l, shouldSetVisibility: shouldSetVisibility}
 }
@@ -37,7 +37,7 @@ func NewGenerator(c *config.Config, l *resolve.Labeler, oldFile *bf.File) *Gener
 // Generator generates Bazel build rules for Go build targets.
 type Generator struct {
 	c                   *config.Config
-	l                   *resolve.Labeler
+	l                   *label.Labeler
 	shouldSetVisibility bool
 }
 

--- a/internal/rules/generator_test.go
+++ b/internal/rules/generator_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/merger"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
-	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
 	"github.com/bazelbuild/bazel-gazelle/internal/rules"
 	bf "github.com/bazelbuild/buildtools/build"
 )
@@ -57,7 +57,7 @@ func TestGenerator(t *testing.T) {
 	repoRoot := filepath.FromSlash("testdata/repo")
 	goPrefix := "example.com/repo"
 	c := testConfig(repoRoot, goPrefix)
-	l := resolve.NewLabeler(c)
+	l := label.NewLabeler(c)
 
 	var dirs []string
 	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
@@ -106,7 +106,7 @@ func TestGenerator(t *testing.T) {
 
 func TestGeneratorEmpty(t *testing.T) {
 	c := testConfig("", "example.com/repo")
-	l := resolve.NewLabeler(c)
+	l := label.NewLabeler(c)
 	g := rules.NewGenerator(c, l, nil)
 
 	pkg := packages.Package{Name: "foo"}
@@ -141,7 +141,7 @@ go_test(name = "go_default_xtest")
 func TestGeneratorEmptyLegacyProto(t *testing.T) {
 	c := testConfig("", "example.com/repo")
 	c.ProtoMode = config.LegacyProtoMode
-	l := resolve.NewLabeler(c)
+	l := label.NewLabeler(c)
 	g := rules.NewGenerator(c, l, nil)
 
 	pkg := packages.Package{Name: "foo"}


### PR DESCRIPTION
This preemptively breaks some dependency cycles.

Also: move relBaseName to pathtools