### PR TITLE
update-repos: add or update repository rules by import path

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,9 @@
 workspace(name = "bazel_gazelle")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "e7249a61c3a244513601d998a13df1fa835433eb", # master on 2018-01-04
-    remote = "https://github.com/bazelbuild/rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
+    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -152,7 +152,8 @@ func runFixUpdate(cmd command, args []string) error {
 	ruleIndex.Finish()
 
 	// Resolve dependencies.
-	resolver := resolve.NewResolver(uc.c, l, ruleIndex, uc.repos)
+	rc := repos.NewRemoteCache(uc.repos)
+	resolver := resolve.NewResolver(uc.c, l, ruleIndex, rc)
 	for i := range visits {
 		for j := range visits[i].rules {
 			visits[i].rules[j] = resolver.ResolveRule(visits[i].rules[j], visits[i].pkgRel)

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/merger"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
@@ -29,9 +30,13 @@ import (
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
+type updateReposFn func(c *updateReposConfiguration, oldFile *bf.File) (*bf.File, error)
+
 type updateReposConfiguration struct {
+	fn           updateReposFn
 	repoRoot     string
 	lockFilename string
+	importPaths  []string
 }
 
 func updateRepos(args []string) error {
@@ -50,12 +55,10 @@ func updateRepos(args []string) error {
 		return fmt.Errorf("error parsing %q: %v", workspacePath, err)
 	}
 
-	genRules, err := repos.ImportRepoRules(c.lockFilename)
+	mergedFile, err := c.fn(c, oldFile)
 	if err != nil {
 		return err
 	}
-
-	mergedFile, _ := merger.MergeFile(genRules, nil, oldFile, merger.RepoAttrs)
 	mergedFile = merger.FixLoads(mergedFile)
 	if err := ioutil.WriteFile(mergedFile.Path, bf.Format(mergedFile), 0666); err != nil {
 		return fmt.Errorf("error writing %q: %v", mergedFile.Path, err)
@@ -80,15 +83,8 @@ func newUpdateReposConfiguration(args []string) (*updateReposConfiguration, erro
 		// flag already prints the error; don't print it again.
 		return nil, errors.New("Try -help for more information")
 	}
-	if len(fs.Args()) != 0 {
-		return nil, fmt.Errorf("Got %d positional arguments; wanted 0.\nTry -help for more information.")
-	}
 
-	c.lockFilename = *fromFileFlag
-	if c.lockFilename == "" {
-		return nil, errors.New("-from_file not provided.\nTry -help for more information.")
-	}
-
+	// Handle general flags that apply to all subcommands.
 	c.repoRoot = *repoRootFlag
 	if c.repoRoot == "" {
 		if repoRoot, err := wspace.Find("."); err != nil {
@@ -98,18 +94,83 @@ func newUpdateReposConfiguration(args []string) (*updateReposConfiguration, erro
 		}
 	}
 
+	// Handle flags specific to each subcommand.
+	switch {
+	case *fromFileFlag != "":
+		if len(fs.Args()) != 0 {
+			return nil, fmt.Errorf("Got %d positional arguments with -from_file; wanted 0.\nTry -help for more information.", len(fs.Args()))
+		}
+		c.fn = importFromLockFile
+		c.lockFilename = *fromFileFlag
+
+	default:
+		if len(fs.Args()) == 0 {
+			return nil, fmt.Errorf("No repositories specified\nTry -help for more information.")
+		}
+		c.fn = updateImportPaths
+		c.importPaths = fs.Args()
+	}
+
 	return c, nil
 }
 
 func updateReposUsage(fs *flag.FlagSet) {
-	fmt.Fprintln(os.Stderr, `usage: gazelle update-repos -from_file file
+	fmt.Fprintln(os.Stderr, `usage:
+
+# Add/update repositories by import path
+gazelle update-repos example.com/repo1 example.com/repo2
+
+# Import repositories from lock file
+gazelle update-repos -from_file=file
 
 The update-repos command updates repository rules in the WORKSPACE file.
-
-Currently, update-repos can only import repository rules from the lock file
-of a vendoring tool, and only dep's Gopkg.lock is supported. More functionality
-is planned though, and you have to start somewhere.
+update-repos can add or update repositories explicitly by import path.
+update-repos can also import repository rules from a vendoring tool's lock
+file (currently only deps' Gopkg.lock is supported).
 
 FLAGS:
 `)
+}
+
+func updateImportPaths(c *updateReposConfiguration, oldFile *bf.File) (*bf.File, error) {
+	rs := repos.ListRepositories(oldFile)
+	rc := repos.NewRemoteCache(rs)
+
+	genRules := make([]bf.Expr, len(c.importPaths))
+	errs := make([]error, len(c.importPaths))
+	var wg sync.WaitGroup
+	wg.Add(len(c.importPaths))
+	for i, imp := range c.importPaths {
+		go func(i int) {
+			defer wg.Done()
+			repo, err := repos.UpdateRepo(rc, imp)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			repo.Remote = "" // don't set these explicitly
+			repo.VCS = ""
+			rule := repos.GenerateRule(repo)
+			genRules[i] = rule
+		}(i)
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	mergedFile, _ := merger.MergeFile(genRules, nil, oldFile, merger.RepoAttrs)
+	return mergedFile, nil
+}
+
+func importFromLockFile(c *updateReposConfiguration, oldFile *bf.File) (*bf.File, error) {
+	genRules, err := repos.ImportRepoRules(c.lockFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	mergedFile, _ := merger.MergeFile(genRules, nil, oldFile, merger.RepoAttrs)
+	return mergedFile, nil
 }

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -4,15 +4,18 @@ go_library(
     name = "go_default_library",
     srcs = [
         "dep.go",
+        "remote.go",
         "repo.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/repos",
     visibility = ["//visibility:public"],
     deps = [
         "//internal/label:go_default_library",
+        "//internal/pathtools:go_default_library",
         "//internal/rules:go_default_library",
         "//vendor/github.com/pelletier/go-toml:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )
 
@@ -20,8 +23,12 @@ go_test(
     name = "go_default_test",
     srcs = [
         "import_test.go",
+        "remote_test.go",
         "repo_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
+    deps = [
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@org_golang_x_tools//go/vcs:go_default_library",
+    ],
 )

--- a/internal/repos/remote.go
+++ b/internal/repos/remote.go
@@ -1,0 +1,327 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repos
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
+	"golang.org/x/tools/go/vcs"
+)
+
+// UpdateRepo returns an object describing a repository at the most recent
+// commit or version tag.
+//
+// This function uses RemoteCache to retrieve information about the repository.
+// Depending on how the RemoteCache was initialized and used earlier, some
+// information may already be locally available. Frequently though, information
+// will be fetched over the network, so this function may be slow.
+func UpdateRepo(rc *RemoteCache, importPath string) (Repo, error) {
+	root, name, err := rc.Root(importPath)
+	if err != nil {
+		return Repo{}, err
+	}
+	remote, vcs, err := rc.Remote(root)
+	if err != nil {
+		return Repo{}, err
+	}
+	commit, tag, err := rc.Head(remote, vcs)
+	if err != nil {
+		return Repo{}, err
+	}
+	repo := Repo{
+		Name:     name,
+		GoPrefix: root,
+		Commit:   commit,
+		Tag:      tag,
+		Remote:   remote,
+		VCS:      vcs,
+	}
+	return repo, nil
+}
+
+// RemoteCache stores information about external repositories. The cache may
+// be initialized with information about known repositories, i.e., those listed
+// in the WORKSPACE file and mentioned on the command line. Other information
+// is retrieved over the network.
+//
+// Public methods of RemoteCache may be slow in cases where a network fetch
+// is needed. Public methods may be called concurrently.
+type RemoteCache struct {
+	// RepoRootForImportPath is vcs.RepoRootForImportPath by default. It may
+	// be overridden so that tests may avoid accessing the network.
+	RepoRootForImportPath func(string, bool) (*vcs.RepoRoot, error)
+
+	// HeadCmd returns the latest commit on the default branch in the given
+	// repository. This is used by Head. It may be stubbed out for tests.
+	HeadCmd func(remote, vcs string) (string, error)
+
+	root, remote, head remoteCacheMap
+}
+
+// remoteCacheMap is a thread-safe, idempotent cache. It is used to store
+// information which should be fetched over the network no more than once.
+// This follows the Memo pattern described in The Go Programming Language,
+// section 9.7.
+type remoteCacheMap struct {
+	mu    sync.Mutex
+	cache map[string]*remoteCacheEntry
+}
+
+type remoteCacheEntry struct {
+	value interface{}
+	err   error
+
+	// ready is nil for entries that were added when the cache was initialized.
+	// It is non-nil for other entries. It is closed when an entry is ready,
+	// i.e., the operation loading the entry completed.
+	ready chan struct{}
+}
+
+type rootValue struct {
+	root, name string
+}
+
+type remoteValue struct {
+	remote, vcs string
+}
+
+type headValue struct {
+	commit, tag string
+}
+
+// NewRemoteCache creates a new RemoteCache with a set of known repositories.
+// The Root and Remote methods will return information about repositories listed
+// here without accessing the network. However, the Head method will still
+// access the network for these repositories to retrieve information about new
+// versions.
+func NewRemoteCache(knownRepos []Repo) *RemoteCache {
+	r := &RemoteCache{
+		RepoRootForImportPath: vcs.RepoRootForImportPath,
+		HeadCmd:               defaultHeadCmd,
+		root:                  remoteCacheMap{cache: make(map[string]*remoteCacheEntry)},
+		remote:                remoteCacheMap{cache: make(map[string]*remoteCacheEntry)},
+		head:                  remoteCacheMap{cache: make(map[string]*remoteCacheEntry)},
+	}
+	for _, repo := range knownRepos {
+		r.root.cache[repo.GoPrefix] = &remoteCacheEntry{
+			value: rootValue{
+				root: repo.GoPrefix,
+				name: repo.Name,
+			},
+		}
+		if repo.Remote != "" {
+			r.remote.cache[repo.GoPrefix] = &remoteCacheEntry{
+				value: remoteValue{
+					remote: repo.Remote,
+					vcs:    repo.VCS,
+				},
+			}
+		}
+	}
+	return r
+}
+
+var gopkginPattern = regexp.MustCompile("^(gopkg.in/(?:[^/]+/)?[^/]+\\.v\\d+)(?:/|$)")
+
+var knownPrefixes = []struct {
+	prefix  string
+	missing int
+}{
+	{prefix: "golang.org/x", missing: 1},
+	{prefix: "google.golang.org", missing: 1},
+	{prefix: "cloud.google.com", missing: 1},
+	{prefix: "github.com", missing: 2},
+}
+
+// Root returns the portion of an import path that corresponds to the root
+// directory of the repository containing the given import path. For example,
+// given "golang.org/x/tools/go/loader", this will return "golang.org/x/tools".
+// The workspace name of the repository is also returned. This may be a custom
+// name set in WORKSPACE, or it may be a generated name based on the root path.
+func (r *RemoteCache) Root(importPath string) (root, name string, err error) {
+	// Try prefixes of the import path in the cache, but don't actually go out
+	// to vcs yet. We do this before handling known special cases because
+	// the cache is pre-populated with repository rules, and we want to use their
+	// names if we can.
+	prefix := importPath
+	for {
+		v, ok, err := r.root.get(prefix)
+		if ok {
+			if err != nil {
+				return "", "", err
+			}
+			value := v.(rootValue)
+			return value.root, value.name, nil
+		}
+
+		prefix = path.Dir(prefix)
+		if prefix == "." || prefix == "/" {
+			break
+		}
+	}
+
+	// Try known prefixes.
+	for _, p := range knownPrefixes {
+		if pathtools.HasPrefix(importPath, p.prefix) {
+			rest := pathtools.TrimPrefix(importPath, p.prefix)
+			var components []string
+			if rest != "" {
+				components = strings.Split(rest, "/")
+			}
+			if len(components) < p.missing {
+				return "", "", fmt.Errorf("import path %q is shorter than the known prefix %q", importPath, p.prefix)
+			}
+			root = p.prefix
+			for _, c := range components[:p.missing] {
+				root = path.Join(root, c)
+			}
+			name = label.ImportPathToBazelRepoName(root)
+			return root, name, nil
+		}
+	}
+
+	// gopkg.in is special, and might have either one or two levels of
+	// missing paths. See http://labix.org/gopkg.in for URL patterns.
+	if match := gopkginPattern.FindStringSubmatch(importPath); len(match) > 0 {
+		root = match[1]
+		name = label.ImportPathToBazelRepoName(root)
+		return root, name, nil
+	}
+
+	// Find the prefix using vcs and cache the result.
+	v, err := r.root.ensure(importPath, func() (interface{}, error) {
+		res, err := r.RepoRootForImportPath(importPath, false)
+		if err != nil {
+			return nil, err
+		}
+		return rootValue{res.Root, label.ImportPathToBazelRepoName(res.Root)}, nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	value := v.(rootValue)
+	return value.root, value.name, nil
+}
+
+// Remote returns the VCS name and the remote URL for a repository with the
+// given root import path. This is suitable for creating new repository rules.
+func (r *RemoteCache) Remote(root string) (remote, vcs string, err error) {
+	v, err := r.remote.ensure(root, func() (interface{}, error) {
+		repo, err := r.RepoRootForImportPath(root, false)
+		if err != nil {
+			return nil, err
+		}
+		return remoteValue{remote: repo.Repo, vcs: repo.VCS.Cmd}, nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	value := v.(remoteValue)
+	return value.remote, value.vcs, nil
+}
+
+// Head returns the most recent commit id on the default branch and latest
+// version tag for the given remote repository. The tag "" is returned if
+// no latest version was found.
+//
+// TODO(jayconrod): support VCS other than git.
+// TODO(jayconrod): support version tags. "" is always returned.
+func (r *RemoteCache) Head(remote, vcs string) (commit, tag string, err error) {
+	if vcs != "git" {
+		return "", "", fmt.Errorf("could not locate recent commit in repo %q with unknown version control scheme %q", remote, vcs)
+	}
+
+	v, err := r.head.ensure(remote, func() (interface{}, error) {
+		commit, err := r.HeadCmd(remote, vcs)
+		if err != nil {
+			return nil, err
+		}
+		return headValue{commit: commit}, nil
+	})
+	if err != nil {
+		return "", "", err
+	}
+	value := v.(headValue)
+	return value.commit, value.tag, nil
+}
+
+func defaultHeadCmd(remote, vcs string) (string, error) {
+	switch vcs {
+	case "local":
+		return "", nil
+
+	case "git":
+		cmd := exec.Command("git", "ls-remote", "--", remote, "HEAD")
+		out, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		ix := bytes.IndexByte(out, '\t')
+		if ix < 0 {
+			return "", fmt.Errorf("could not parse output for git ls-remote for %q", remote)
+		}
+		return string(out[:ix]), nil
+
+	default:
+		return "", fmt.Errorf("unknown version control system: %s", vcs)
+	}
+}
+
+// get retrieves a value associated with the given key from the cache. ok will
+// be true if the key exists in the cache, even if it's in the process of
+// being fetched.
+func (m *remoteCacheMap) get(key string) (value interface{}, ok bool, err error) {
+	m.mu.Lock()
+	e, ok := m.cache[key]
+	m.mu.Unlock()
+	if !ok {
+		return nil, ok, nil
+	}
+	if e.ready != nil {
+		<-e.ready
+	}
+	return e.value, ok, e.err
+}
+
+// ensure retreives a value associated with the given key from the cache. If
+// the key does not exist in the cache, the load function will be called,
+// and its result will be associated with the key. The load function will not
+// be called more than once for any key.
+func (m *remoteCacheMap) ensure(key string, load func() (interface{}, error)) (interface{}, error) {
+	m.mu.Lock()
+	e, ok := m.cache[key]
+	if !ok {
+		e = &remoteCacheEntry{ready: make(chan struct{})}
+		m.cache[key] = e
+		m.mu.Unlock()
+		e.value, e.err = load()
+		close(e.ready)
+	} else {
+		m.mu.Unlock()
+		if e.ready != nil {
+			<-e.ready
+		}
+	}
+	return e.value, e.err
+}

--- a/internal/repos/remote_test.go
+++ b/internal/repos/remote_test.go
@@ -1,0 +1,223 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repos
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/vcs"
+)
+
+func TestRootSpecialCases(t *testing.T) {
+	for _, tc := range []struct {
+		in, wantRoot, wantName string
+		repos                  []Repo
+		wantError              bool
+	}{
+		{in: "golang.org/x/net/context", wantRoot: "golang.org/x/net", wantName: "org_golang_x_net"},
+		{in: "golang.org/x/tools/go/vcs", wantRoot: "golang.org/x/tools", wantName: "org_golang_x_tools"},
+		{in: "golang.org/x/goimports", wantRoot: "golang.org/x/goimports", wantName: "org_golang_x_goimports"},
+		{in: "cloud.google.com/fashion/industry", wantRoot: "cloud.google.com/fashion", wantName: "com_google_cloud_fashion"},
+		{in: "github.com/foo", wantError: true},
+		{in: "github.com/foo/bar", wantRoot: "github.com/foo/bar", wantName: "com_github_foo_bar"},
+		{in: "github.com/foo/bar/baz", wantRoot: "github.com/foo/bar", wantName: "com_github_foo_bar"},
+		{in: "gopkg.in/yaml.v2", wantRoot: "gopkg.in/yaml.v2", wantName: "in_gopkg_yaml_v2"},
+		{in: "gopkg.in/src-d/go-git.v4", wantRoot: "gopkg.in/src-d/go-git.v4", wantName: "in_gopkg_src_d_go_git_v4"},
+		{in: "unsupported.org/x/net/context", wantError: true},
+		{
+			in: "private.com/my/repo/package/path",
+			repos: []Repo{
+				{
+					Name:     "com_other_host_repo",
+					GoPrefix: "other-host.com/repo",
+				}, {
+					Name:     "com_private_my_repo",
+					GoPrefix: "private.com/my/repo",
+				},
+			},
+			wantRoot: "private.com/my/repo",
+			wantName: "com_private_my_repo",
+		},
+		{
+			in: "unsupported.org/x/net/context",
+			repos: []Repo{
+				{
+					Name:     "com_private_my_repo",
+					GoPrefix: "private.com/my/repo",
+				},
+			},
+			wantError: true,
+		},
+		{
+			in: "github.com/foo/bar",
+			repos: []Repo{{
+				Name:     "custom_repo",
+				GoPrefix: "github.com/foo/bar",
+			}},
+			wantRoot: "github.com/foo/bar",
+			wantName: "custom_repo",
+		},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			fmt.Fprintf(os.Stderr, "testing %s\n", tc.in)
+			rc := newStubRemoteCache(tc.repos)
+			if gotRoot, gotName, err := rc.Root(tc.in); err != nil {
+				if !tc.wantError {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else if tc.wantError {
+				t.Errorf("unexpected success: %v", tc.in)
+			} else if gotRoot != tc.wantRoot {
+				t.Errorf("root for %q: got %q; want %q", tc.in, gotRoot, tc.wantRoot)
+			} else if gotName != tc.wantName {
+				t.Errorf("name for %q: got %q; want %q", tc.in, gotName, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestRemote(t *testing.T) {
+	for _, tc := range []struct {
+		desc, root          string
+		repos               []Repo
+		wantRemote, wantVCS string
+		wantError           bool
+	}{
+		{
+			desc:      "unstubbed_remote",
+			root:      "github.com/bazelbuild/bazel-gazelle",
+			wantError: true, // stub should return an error
+		}, {
+			desc: "known_repo",
+			root: "github.com/example/project",
+			repos: []Repo{{
+				Name:     "com_github_example_project",
+				GoPrefix: "github.com/example/project",
+				Remote:   "https://private.com/example/project",
+				VCS:      "git",
+			}},
+			wantRemote: "https://private.com/example/project",
+			wantVCS:    "git",
+		}, {
+			desc:       "git_repo",
+			root:       "example.com/repo", // stub knows this
+			wantRemote: "https://example.com/repo.git",
+			wantVCS:    "git",
+		}, {
+			desc: "local_repo",
+			root: "github.com/example/project",
+			repos: []Repo{{
+				Name:     "com_github_example_project",
+				GoPrefix: "github.com/example/project",
+				Remote:   "/home/joebob/go/src/github.com/example/project",
+				VCS:      "local",
+			}},
+			wantRemote: "/home/joebob/go/src/github.com/example/project",
+			wantVCS:    "local",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			rc := newStubRemoteCache(tc.repos)
+			if gotRemote, gotVCS, err := rc.Remote(tc.root); err != nil {
+				if !tc.wantError {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else if tc.wantError {
+				t.Errorf("unexpected success")
+			} else if gotRemote != tc.wantRemote {
+				t.Errorf("remote for %q: got %q ; want %q", tc.root, gotRemote, tc.wantRemote)
+			} else if gotVCS != tc.wantVCS {
+				t.Errorf("vcs for %q: got %q ; want %q", tc.root, gotVCS, tc.wantVCS)
+			}
+		})
+	}
+}
+
+func TestHead(t *testing.T) {
+	for _, tc := range []struct {
+		desc, remote, vcs   string
+		wantCommit, wantTag string
+		wantError           bool
+	}{
+		{
+			desc:      "unstubbed_remote",
+			remote:    "https://github.com/bazelbuild/bazel-gazelle",
+			vcs:       "git",
+			wantError: true, // stub should return an error
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			rc := newStubRemoteCache(nil)
+			if gotCommit, gotTag, err := rc.Head(tc.remote, tc.vcs); err != nil {
+				if !tc.wantError {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else if tc.wantError {
+				t.Errorf("unexpected success")
+			} else if gotCommit != tc.wantCommit {
+				t.Errorf("commit for %q: got %q ; want %q", tc.remote, gotCommit, tc.wantCommit)
+			} else if gotTag != tc.wantTag {
+				t.Errorf("tag for %q: got %q ; want %q", tc.remote, gotTag, tc.wantTag)
+			}
+		})
+	}
+}
+
+func newStubRemoteCache(rs []Repo) *RemoteCache {
+	rc := NewRemoteCache(rs)
+	rc.RepoRootForImportPath = stubRepoRootForImportPath
+	rc.HeadCmd = stubHeadCmd
+	return rc
+}
+
+// stubRepoRootForImportPath is a stub implementation of vcs.RepoRootForImportPath
+func stubRepoRootForImportPath(importpath string, verbose bool) (*vcs.RepoRoot, error) {
+	if strings.HasPrefix(importpath, "example.com/repo.git") {
+		return &vcs.RepoRoot{
+			VCS:  vcs.ByCmd("git"),
+			Repo: "https://example.com/repo.git",
+			Root: "example.com/repo.git",
+		}, nil
+	}
+
+	if strings.HasPrefix(importpath, "example.com/repo") {
+		return &vcs.RepoRoot{
+			VCS:  vcs.ByCmd("git"),
+			Repo: "https://example.com/repo.git",
+			Root: "example.com/repo",
+		}, nil
+	}
+
+	if strings.HasPrefix(importpath, "example.com") {
+		return &vcs.RepoRoot{
+			VCS:  vcs.ByCmd("git"),
+			Repo: "https://example.com",
+			Root: "example.com",
+		}, nil
+	}
+
+	return nil, fmt.Errorf("could not resolve import path: %q", importpath)
+}
+
+func stubHeadCmd(remote, vcs string) (string, error) {
+	if vcs == "git" && remote == "https://example.com/repo" {
+		return "abcdef", nil
+	}
+	return "", fmt.Errorf("could not resolve remote: %q", remote)
+}

--- a/internal/repos/repo_test.go
+++ b/internal/repos/repo_test.go
@@ -31,7 +31,7 @@ func TestGenerateRepoRules(t *testing.T) {
 		GoPrefix: "golang.org/x/tools",
 		Commit:   "123456",
 	}
-	got := bf.FormatString(generateRepoRule(repo))
+	got := bf.FormatString(GenerateRule(repo))
 	want := `go_repository(
     name = "org_golang_x_tools",
     commit = "123456",

--- a/internal/resolve/BUILD.bazel
+++ b/internal/resolve/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//internal/pathtools:go_default_library",
         "//internal/repos:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
-        "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -45,11 +45,11 @@ type nonlocalResolver interface {
 	resolve(imp string) (label.Label, error)
 }
 
-func NewResolver(c *config.Config, l *label.Labeler, ix *RuleIndex, repos []repos.Repo) *Resolver {
+func NewResolver(c *config.Config, l *label.Labeler, ix *RuleIndex, rc *repos.RemoteCache) *Resolver {
 	var e nonlocalResolver
 	switch c.DepMode {
 	case config.ExternalMode:
-		e = newExternalResolver(l, repos)
+		e = newExternalResolver(l, rc)
 	case config.VendorMode:
 		e = newVendoredResolver(l)
 	}

--- a/internal/resolve/resolve_external.go
+++ b/internal/resolve/resolve_external.go
@@ -16,14 +16,9 @@ limitations under the License.
 package resolve
 
 import (
-	"fmt"
-	"path"
-	"regexp"
-
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
-	"golang.org/x/tools/go/vcs"
 )
 
 // externalResolver resolves import paths to external repositories. It uses
@@ -33,137 +28,32 @@ import (
 // guidelines in http://bazel.io/docs/be/functions.html#workspace. The remaining
 // portion of the import path is treated as the package name.
 type externalResolver struct {
-	l *label.Labeler
-
-	// repoRootForImportPath is vcs.RepoRootForImportPath by default. It may
-	// be overridden by tests.
-	repoRootForImportPath func(string, bool) (*vcs.RepoRoot, error)
-
-	// cache stores lookup results, both positive and negative to reduce
-	// network fetches when there are multiple imports on the same external repo.
-	cache map[string]repoRootCacheEntry
-
-	// prefixToName maps import path prefixes to repository names.
-	prefixToName map[string]string
-}
-
-type repoRootCacheEntry struct {
-	// prefix is part of an import path that corresponds to a repository root,
-	// possibly with some components missing.
-	prefix string
-
-	// missing is the number of components missing from prefix to make a full
-	// repository root prefix. For most repositories, this is 0, meaning the
-	// prefix is the full path to the repository root. For some well-known sites,
-	// this is non-zero. For example, we can store the prefix "github.com" with
-	// missing as 2, since GitHub always has two path components before the
-	// actual repository.
-	missing int
-
-	// err is an error we encountered when resolving this prefix. This is used
-	// for caching negative results.
-	err error
+	l  *label.Labeler
+	rc *repos.RemoteCache
 }
 
 var _ nonlocalResolver = (*externalResolver)(nil)
 
-func newExternalResolver(l *label.Labeler, repos []repos.Repo) *externalResolver {
-	resolver := &externalResolver{
-		l:                     l,
-		cache:                 make(map[string]repoRootCacheEntry),
-		prefixToName:          make(map[string]string),
-		repoRootForImportPath: vcs.RepoRootForImportPath,
-	}
-
-	for _, e := range []repoRootCacheEntry{
-		{prefix: "golang.org/x", missing: 1},
-		{prefix: "google.golang.org", missing: 1},
-		{prefix: "cloud.google.com", missing: 1},
-		{prefix: "github.com", missing: 2},
-	} {
-		resolver.cache[e.prefix] = e
-	}
-
-	for _, e := range repos {
-		resolver.cache[e.GoPrefix] = repoRootCacheEntry{prefix: e.GoPrefix, missing: 0}
-		resolver.prefixToName[e.GoPrefix] = e.Name
-	}
-
-	return resolver
+func newExternalResolver(l *label.Labeler, rc *repos.RemoteCache) *externalResolver {
+	return &externalResolver{l: l, rc: rc}
 }
 
-// Resolve resolves "importpath" into a label, assuming that it is a label in an
+// Resolve resolves "importPath" into a label, assuming that it is a label in an
 // external repository. It also assumes that the external repository follows the
 // recommended reverse-DNS form of workspace name as described in
 // http://bazel.io/docs/be/functions.html#workspace.
-func (r *externalResolver) resolve(importpath string) (label.Label, error) {
-	prefix, err := r.lookupPrefix(importpath)
+func (r *externalResolver) resolve(importPath string) (label.Label, error) {
+	prefix, repo, err := r.rc.Root(importPath)
 	if err != nil {
 		return label.NoLabel, err
 	}
 
-	repo, ok := r.prefixToName[prefix]
-	if !ok {
-		repo = label.ImportPathToBazelRepoName(prefix)
-		r.prefixToName[prefix] = repo
-	}
-
 	var pkg string
-	if importpath != prefix {
-		pkg = pathtools.TrimPrefix(importpath, prefix)
+	if importPath != prefix {
+		pkg = pathtools.TrimPrefix(importPath, prefix)
 	}
 
 	l := r.l.LibraryLabel(pkg)
 	l.Repo = repo
 	return l, nil
-}
-
-var gopkginPattern = regexp.MustCompile("^(gopkg.in/(?:[^/]+/)?[^/]+\\.v\\d+)(?:/|$)")
-
-// lookupPrefix determines the prefix of "importpath" that corresponds to
-// the root of the repository. Results are cached.
-func (r *externalResolver) lookupPrefix(importpath string) (string, error) {
-	// subpaths contains slices of importpath with components removed. For
-	// example:
-	//   golang.org/x/tools/go/vcs
-	//   golang.org/x/tools/go
-	//   golang.org/x/tools
-	subpaths := []string{importpath}
-
-	// Check the cache for prefixes of the import path.
-	prefix := importpath
-	for {
-		if e, ok := r.cache[prefix]; ok {
-			if e.missing >= len(subpaths) {
-				return "", fmt.Errorf("import path %q is shorter than the known prefix %q", prefix, e.prefix)
-			}
-			// Cache hit. Restore n components of the import path to get the
-			// repository root.
-			return subpaths[len(subpaths)-e.missing-1], e.err
-		}
-
-		// Prefix not found. Remove the last component and try again.
-		prefix = path.Dir(prefix)
-		if prefix == "." || prefix == "/" {
-			// Cache miss.
-			break
-		}
-		subpaths = append(subpaths, prefix)
-	}
-
-	// gopkg.in is special, and might have either one or two levels of
-	// missing paths. See http://labix.org/gopkg.in for URL patterns.
-	if match := gopkginPattern.FindStringSubmatch(importpath); len(match) > 0 {
-		return match[1], nil
-	}
-
-	// Look up the import path using vcs.
-	root, err := r.repoRootForImportPath(importpath, false)
-	if err != nil {
-		r.cache[importpath] = repoRootCacheEntry{prefix: importpath, err: err}
-		return "", err
-	}
-	prefix = root.Root
-	r.cache[prefix] = repoRootCacheEntry{prefix: prefix}
-	return prefix, nil
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -337,13 +337,14 @@ func TestResolveGoLocalError(t *testing.T) {
 	c := &config.Config{GoPrefix: "example.com/repo"}
 	l := label.NewLabeler(c)
 	ix := NewRuleIndex()
-	r := NewResolver(c, l, ix, nil)
+	rc := newStubRemoteCache(nil)
+	r := NewResolver(c, l, ix, rc)
 
 	for _, importpath := range []string{
 		"fmt",
-		"example.com/another",
-		"example.com/another/sub",
-		"example.com/repo_suffix",
+		"unknown.com/another",
+		"unknown.com/another/sub",
+		"unknown.com/repo_suffix",
 	} {
 		if l, err := r.resolveGo(importpath, label.NoLabel); err == nil {
 			t.Errorf("r.resolveGo(%q) = %s; want error", importpath, l)


### PR DESCRIPTION
The update-repos command can now add or update go_repository rules by
import path. To use:

    gazelle update-repos example.com/repo1 example.com/repo2

This will automatically discover the remote, VCS, and latest commit
for each repository containing the named packages. If a repository
already exists in WORKSPACE, it will be updated in place.

This functionality replaces wtool, which will be deleted soon after
this lands.

Related #56