### PR TITLE
cmd/gazelle: delete rules in directories which have no source files

### DIFF
--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 )
 
 // Package contains metadata about a Go package extracted from a directory.
@@ -96,6 +97,20 @@ type PlatformStrings struct {
 // IsCommand returns true if the package name is "main".
 func (p *Package) IsCommand() bool {
 	return p.Name == "main"
+}
+
+// EmptyPackage returns an empty package. The package name and import path
+// are inferred from the directory name and configuration. This is useful
+// for deleting rules in directories which no longer have source files.
+func EmptyPackage(c *config.Config, dir, rel string) *Package {
+	packageName := pathtools.RelBaseName(rel, c.GoPrefix, c.RepoRoot)
+	pb := packageBuilder{
+		name: packageName,
+		dir:  dir,
+		rel:  rel,
+	}
+	pb.inferImportPath(c)
+	return pb.build()
 }
 
 func (t *GoTarget) HasGo() bool {

--- a/internal/packages/walk.go
+++ b/internal/packages/walk.go
@@ -31,6 +31,8 @@ import (
 
 // A WalkFunc is a callback called by Walk in each visited directory.
 //
+// dir is the absolute file system path to the directory being visited.
+//
 // rel is the relative slash-separated path to the directory from the
 // repository root. Will be "" for the repository root directory itself.
 //
@@ -46,7 +48,7 @@ import (
 // was no file.
 //
 // isUpdateDir is true for directories that Gazelle was asked to update.
-type WalkFunc func(rel string, c *config.Config, pkg *Package, oldFile *bf.File, isUpdateDir bool)
+type WalkFunc func(dir, rel string, c *config.Config, pkg *Package, oldFile *bf.File, isUpdateDir bool)
 
 // Walk traverses a directory tree. In each directory, Walk parses existing
 // build files. In directories that Gazelle was asked to update (c.Dirs), Walk
@@ -193,7 +195,7 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 
 		hasPackage := subdirHasPackage || oldFile != nil
 		if haveError || !isUpdateDir || ignore {
-			f(rel, c, nil, oldFile, false)
+			f(dir, rel, c, nil, oldFile, false)
 			return hasPackage
 		}
 
@@ -203,7 +205,7 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 			genFiles = findGenFiles(oldFile, excluded)
 		}
 		pkg := buildPackage(c, dir, rel, pkgFiles, otherFiles, genFiles, hasTestdata)
-		f(rel, c, pkg, oldFile, true)
+		f(dir, rel, c, pkg, oldFile, true)
 		return hasPackage || pkg != nil
 	}
 

--- a/internal/packages/walk_test.go
+++ b/internal/packages/walk_test.go
@@ -83,7 +83,7 @@ func createFiles(files []fileSpec) (string, error) {
 
 func walkPackages(c *config.Config) []*packages.Package {
 	var pkgs []*packages.Package
-	packages.Walk(c, c.RepoRoot, func(_ string, _ *config.Config, pkg *packages.Package, _ *bf.File, _ bool) {
+	packages.Walk(c, c.RepoRoot, func(_, _ string, _ *config.Config, pkg *packages.Package, _ *bf.File, _ bool) {
 		if pkg != nil {
 			pkgs = append(pkgs, pkg)
 		}
@@ -316,7 +316,7 @@ func TestVendorResetsPrefix(t *testing.T) {
 		ValidBuildFileNames: config.DefaultValidBuildFileNames,
 		GoPrefix:            basePrefix,
 	}
-	packages.Walk(c, c.RepoRoot, func(rel string, c *config.Config, _ *packages.Package, _ *bf.File, _ bool) {
+	packages.Walk(c, c.RepoRoot, func(_, rel string, c *config.Config, _ *packages.Package, _ *bf.File, _ bool) {
 		if path.Base(rel) != "vendor" {
 			return
 		}
@@ -532,25 +532,25 @@ import "github.com/jr_hacker/stuff"
 func TestIgnore(t *testing.T) {
 	files := []fileSpec{
 		{
-			path: "BUILD",
+			path:    "BUILD",
 			content: "# gazelle:ignore",
 		}, {
-			path: "foo.go",
+			path:    "foo.go",
 			content: "package foo",
 		}, {
-			path: "bar/bar.go",
+			path:    "bar/bar.go",
 			content: "package bar",
 		},
 	}
 	want := []*packages.Package{
 		{
-			Name: "bar",
-			Rel: "bar",
+			Name:       "bar",
+			Rel:        "bar",
 			ImportPath: "example.com/repo/bar",
 			Library: packages.GoTarget{
-			Sources: packages.PlatformStrings{
-				Generic: []string{"bar.go"},
-			},
+				Sources: packages.PlatformStrings{
+					Generic: []string{"bar.go"},
+				},
 			},
 		},
 	}

--- a/internal/rules/generator_test.go
+++ b/internal/rules/generator_test.go
@@ -44,7 +44,7 @@ func testConfig(repoRoot, goPrefix string) *config.Config {
 func packageFromDir(c *config.Config, dir string) (*packages.Package, *bf.File) {
 	var pkg *packages.Package
 	var oldFile *bf.File
-	packages.Walk(c, dir, func(rel string, _ *config.Config, p *packages.Package, f *bf.File, _ bool) {
+	packages.Walk(c, dir, func(_, rel string, _ *config.Config, p *packages.Package, f *bf.File, _ bool) {
 		if p != nil && p.Dir == dir {
 			pkg = p
 			oldFile = f


### PR DESCRIPTION
This is a tool to update labels in a tree of build files after it's
been moved from another place. This is especially useful for vendoring
repositories that already have build files.

Fixes #63
