### PR TITLE
internal/config: inferred proto mode can't override explicit default

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -199,7 +199,8 @@ func newFixUpdateConfiguration(cmd command, args []string) (*updateConfig, error
 	mode := fs.String("mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 	outDir := fs.String("experimental_out_dir", "", "write build files to an alternate directory tree")
 	outSuffix := fs.String("experimental_out_suffix", "", "extra suffix appended to build file names. Only used if -experimental_out_dir is also set.")
-	proto := fs.String("proto", "default", "default: generates new proto rules\n\tdisable: does not touch proto rules\n\tlegacy (deprecated): generates old proto rules")
+	var proto explicitFlag
+	fs.Var(&proto, "proto", "default: generates new proto rules\n\tdisable: does not touch proto rules\n\tlegacy (deprecated): generates old proto rules")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			fixUpdateUsage(fs)
@@ -271,9 +272,12 @@ func newFixUpdateConfiguration(cmd command, args []string) (*updateConfig, error
 		return nil, err
 	}
 
-	uc.c.ProtoMode, err = config.ProtoModeFromString(*proto)
-	if err != nil {
-		return nil, err
+	if proto.set {
+		uc.c.ProtoMode, err = config.ProtoModeFromString(proto.value)
+		if err != nil {
+			return nil, err
+		}
+		uc.c.ProtoModeExplicit = true
 	}
 
 	emit, ok := modeFromName[*mode]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,9 @@ type Config struct {
 
 	// ProtoMode determines how rules are generated for protos.
 	ProtoMode ProtoMode
+
+	// ProtoModeExplicit indicates whether the proto mode was set explicitly.
+	ProtoModeExplicit bool
 }
 
 var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}

--- a/internal/config/directives.go
+++ b/internal/config/directives.go
@@ -115,6 +115,7 @@ func ApplyDirectives(c *Config, directives []Directive, rel string) *Config {
 				continue
 			}
 			modified.ProtoMode = protoMode
+			modified.ProtoModeExplicit = true
 			didModify = true
 		}
 	}
@@ -131,7 +132,7 @@ func ApplyDirectives(c *Config, directives []Directive, rel string) *Config {
 // repository, legacy mode is used. If go_proto_library is loaded from another
 // file, proto rule generation is disabled.
 func InferProtoMode(c *Config, rel string, f *bf.File, directives []Directive) *Config {
-	if c.ProtoMode != DefaultProtoMode {
+	if c.ProtoMode != DefaultProtoMode || c.ProtoModeExplicit {
 		return c
 	}
 	for _, d := range directives {

--- a/internal/config/directives_test.go
+++ b/internal/config/directives_test.go
@@ -121,6 +121,14 @@ load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 `,
 			want: DefaultProtoMode,
 		}, {
+			desc:    "explicit_no_override",
+			content: `load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")`,
+			c: Config{
+				ProtoMode:         DefaultProtoMode,
+				ProtoModeExplicit: true,
+			},
+			want: DefaultProtoMode,
+		}, {
 			desc: "vendor",
 			rel:  "vendor",
 			want: DisableProtoMode,


### PR DESCRIPTION
If the proto mode is explicitly set to the default mode (via the
command line or directive), it will no longer be overridden by an
inferred legacy or disabled mode. It can still be overridden by an
explicit directive in a subdirectory.

Fixes #104