### PR TITLE
Don't resolve go_proto_library dependencies on well known types

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -283,39 +283,7 @@ func (r *Resolver) resolveGoProto(imp string, from label.Label) (label.Label, er
 	stem := imp[:len(imp)-len(".proto")]
 
 	if isWellKnown(stem) {
-		// Well Known Type
-		base := path.Base(stem)
-		if base == "descriptor" {
-			switch r.c.DepMode {
-			case config.ExternalMode:
-				label := r.l.LibraryLabel(descriptorPkg)
-				if r.c.GoPrefix != config.WellKnownTypesGoPrefix {
-					label.Repo = config.WellKnownTypesGoProtoRepo
-				}
-				return label, nil
-			case config.VendorMode:
-				pkg := path.Join("vendor", config.WellKnownTypesGoPrefix, descriptorPkg)
-				label := r.l.LibraryLabel(pkg)
-				return label, nil
-			default:
-				log.Panicf("unknown external mode: %v", r.c.DepMode)
-			}
-		}
-
-		switch r.c.DepMode {
-		case config.ExternalMode:
-			pkg := path.Join(wellKnownGoProtoPkg, base)
-			label := r.l.LibraryLabel(pkg)
-			if r.c.GoPrefix != config.WellKnownTypesGoPrefix {
-				label.Repo = config.WellKnownTypesGoProtoRepo
-			}
-			return label, nil
-		case config.VendorMode:
-			pkg := path.Join("vendor", config.WellKnownTypesGoPrefix, wellKnownGoProtoPkg, base)
-			return r.l.LibraryLabel(pkg), nil
-		default:
-			log.Panicf("unknown external mode: %v", r.c.DepMode)
-		}
+		return label.NoLabel, standardImportError{imp}
 	}
 
 	if l, err := r.ix.findLabelByImport(importSpec{config.ProtoLang, imp}, config.GoLang, from); err != nil {

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -405,24 +405,24 @@ func TestResolveProto(t *testing.T) {
 			desc:        "well known",
 			imp:         "google/protobuf/any.proto",
 			wantProto:   label.New("com_google_protobuf", "", "any_proto"),
-			wantGoProto: label.New("com_github_golang_protobuf", "ptypes/any", config.DefaultLibName),
+			wantGoProto: label.NoLabel,
 		}, {
 			desc:        "well known vendor",
 			depMode:     config.VendorMode,
 			imp:         "google/protobuf/any.proto",
 			wantProto:   label.New("com_google_protobuf", "", "any_proto"),
-			wantGoProto: label.New("", "vendor/github.com/golang/protobuf/ptypes/any", config.DefaultLibName),
+			wantGoProto: label.NoLabel,
 		}, {
 			desc:        "descriptor",
 			imp:         "google/protobuf/descriptor.proto",
 			wantProto:   label.New("com_google_protobuf", "", "descriptor_proto"),
-			wantGoProto: label.New("com_github_golang_protobuf", "protoc-gen-go/descriptor", config.DefaultLibName),
+			wantGoProto: label.NoLabel,
 		}, {
 			desc:        "descriptor vendor",
 			depMode:     config.VendorMode,
 			imp:         "google/protobuf/descriptor.proto",
 			wantProto:   label.New("com_google_protobuf", "", "descriptor_proto"),
-			wantGoProto: label.New("", "vendor/github.com/golang/protobuf/protoc-gen-go/descriptor", config.DefaultLibName),
+			wantGoProto: label.NoLabel,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -436,18 +436,22 @@ func TestResolveProto(t *testing.T) {
 
 			got, err := r.resolveProto(tc.imp, tc.from)
 			if err != nil {
-				t.Errorf("resolveProto: got error %v ; want success", err)
+				t.Errorf("resolveProto: got error %v; want success", err)
 			}
 			if !reflect.DeepEqual(got, tc.wantProto) {
-				t.Errorf("resolveProto: got %s ; want %s", got, tc.wantProto)
+				t.Errorf("resolveProto: got %s; want %s", got, tc.wantProto)
 			}
 
 			got, err = r.resolveGoProto(tc.imp, tc.from)
 			if err != nil {
-				t.Errorf("resolveGoProto: go error %v ; want success", err)
+				if tc.wantGoProto != label.NoLabel {
+					t.Errorf("resolveGoProto: got error %v; want %s", got, tc.wantGoProto)
+				} else if _, ok := err.(standardImportError); !ok {
+					t.Errorf("resolveGoProto: got error %v; want standardImportError", err)
+				}
 			}
-			if !reflect.DeepEqual(got, tc.wantGoProto) {
-				t.Errorf("resolveGoProto: got %s ; want %s", got, tc.wantGoProto)
+			if !got.Equal(tc.wantGoProto) {
+				t.Errorf("resolveGoProto: got %s; want %s", got, tc.wantGoProto)
 			}
 		})
 	}


### PR DESCRIPTION
go_proto_compiler is responsible for adding these automatically. They
no longer need to be specified explicitly.

Fixes #46
Related #141