### PR TITLE
Don't infer an import path from a simple package name in a proto file

### DIFF
--- a/internal/packages/fileinfo_proto.go
+++ b/internal/packages/fileinfo_proto.go
@@ -60,12 +60,18 @@ func protoFileInfo(c *config.Config, dir, rel, name string) fileInfo {
 
 		case match[goPackageSubexpIndex] != nil:
 			gopkg := unquoteProtoString(match[goPackageSubexpIndex])
-			if i := strings.LastIndexByte(gopkg, ';'); i != -1 {
-				info.importPath = gopkg[:i]
-				info.packageName = gopkg[i+1:]
+			// If there's no / in the package option, then it's just a
+			// simple package name, not a full import path.
+			if strings.LastIndexByte(gopkg, '/') == -1 {
+				info.packageName = gopkg
 			} else {
-				info.importPath = gopkg
-				info.packageName = path.Base(gopkg)
+				if i := strings.LastIndexByte(gopkg, ';'); i != -1 {
+					info.importPath = gopkg[:i]
+					info.packageName = gopkg[i+1:]
+				} else {
+					info.importPath = gopkg
+					info.packageName = path.Base(gopkg)
+				}
 			}
 
 		case match[serviceSubexpIndex] != nil:

--- a/internal/packages/fileinfo_proto_test.go
+++ b/internal/packages/fileinfo_proto_test.go
@@ -115,6 +115,14 @@ import "second.proto";`,
 				importPath:  "github.com/example/project",
 			},
 		}, {
+			desc:  "go_package_simple",
+			name:  "gopkg_simple.proto",
+			proto: `option go_package = "bar";`,
+			want: fileInfo{
+				packageName: "bar",
+				importPath:  "",
+			},
+		}, {
 			desc:  "service",
 			name:  "service.proto",
 			proto: `service ChatService {}`,


### PR DESCRIPTION
Proto files can fill in the `go_package` option in at least three different ways (per https://github.com/golang/protobuf/issues/139):
```proto
option go_package = "foo";
option go_package = "github.com/example/foo";
option go_package = "github.com/example/foo;bar";
```

Gazelle was only handling the latter two cases, where the option referred to a full import path. With this change, it only treats the option as an import path when it really looks like one. ([This is similar to what `protoc-gen-go` does](https://github.com/golang/protobuf/blob/bbd03ef6da3a115852eaf24c8a1c46aeb39aa175/protoc-gen-go/generator/generator.go#L272-L295).)

Fixes #124.