### PR TITLE
internal/merger: make "compilers" attribute unmergeable

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -99,7 +99,6 @@ func init() {
 				"go_proto_library",
 			},
 			attrs: []string{
-				"compilers",
 				"proto",
 			},
 		}, {


### PR DESCRIPTION
Gazelle won't modify or delete this attribute if it's set
in existing rules.

Fixes #86