### PR TITLE
Update overlay repository and rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "bazel_gazelle")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go",
-    commit = "d36234e86678457e769ab62e597f90eef025bf8d",
+    commit = "3e6e9bbf8f9ed35f5956fba80dde9283e121a66c",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/internal/wspace/finder_test.go
+++ b/internal/wspace/finder_test.go
@@ -29,6 +29,10 @@ func TestFind(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
+	tmp, err = filepath.EvalSymlinks(tmp) // on macOS, TEST_TEMPDIR is a symlink
+	if err != nil {
+		t.Fatal(err)
+	}
 	if parent, err := Find(tmp); err == nil {
 		t.Skipf("WORKSPACE visible in parent %q of tmp %q", parent, tmp)
 	}


### PR DESCRIPTION
* In overlay repository rules, resolve labels before downloading the
  repo. This is a backport of bazelbuild/rules_go#1349.
* Update io_bazel_rules_go to tip of master.
* Fix //internal/wspace:go_default_test, which was broken on macOS.