### PR TITLE
internal/label: fix a parse error with implicit names

### DIFF
--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -41,7 +41,7 @@ var NoLabel = Label{}
 
 var (
 	labelRepoRegexp = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
-	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/.-]*$`)
+	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
 	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
 )
 
@@ -93,7 +93,7 @@ func Parse(s string) (Label, error) {
 		return NoLabel, fmt.Errorf("label parse error: empty package and name: %q", origStr)
 	}
 	if name == "" {
-		name = pkg
+		name = path.Base(pkg)
 	}
 
 	return Label{

--- a/internal/label/label_test.go
+++ b/internal/label/label_test.go
@@ -65,9 +65,11 @@ func TestParse(t *testing.T) {
 		{str: "a", want: Label{Name: "a", Relative: true}},
 		{str: "//:a", want: Label{Name: "a", Relative: false}},
 		{str: "//a", want: Label{Pkg: "a", Name: "a"}},
+		{str: "//a/b", want: Label{Pkg: "a/b", Name: "b"}},
 		{str: "//a:b", want: Label{Pkg: "a", Name: "b"}},
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
+		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
//a/b should have name "b", not "a/b". Also "_" is allowed in package names.