### PR TITLE
Replace loads of go_repository from rules_go

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1121,18 +1121,22 @@ func TestImportReposFromDep(t *testing.T) {
 	files := []fileSpec{
 		{
 			path: "WORKSPACE",
-			content: `workspace(name = "bazel_gazelle")
-
+			content: `
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.1/rules_go-0.7.1.tar.gz",
-    sha256 = "341d5eacef704415386974bc82a1783a8b7ffbff2ab6ba02375e1ca20d9b031c",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
+    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.0/bazel-gazelle-0.10.0.tar.gz",
+    sha256 = "6228d9618ab9536892aa69082c063207c91e777e51bd3c5544c9c060cafe1bd8",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repository")
 go_rules_dependencies()
 go_register_toolchains()
 
-load("//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
 
 go_repository(
@@ -1206,21 +1210,26 @@ http_archive(
 	checkFiles(t, dir, []fileSpec{
 		{
 			path: "WORKSPACE",
-			content: `workspace(name = "bazel_gazelle")
-
+			content: `
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.1/rules_go-0.7.1.tar.gz",
-    sha256 = "341d5eacef704415386974bc82a1783a8b7ffbff2ab6ba02375e1ca20d9b031c",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
+    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_repository", "go_rules_dependencies")
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.0/bazel-gazelle-0.10.0.tar.gz",
+    sha256 = "6228d9618ab9536892aa69082c063207c91e777e51bd3c5544c9c060cafe1bd8",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 
 go_register_toolchains()
 
-load("//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -54,6 +54,7 @@ func updateRepos(args []string) error {
 	if err != nil {
 		return fmt.Errorf("error parsing %q: %v", workspacePath, err)
 	}
+	merger.FixWorkspace(f)
 
 	if err := c.fn(c, f); err != nil {
 		return err

--- a/deps.bzl
+++ b/deps.bzl
@@ -12,26 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_gazelle//internal:go_repository.bzl", "go_repository_tools")
-load("@bazel_gazelle//internal:overlay_repository.bzl",
-    _git_repository = "git_repository",
-    _http_archive = "http_archive",
+load(
+    "@bazel_gazelle//internal:go_repository.bzl",
+    "go_repository",
+    _go_repository_tools = "go_repository_tools",
+)
+load(
+    "@bazel_gazelle//internal:overlay_repository.bzl",
+    "git_repository",
+    "http_archive",
 )
 load("@bazel_gazelle//third_party:manifest.bzl",
     _manifest = "manifest",
 )
 
 def gazelle_dependencies():
-  go_repository_tools(name = "bazel_gazelle_go_repository_tools")
+  _go_repository_tools(name = "bazel_gazelle_go_repository_tools")
 
-  _maybe(_git_repository,
+  _maybe(git_repository,
       name = "bazel_skylib",
       remote = "https://github.com/bazelbuild/bazel-skylib",
       commit = "f3dd8fd95a7d078cb10fd7fb475b22c3cdbcb307", # 0.2.0 as of 2017-12-04
   )
 
   # io_bazel_rules_go also declares this (for now). Keep in sync.
-  _maybe(_http_archive,
+  _maybe(http_archive,
       name = "org_golang_x_tools",
       # release-branch.go1.9, as of 2017-08-25
       urls = ["https://codeload.github.com/golang/tools/zip/5d2fd3ccab986d52112bf301d47a819783339d0e"],
@@ -42,7 +47,7 @@ def gazelle_dependencies():
 
   # TODO(jayconrod): restore when rules_go go_repository_tools no longer
   # requires this to be vendored.
-  # _maybe(_git_repository,
+  # _maybe(git_repository,
   #     name = "com_github_pelletier_go_toml",
   #     remote = "https://github.com/pelletier/go-toml",
   #     commit = "16398bac157da96aa88f98a2df640c7f32af1da2", # v1.0.1 as of 2017-12-19

--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -421,7 +421,11 @@ func FixLoads(f *bf.File) {
 	// Fix the load statements. The order is important, so we iterate over
 	// knownLoads instead of knownFiles.
 	changed := false
-	var newFirstLoads []*bf.CallExpr
+	type newLoad struct {
+		index int
+		load  *bf.CallExpr
+	}
+	var newLoads []newLoad
 	for _, l := range knownLoads {
 		file := l.file
 		first := true
@@ -441,7 +445,8 @@ func FixLoads(f *bf.File) {
 		if first {
 			load := fixLoad(nil, file, usedKinds[file])
 			if load != nil {
-				newFirstLoads = append(newFirstLoads, load)
+				index := newLoadIndex(f.Stmt, l.after)
+				newLoads = append(newLoads, newLoad{index, load})
 				changed = true
 			}
 		}
@@ -449,15 +454,21 @@ func FixLoads(f *bf.File) {
 	if !changed {
 		return
 	}
+	sort.Slice(newLoads, func(i, j int) bool {
+		return newLoads[i].index < newLoads[j].index
+	})
 
-	// Rebuild the file.
+	// Rebuild the file. Insert new loads at appropriate indices, replace fixed
+	// loads, and drop deleted loads.
 	oldStmt := f.Stmt
-	f.Stmt = make([]bf.Expr, 0, len(oldStmt)+len(newFirstLoads))
-	for _, l := range newFirstLoads {
-		f.Stmt = append(f.Stmt, l)
-	}
+	f.Stmt = make([]bf.Expr, 0, len(oldStmt)+len(newLoads))
+	newLoadIndex := 0
 	loadIndex := 0
 	for i, stmt := range oldStmt {
+		for newLoadIndex < len(newLoads) && i == newLoads[newLoadIndex].index {
+			f.Stmt = append(f.Stmt, newLoads[newLoadIndex].load)
+			newLoadIndex++
+		}
 		if loadIndex < len(loads) && i == loads[loadIndex].index {
 			if loads[loadIndex].fixed != nil {
 				f.Stmt = append(f.Stmt, loads[loadIndex].fixed)
@@ -470,19 +481,27 @@ func FixLoads(f *bf.File) {
 }
 
 // knownLoads is a list of files Gazelle will generate loads from and
-// the symbols it knows about.  All symbols Gazelle ever generated
+// the symbols it knows about. All symbols Gazelle ever generated
 // loads for are present, including symbols it no longer uses (e.g.,
 // cgo_library). Manually loaded symbols (e.g., go_embed_data) are not
-// included. The order of the files here will match the order of
-// generated load statements. The symbols should be sorted
-// lexicographically.
+// included.
+//
+// Some symbols have a list of function calls that they should be loaded
+// after. This is important for WORKSPACE, where function calls may
+// introduce new repository names.
+//
+// The order of the files here will match the order of generated load
+// statements. The symbols should be sorted lexicographically. If a
+// symbol appears in more than one file (e.g., because it was moved),
+// it will be loaded from the last file in this list.
 var knownLoads = []struct {
 	file  string
 	kinds []string
+	after []string
 }{
 	{
-		"@io_bazel_rules_go//go:def.bzl",
-		[]string{
+		file: "@io_bazel_rules_go//go:def.bzl",
+		kinds: []string{
 			"cgo_library",
 			"go_binary",
 			"go_library",
@@ -491,10 +510,20 @@ var knownLoads = []struct {
 			"go_test",
 		},
 	}, {
-		"@io_bazel_rules_go//proto:def.bzl",
-		[]string{
+		file: "@io_bazel_rules_go//proto:def.bzl",
+		kinds: []string{
 			"go_grpc_library",
 			"go_proto_library",
+		},
+	}, {
+		file: "@bazel_gazelle//:deps.bzl",
+		kinds: []string{
+			"go_repository",
+		},
+		after: []string{
+			"go_rules_dependencies",
+			"go_register_toolchains",
+			"gazelle_dependencies",
 		},
 	},
 }
@@ -579,6 +608,73 @@ func fixLoad(load *bf.CallExpr, file string, kinds map[string]bool) *bf.CallExpr
 		return nil
 	}
 	return &fixed
+}
+
+// newLoadIndex returns the index in stmts where a new load statement should
+// be inserted. after is a list of function names that the load should not
+// be inserted before.
+func newLoadIndex(stmts []bf.Expr, after []string) int {
+	if len(after) == 0 {
+		return 0
+	}
+	index := 0
+	for i, stmt := range stmts {
+		call, ok := stmt.(*bf.CallExpr)
+		if !ok {
+			continue
+		}
+		x, ok := call.X.(*bf.LiteralExpr)
+		if !ok {
+			continue
+		}
+		for _, a := range after {
+			if x.Token == a {
+				index = i + 1
+			}
+		}
+	}
+	return index
+}
+
+// FixWorkspace updates rules in the WORKSPACE file f that were used with an
+// older version of rules_go or gazelle.
+func FixWorkspace(f *bf.File) {
+	removeLegacyGoRepository(f)
+}
+
+// removeLegacyGoRepository removes loads of go_repository from
+// @io_bazel_rules_go. FixLoads should be called after this; it will load from
+// @bazel_gazelle.
+func removeLegacyGoRepository(f *bf.File) {
+	var deletedStmtIndices []int
+	for stmtIndex, stmt := range f.Stmt {
+		call, ok := stmt.(*bf.CallExpr)
+		if !ok || len(call.List) < 1 {
+			continue
+		}
+		if x, ok := call.X.(*bf.LiteralExpr); !ok || x.Token != "load" {
+			continue
+		}
+		if path, ok := call.List[0].(*bf.StringExpr); !ok || path.Value != "@io_bazel_rules_go//go:def.bzl" {
+			continue
+		}
+		var deletedArgIndices []int
+		for argIndex, arg := range call.List {
+			str, ok := arg.(*bf.StringExpr)
+			if !ok {
+				continue
+			}
+			if str.Value == "go_repository" {
+				deletedArgIndices = append(deletedArgIndices, argIndex)
+			}
+		}
+		if len(call.List)-len(deletedArgIndices) == 1 {
+			deletedStmtIndices = append(deletedStmtIndices, stmtIndex)
+		} else {
+			call.List = deleteIndices(call.List, deletedArgIndices)
+		}
+	}
+	f.Stmt = deleteIndices(f.Stmt, deletedStmtIndices)
 }
 
 type byString []*bf.StringExpr

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -910,6 +910,9 @@ func stringValue(e bf.Expr) string {
 // deleteIndices copies a list, dropping elements at deletedIndices.
 // deletedIndices must be sorted.
 func deleteIndices(stmt []bf.Expr, deletedIndices []int) []bf.Expr {
+	if len(deletedIndices) == 0 {
+		return stmt
+	}
 	kept := make([]bf.Expr, 0, len(stmt)-len(deletedIndices))
 	di := 0
 	for i, s := range stmt {


### PR DESCRIPTION
* gazelle update-repos and gazelle fix will now change a load of
  go_repository from @io_bazel_rules_go to @bazel_gazelle.
* If a new load needs to be inserted, it will be after any calls to
  go_rules_dependencies, go_register_toolchains, and
  gazelle_dependencies.