### PR TITLE
Address some minor warning thrown by linters.

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,7 @@ func TestPreprocessTags(t *testing.T) {
 	unexpectedTags := []string{"x", "cgo", "go1.8", "go1.7"}
 	for _, tag := range unexpectedTags {
 		if c.GenericTags[tag] {
-			t.Errorf("tag %q unexpectedly set")
+			t.Errorf("tag %q unexpectedly set", tag)
 		}
 	}
 }

--- a/internal/config/directives.go
+++ b/internal/config/directives.go
@@ -163,7 +163,8 @@ func InferProtoMode(c *Config, rel string, f *bf.File, directives []Directive) *
 		if !ok {
 			continue
 		}
-		if x, ok := c.X.(*bf.LiteralExpr); !ok || x.Token != "load" || len(c.List) == 0 {
+		x, ok := c.X.(*bf.LiteralExpr)
+		if !ok || x.Token != "load" || len(c.List) == 0 {
 			continue
 		}
 		name, ok := c.List[0].(*bf.StringExpr)

--- a/internal/config/platform.go
+++ b/internal/config/platform.go
@@ -117,10 +117,10 @@ func init() {
 	}
 	KnownOSs = make([]string, 0, len(KnownOSSet))
 	KnownArchs = make([]string, 0, len(KnownArchSet))
-	for os, _ := range KnownOSSet {
+	for os := range KnownOSSet {
 		KnownOSs = append(KnownOSs, os)
 	}
-	for arch, _ := range KnownArchSet {
+	for arch := range KnownArchSet {
 		KnownArchs = append(KnownArchs, arch)
 	}
 	sort.Strings(KnownOSs)


### PR DESCRIPTION
- 1 missing format argument in test error message
- 1 removal of variable shadowing
- 2 loop range simplifications