### PR TITLE
cmd/move_labels: add tool for updating labels after move

### DIFF
--- a/cmd/move_labels/BUILD.bazel
+++ b/cmd/move_labels/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["move_labels.go"],
+    importpath = "github.com/bazelbuild/bazel-gazelle/cmd/move_labels",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//internal/label:go_default_library",
+        "//internal/pathtools:go_default_library",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "move_labels",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["move_labels_test.go"],
+    embed = [":go_default_library"],
+)

--- a/cmd/move_labels/move_labels.go
+++ b/cmd/move_labels/move_labels.go
@@ -1,0 +1,234 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
+	"github.com/bazelbuild/buildtools/build"
+)
+
+const usageMessage = `usage: move_labels [-repo_root=root] [-from=dir] -to=dir
+
+move_labels updates Bazel labels in a tree containing build files after the
+tree has been moved to a new location. This is useful for vendoring
+repositories that already have Bazel build files.
+
+`
+
+func main() {
+	log.SetPrefix("move_labels: ")
+	log.SetFlags(0)
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(args []string) error {
+	c, err := newConfiguration(args)
+	if err != nil {
+		return err
+	}
+
+	files, err := moveLabelsInDir(c)
+	if err != nil {
+		return err
+	}
+
+	var errs errorList
+	for _, file := range files {
+		content := build.Format(file)
+		if err := ioutil.WriteFile(file.Path, content, 0666); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+func moveLabelsInDir(c *configuration) ([]*build.File, error) {
+	toRel, err := filepath.Rel(c.repoRoot, c.to)
+	if err != nil {
+		return nil, err
+	}
+	toRel = filepath.ToSlash(toRel)
+
+	var files []*build.File
+	var errors errorList
+	err = filepath.Walk(c.to, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if name := info.Name(); name != "BUILD" && name != "BUILD.bazel" {
+			return nil
+		}
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			errors = append(errors, err)
+			return nil
+		}
+		file, err := build.Parse(path, content)
+		if err != nil {
+			errors = append(errors, err)
+			return nil
+		}
+		moveLabelsInFile(file, c.from, toRel)
+		files = append(files, file)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(errors) > 0 {
+		return nil, errors
+	}
+	return files, nil
+}
+
+func moveLabelsInFile(file *build.File, from, to string) {
+	build.Edit(file, func(x build.Expr, _ []build.Expr) build.Expr {
+		str, ok := x.(*build.StringExpr)
+		if !ok {
+			return nil
+		}
+		label := str.Value
+		moved := moveLabel(from, to, label)
+		if moved == label {
+			return nil
+		}
+		return &build.StringExpr{Value: moved}
+	})
+}
+
+func moveLabel(from, to, str string) string {
+	l, err := label.Parse(str)
+	if err != nil {
+		return str
+	}
+	if l.Relative || l.Repo != "" ||
+		l.Pkg == "visibility" || l.Pkg == "conditions" ||
+		pathtools.HasPrefix(l.Pkg, to) || !pathtools.HasPrefix(l.Pkg, from) {
+		return str
+	}
+	l.Pkg = path.Join(to, pathtools.TrimPrefix(l.Pkg, from))
+	return l.String()
+}
+
+func isBuiltinLabel(label string) bool {
+	return strings.HasPrefix(label, "//visibility:") || strings.HasPrefix(label, "//conditions:")
+}
+
+type configuration struct {
+	// repoRoot is the repository root directory, formatted as an absolute
+	// file system path.
+	repoRoot string
+
+	// from is the original location of the build files within their repository,
+	// formatted as a slash-separated relative path from the original
+	// repository root.
+	from string
+
+	// to is the new location of the build files, formatted as an absolute
+	// file system path.
+	to string
+}
+
+func newConfiguration(args []string) (*configuration, error) {
+	var err error
+	c := &configuration{}
+	fs := flag.NewFlagSet("move_labels", flag.ContinueOnError)
+	fs.Usage = func() {}
+	fs.StringVar(&c.repoRoot, "repo_root", "", "repository root directory; inferred to be parent directory containing WORKSPACE file")
+	fs.StringVar(&c.from, "from", "", "original location of build files, formatted as a slash-separated relative path from the original repository root")
+	fs.StringVar(&c.to, "to", "", "new location of build files, formatted as a file system path")
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			fmt.Fprint(os.Stderr, usageMessage)
+			fs.PrintDefaults()
+			os.Exit(0)
+		}
+		// flag already prints an error; don't print again.
+		return nil, errors.New("Try -help for more information")
+	}
+
+	if c.repoRoot == "" {
+		c.repoRoot, err = findRepoRoot()
+		if err != nil {
+			return nil, err
+		}
+	}
+	c.repoRoot, err = filepath.Abs(c.repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.to == "" {
+		return nil, errors.New("-to must be specified. Try -help for more information.")
+	}
+	c.to, err = filepath.Abs(c.to)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(fs.Args()) != 0 {
+		return nil, errors.New("No positional arguments expected. Try -help for more information.")
+	}
+
+	return c, nil
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		workspacePath := filepath.Join(dir, "WORKSPACE")
+		_, err := os.Stat(workspacePath)
+		if err == nil {
+			return dir, nil
+		}
+		if strings.HasSuffix(dir, string(os.PathSeparator)) {
+			// root directory
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+	return "", fmt.Errorf("could not find WORKSPACE file. -repo_root must be set explicitly.")
+}
+
+type errorList []error
+
+func (e errorList) Error() string {
+	buf := new(bytes.Buffer)
+	for _, err := range e {
+		fmt.Fprintln(buf, err.Error())
+	}
+	return buf.String()
+}

--- a/cmd/move_labels/move_labels_test.go
+++ b/cmd/move_labels/move_labels_test.go
@@ -49,6 +49,9 @@ x_binary(
         "//old/b:b_lib",
         "@c//old:c_lib",
     ],
+    locs = [
+        "abc $(location  //old/b) $(locations //old/b:b_lib) xyz",
+    ],
 )
 `,
 			}},
@@ -64,6 +67,9 @@ x_binary(
         "//new/b",
         "//new/b:b_lib",
         "@c//old:c_lib",
+    ],
+    locs = [
+        "abc $(location  //new/b) $(locations //new/b:b_lib) xyz",
     ],
 )
 `,

--- a/cmd/move_labels/move_labels_test.go
+++ b/cmd/move_labels/move_labels_test.go
@@ -1,0 +1,275 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fileSpec struct {
+	path, content string
+}
+
+func TestMoveLabels(t *testing.T) {
+	for _, tc := range []struct {
+		desc, from, to string
+		files, want    []fileSpec
+	}{
+		{
+			desc: "move",
+			from: "old",
+			to:   "new",
+			files: []fileSpec{{
+				path: "new/a/BUILD",
+				content: `
+load("//old:def.bzl", "x_binary")
+
+x_binary(
+    name = "a",
+    deps = [
+        ":a_lib",
+        "//old/b",
+        "//old/b:b_lib",
+        "@c//old:c_lib",
+    ],
+)
+`,
+			}},
+			want: []fileSpec{{
+				path: "new/a/BUILD",
+				content: `
+load("//new:def.bzl", "x_binary")
+
+x_binary(
+    name = "a",
+    deps = [
+        ":a_lib",
+        "//new/b",
+        "//new/b:b_lib",
+        "@c//old:c_lib",
+    ],
+)
+`,
+			}},
+		}, {
+			desc: "vendor",
+			from: "",
+			to:   "vendor/github.com/bazelbuild/buildtools",
+			files: []fileSpec{
+				{
+					path: "vendor/github.com/bazelbuild/buildtools/BUILD.bazel",
+					content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+go_prefix("github.com/bazelbuild/buildtools")
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
+test_suite(
+    name = "tests",
+    tests = [
+        "//api_proto:api.gen.pb.go_checkshtest",
+        "//build:go_default_test",
+        "//build:parse.y.go_checkshtest",
+        "//build_proto:build.gen.pb.go_checkshtest",
+        "//deps_proto:deps.gen.pb.go_checkshtest",
+        "//edit:go_default_test",
+        "//extra_actions_base_proto:extra_actions_base.gen.pb.go_checkshtest",
+        "//lang:tables.gen.go_checkshtest",
+        "//tables:go_default_test",
+        "//wspace:go_default_test",
+    ],
+)
+`,
+				}, {
+					path: `vendor/github.com/bazelbuild/buildtools/edit/BUILD.bazel`,
+					content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "buildozer.go",
+        "edit.go",
+        "fix.go",
+        "types.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//api_proto:go_default_library",
+        "//build:go_default_library",
+        "//build_proto:go_default_library",
+        "//file:go_default_library",
+        "//lang:go_default_library",
+        "//tables:go_default_library",
+        "//wspace:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["edit_test.go"],
+    library = ":go_default_library",
+    deps = ["//build:go_default_library"],
+)
+`,
+				},
+			},
+			want: []fileSpec{
+				{
+					path: "vendor/github.com/bazelbuild/buildtools/BUILD.bazel",
+					content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+go_prefix("github.com/bazelbuild/buildtools")
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
+test_suite(
+    name = "tests",
+    tests = [
+        "//vendor/github.com/bazelbuild/buildtools/api_proto:api.gen.pb.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_test",
+        "//vendor/github.com/bazelbuild/buildtools/build:parse.y.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/build_proto:build.gen.pb.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/deps_proto:deps.gen.pb.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/edit:go_default_test",
+        "//vendor/github.com/bazelbuild/buildtools/extra_actions_base_proto:extra_actions_base.gen.pb.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/lang:tables.gen.go_checkshtest",
+        "//vendor/github.com/bazelbuild/buildtools/tables:go_default_test",
+        "//vendor/github.com/bazelbuild/buildtools/wspace:go_default_test",
+    ],
+)
+`,
+				}, {
+					path: `vendor/github.com/bazelbuild/buildtools/edit/BUILD.bazel`,
+					content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "buildozer.go",
+        "edit.go",
+        "fix.go",
+        "types.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/bazelbuild/buildtools/api_proto:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build_proto:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/file:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/lang:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/tables:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/wspace:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["edit_test.go"],
+    library = ":go_default_library",
+    deps = ["//vendor/github.com/bazelbuild/buildtools/build:go_default_library"],
+)
+`,
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir, err := createFiles(tc.files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			args := []string{"-repo_root", dir, "-from", tc.from, "-to", filepath.Join(dir, filepath.FromSlash(tc.to))}
+			if err := run(args); err != nil {
+				t.Fatal(err)
+			}
+
+			checkFiles(t, dir, tc.want)
+		})
+	}
+}
+
+func createFiles(files []fileSpec) (string, error) {
+	dir, err := ioutil.TempDir(os.Getenv("TEST_TEMPDIR"), "integration_test")
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range files {
+		path := filepath.Join(dir, filepath.FromSlash(f.path))
+		if strings.HasSuffix(f.path, "/") {
+			if err := os.MkdirAll(path, 0700); err != nil {
+				os.RemoveAll(dir)
+				return "", err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			os.RemoveAll(dir)
+			return "", err
+		}
+		if err := ioutil.WriteFile(path, []byte(f.content), 0600); err != nil {
+			os.RemoveAll(dir)
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func checkFiles(t *testing.T, dir string, files []fileSpec) {
+	for _, f := range files {
+		path := filepath.Join(dir, f.path)
+		if strings.HasSuffix(f.path, "/") {
+			if st, err := os.Stat(path); err != nil {
+				t.Errorf("could not stat %s: %v", f.path, err)
+			} else if !st.IsDir() {
+				t.Errorf("not a directory: %s", f.path)
+			}
+		} else {
+			want := f.content
+			if len(want) > 0 && want[0] == '\n' {
+				// Strip leading newline, added for readability.
+				want = want[1:]
+			}
+			gotBytes, err := ioutil.ReadFile(filepath.Join(dir, f.path))
+			if err != nil {
+				t.Errorf("could not read %s: %v", f.path, err)
+				continue
+			}
+			got := string(gotBytes)
+			if got != want {
+				t.Errorf("%s: got %s ; want %s", f.path, got, f.content)
+			}
+		}
+	}
+}

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -41,7 +41,7 @@ var NoLabel = Label{}
 
 var (
 	labelRepoRegexp = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
-	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/.-]*$`)
+	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
 	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
 )
 
@@ -93,7 +93,7 @@ func Parse(s string) (Label, error) {
 		return NoLabel, fmt.Errorf("label parse error: empty package and name: %q", origStr)
 	}
 	if name == "" {
-		name = pkg
+		name = path.Base(pkg)
 	}
 
 	return Label{

--- a/internal/label/label_test.go
+++ b/internal/label/label_test.go
@@ -65,9 +65,11 @@ func TestParse(t *testing.T) {
 		{str: "a", want: Label{Name: "a", Relative: true}},
 		{str: "//:a", want: Label{Name: "a", Relative: false}},
 		{str: "//a", want: Label{Pkg: "a", Name: "a"}},
+		{str: "//a/b", want: Label{Pkg: "a/b", Name: "b"}},
 		{str: "//a:b", want: Label{Pkg: "a", Name: "b"}},
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
+		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
This is a tool to update labels in a tree of build files after it's
been moved from another place. This is especially useful for vendoring
repositories that already have build files.

Fixes #63
