### PR TITLE
Stop using select in srcs

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -159,10 +159,10 @@ go_library(
     name = "go_default_library",
     srcs = select({
         "@io_bazel_rules_go//go/platform:linux": [
-						# top comment
-						"foo.go",  # side comment
-						# bar comment
-						"bar.go",
+            # foo comment
+            "foo.go",  # side comment
+            # bar comment
+            "bar.go",
         ],
         "//conditions:default": [],
     }),
@@ -198,15 +198,12 @@ package foo
 
 go_library(
     name = "go_default_library",
-    srcs = select({
-        "@io_bazel_rules_go//go/platform:linux": [
-            # top comment
-            # bar comment
-            "bar.go",
-            "foo.go",  # side comment
-        ],
-        "//conditions:default": [],
-    }),
+    srcs = [
+        # bar comment
+        "bar.go",
+        # foo comment
+        "foo.go",  # side comment
+    ],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
     deps = select({

--- a/internal/merger/fix_test.go
+++ b/internal/merger/fix_test.go
@@ -123,6 +123,40 @@ go_test(
 )
 `,
 		},
+		// flattenSrcs tests
+		{
+			desc: "flatten srcs",
+			old: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gen.go",
+    ] + select({
+        "@io_bazel_rules_go//platform:darwin_amd64": [
+            # darwin
+            "foo.go", # keep
+        ],
+        "@io_bazel_rules_go//platform:linux_amd64": [
+            # linux
+            "foo.go", # keep
+        ],
+    }),
+)
+`,
+			want: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        # darwin
+        # linux
+        "foo.go",  # keep
+        "gen.go",
+    ],
+)
+`,
+		},
 		// squashCgoLibrary tests
 		{
 			desc: "no cgo_library",

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -129,6 +129,34 @@ func (ps *PlatformStrings) IsEmpty() bool {
 	return len(ps.Generic) == 0 && len(ps.OS) == 0 && len(ps.Arch) == 0 && len(ps.Platform) == 0
 }
 
+func (ps *PlatformStrings) Flat() []string {
+	unique := make(map[string]struct{})
+	for _, s := range ps.Generic {
+		unique[s] = struct{}{}
+	}
+	for _, ss := range ps.OS {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	for _, ss := range ps.Arch {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	for _, ss := range ps.Platform {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	flat := make([]string, 0, len(unique))
+	for s := range unique {
+		flat = append(flat, s)
+	}
+	sort.Strings(flat)
+	return flat
+}
+
 func (ps *PlatformStrings) firstGoFile() string {
 	for _, f := range ps.Generic {
 		if strings.HasSuffix(f, ".go") {

--- a/internal/rules/generator.go
+++ b/internal/rules/generator.go
@@ -223,7 +223,7 @@ func (g *Generator) generateTest(pkg *packages.Package, library string, isXTest 
 func (g *Generator) commonAttrs(pkgRel, name, visibility string, target packages.GoTarget) []KeyValue {
 	attrs := []KeyValue{{"name", name}}
 	if !target.Sources.IsEmpty() {
-		attrs = append(attrs, KeyValue{"srcs", target.Sources})
+		attrs = append(attrs, KeyValue{"srcs", target.Sources.Flat()})
 	}
 	if target.Cgo {
 		attrs = append(attrs, KeyValue{"cgo", true})

--- a/internal/rules/testdata/repo/cgolib_with_build_tags/BUILD.want
+++ b/internal/rules/testdata/repo/cgolib_with_build_tags/BUILD.want
@@ -3,66 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "asm_linux.S",
+        "asm_other.S",
         "foo.go",
         "foo.h",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:android": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:dragonfly": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:freebsd": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "asm_linux.S",
-            "foo_linux.c",
-            "pure_linux.go",
-        ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:netbsd": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:openbsd": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:plan9": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:solaris": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "@io_bazel_rules_go//go/platform:windows": [
-            "asm_other.S",
-            "foo_other.c",
-            "pure_other.go",
-        ],
-        "//conditions:default": [],
-    }),
+        "foo_linux.c",
+        "foo_other.c",
+        "pure_linux.go",
+        "pure_other.go",
+    ],
     _gazelle_imports = [
         "example.com/repo/lib",
         "fmt",

--- a/internal/rules/testdata/repo/gen_and_exclude/BUILD.want
+++ b/internal/rules/testdata/repo/gen_and_exclude/BUILD.want
@@ -4,16 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = [
         "gen.go",
+        "gen_linux.go",
+        "gen_static_darwin.go",
         "static.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "gen_static_darwin.go",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "gen_linux.go",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     _gazelle_imports = select({
         "@io_bazel_rules_go//go/platform:darwin": [
             "github.com/jr_hacker/darwin",

--- a/internal/rules/testdata/repo/platforms/BUILD.want
+++ b/internal/rules/testdata/repo/platforms/BUILD.want
@@ -5,31 +5,19 @@ go_library(
     srcs = [
         "cgo_generic.c",
         "cgo_generic.go",
+        "cgo_linux.c",
+        "cgo_linux.go",
         "generic.go",
         "no_cgo.go",
         "release.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "suffix_darwin.go",
-            "tag_d.go",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "cgo_linux.c",
-            "cgo_linux.go",
-            "suffix_linux.go",
-            "tag_l.go",
-        ],
-        "//conditions:default": [],
-    }) + select({
-        "@io_bazel_rules_go//go/platform:amd64": [
-            "suffix_amd64.go",
-            "tag_a.go",
-        ],
-        "@io_bazel_rules_go//go/platform:arm": [
-            "suffix_arm.go",
-        ],
-        "//conditions:default": [],
-    }),
+        "suffix_amd64.go",
+        "suffix_arm.go",
+        "suffix_darwin.go",
+        "suffix_linux.go",
+        "tag_a.go",
+        "tag_d.go",
+        "tag_l.go",
+    ],
     _gazelle_imports = [
         "example.com/repo/platforms/generic",
     ] + select({
@@ -58,10 +46,6 @@ go_test(
     name = "go_default_xtest",
     srcs = [
         "generic_test.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:linux": [
-            "suffix_linux_test.go",
-        ],
-        "//conditions:default": [],
-    }),
+        "suffix_linux_test.go",
+    ],
 )


### PR DESCRIPTION
Platform-specfic srcs, separated with select expressions, have caused
a few problems. If the goos and goarch attributes of go_binary are
used, the wrong set of sources may be compiled. rules like go_path
will get filtered lists of sources without any way to get the
unfiltered list.

Separating sources is largely unnecessary, since rules_go also filters
sources at execution time. Therefore, this separation is being removed
by Gazelle.

* Rules generated by gazelle will now have flat srcs lists.
* Existing srcs lists will be flattened by "gazelle update" before
  merging. Sources that appear multiple times will be de-duplicated,
  and comments will be consolidated.

Note that Gazelle still filters sources, it just doesn't generate select
expresions for them anymore. Unbuildable sources (e.g., with
+build ignore) will not appear in any list. Dependencies and flags
will still be platform-specific.

Fixes #134