### PR TITLE
internal/wspace: accept relative paths

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -229,11 +229,7 @@ func newFixUpdateConfiguration(cmd command, args []string) (*updateConfig, error
 			return nil, fmt.Errorf("-repo_root not specified, and WORKSPACE cannot be found: %v", err)
 		}
 	} else {
-		cwd, err := filepath.Abs(".")
-		if err != nil {
-			return nil, err
-		}
-		uc.c.RepoRoot, err = wspace.Find(cwd)
+		uc.c.RepoRoot, err = wspace.Find(".")
 		if err != nil {
 			return nil, fmt.Errorf("-repo_root not specified, and WORKSPACE cannot be found: %v", err)
 		}


### PR DESCRIPTION
Find now accepts relative paths (it calls filepath.Abs first). It was
previously misused in update-repos.go.

Fixes #118