### PR TITLE
Update com_github_bazelbuild_buildtools

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -34,7 +34,7 @@ def gazelle_dependencies():
   _maybe(_git_repository,
       name = "com_github_bazelbuild_buildtools",
       remote = "https://github.com/bazelbuild/buildtools",
-      commit = "a05406a1a855c6d8ebfc368555ace7638d83c0d9", # 0.6.0 as of 2018-02-09
+      commit = "80c7f0d45d7e40fa1f7362852697d4a03df557b3", # master as of 2018-02-26
   )
 
   # io_bazel_rules_go also declares this (for now). Keep in sync.

--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -90,7 +90,7 @@ func squashCgoLibrary(oldFile *bf.File) *bf.File {
 	// Copy the comments and attributes from cgo_library into go_library. If no
 	// go_library exists, create an empty one.
 	var fixedGoLibraryExpr bf.CallExpr
-	fixedGoLibrary := bf.Rule{&fixedGoLibraryExpr}
+	fixedGoLibrary := bf.Rule{Call: &fixedGoLibraryExpr}
 	if goLibrary.Call == nil {
 		fixedGoLibrary.SetKind("go_library")
 		fixedGoLibrary.SetAttr("name", &bf.StringExpr{Value: config.DefaultLibName})

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -803,7 +803,7 @@ func match(stmts []bf.Expr, x *bf.CallExpr) (*bf.CallExpr, int, error) {
 		index int
 	}
 
-	xr := bf.Rule{x}
+	xr := bf.Rule{Call: x}
 	xname := xr.Name()
 	xkind := xr.Kind()
 	var nameMatches []matchInfo
@@ -863,11 +863,11 @@ func match(stmts []bf.Expr, x *bf.CallExpr) (*bf.CallExpr, int, error) {
 }
 
 func kind(c *bf.CallExpr) string {
-	return (&bf.Rule{c}).Kind()
+	return (&bf.Rule{Call: c}).Kind()
 }
 
 func name(c *bf.CallExpr) string {
-	return (&bf.Rule{c}).Name()
+	return (&bf.Rule{Call: c}).Name()
 }
 
 // isRuleEmpty returns true if a rule cannot be built because it has no sources,

--- a/internal/rules/generator.go
+++ b/internal/rules/generator.go
@@ -180,7 +180,7 @@ func hasDefaultVisibility(oldFile *bf.File) bool {
 		if !ok {
 			continue
 		}
-		r := bf.Rule{c}
+		r := bf.Rule{Call: c}
 		if r.Kind() == "package" && r.Attr("default_visibility") != nil {
 			return true
 		}

--- a/internal/rules/sort_labels.go
+++ b/internal/rules/sort_labels.go
@@ -42,7 +42,7 @@ func SortLabels(f *bf.File) {
 		if !ok {
 			continue
 		}
-		r := bf.Rule{c}
+		r := bf.Rule{Call: c}
 		if !goRuleKinds[r.Kind()] {
 			continue
 		}


### PR DESCRIPTION
github.com/bazelbuild/buildtools/build has made some API changes that
affect Gazelle. This change updates buildtools and ensures Gazelle
remains compatible.

Note that com_github_bazelbuild_buildtools is shadowed by the one
declared in io_bazel_rules_go. The corresponding dependency, along
with the bazel_gazelle dependency in rules_go will be updated after
this change is submitted.