### PR TITLE
run gazelle in pure mode

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -31,6 +31,12 @@ go_library(
 go_binary(
     name = "gazelle",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "gazelle_pure",
+    embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
 go_binary(
     name = "gazelle",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
I don't see any reason not to. I do it manually by passing `--features` to `bazel run`, since my `libstdc++` is broken.