### PR TITLE
internal/resolve: fix nested vendoring

### DIFF
--- a/internal/resolve/index.go
+++ b/internal/resolve/index.go
@@ -240,8 +240,8 @@ func (ix *RuleIndex) findRuleByImport(imp importSpec, lang config.Language, from
 			isVendored := false
 			vendorRoot := ""
 			parts := strings.Split(m.label.Pkg, "/")
-			for i, part := range parts {
-				if part == "vendor" {
+			for i := len(parts) - 1; i >= 0; i-- {
+				if parts[i] == "vendor" {
 					isVendored = true
 					vendorRoot = strings.Join(parts[:i], "/")
 					break
@@ -257,18 +257,18 @@ func (ix *RuleIndex) findRuleByImport(imp importSpec, lang config.Language, from
 				bestMatchIsVendored = isVendored
 				bestMatchVendorRoot = vendorRoot
 				matchError = nil
-			} else if !isVendored && (bestMatchIsVendored || len(vendorRoot) < len(bestMatchVendorRoot)) {
+			} else if (!isVendored && bestMatchIsVendored) || (isVendored && len(vendorRoot) < len(bestMatchVendorRoot)) {
 				// Current match is worse
 			} else {
 				// Match is ambiguous
-				matchError = fmt.Errorf("multiple rules (%s and %s) may be imported with %q", bestMatch.label, m.label, imp.imp)
+				matchError = fmt.Errorf("multiple rules (%s and %s) may be imported with %q from %s", bestMatch.label, m.label, imp.imp, from)
 			}
 
 		default:
 			if bestMatch == nil {
 				bestMatch = m
 			} else {
-				matchError = fmt.Errorf("multiple rules (%s and %s) may be imported with %q", bestMatch.label, m.label, imp.imp)
+				matchError = fmt.Errorf("multiple rules (%s and %s) may be imported with %q from %s", bestMatch.label, m.label, imp.imp, from)
 			}
 		}
 	}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -172,6 +172,30 @@ go_library(
 			imp:  "example.com/foo",
 			from: label.New("", "shallow/deep", "deep"),
 			want: label.New("", "shallow/deep/vendor", "deep"),
+		}, {
+			desc: "nested_vendor",
+			buildFiles: []fileSpec{
+				{
+					rel: "vendor/a",
+					content: `
+go_library(
+    name = "a",
+    importpath = "a",
+)
+`,
+				}, {
+					rel: "vendor/b/vendor/a",
+					content: `
+go_library(
+    name = "a",
+    importpath = "a",
+)
+`,
+				},
+			},
+			imp:  "a",
+			from: label.New("", "vendor/b/c", "c"),
+			want: label.New("", "vendor/b/vendor/a", "a"),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
When the same import is available in multiple visible vendor directories,
Gazelle should pick the most deeply nested directory.

Fixes #87