### PR TITLE
internal/merger: more flexible rule matching

### DIFF
--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -293,15 +293,7 @@ func removeLegacyProto(c *config.Config, oldFile *bf.File) *bf.File {
 		sort.Ints(deletedIndices)
 	}
 	fixedFile := *oldFile
-	fixedFile.Stmt = make([]bf.Expr, 0, len(oldFile.Stmt)-len(deletedIndices))
-	di := 0
-	for i, stmt := range oldFile.Stmt {
-		if di < len(deletedIndices) && i == deletedIndices[di] {
-			di++
-			continue
-		}
-		fixedFile.Stmt = append(fixedFile.Stmt, stmt)
-	}
+	fixedFile.Stmt = deleteIndices(oldFile.Stmt, deletedIndices)
 	return &fixedFile
 }
 


### PR DESCRIPTION
Previously, Gazelle would merge a generated rule with an existing rule
if the existing rule had the same name and kind. This change makes the
matching algorithm more flexible.

* The kind must always match. This may be relaxed in the future.
* If the name doesn't match any existing rule, Gazelle will consider
  other attributes based on the kind. For example, when matching
  go_library, Gazelle will look for matching importpath attributes.
* go_binary rules will match any go_binary rules in the same
  build file.

Fixes #106
Related #99
Fixes #17