### PR TITLE
Resolve Go WKT imports to rules_go

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -42,12 +42,14 @@ const (
 	// WellKnownTypesProtoRepo is the repository containing proto_library rules
 	// for the Well Known Types.
 	WellKnownTypesProtoRepo = "com_google_protobuf"
-	// WellKnownTypesGoProtoRepo is the repository containing go_library rules
-	// for the Well Known Types.
-	WellKnownTypesGoProtoRepo = "com_github_golang_protobuf"
+	// WellKnownTypeProtoPrefix is the proto import path prefix for the
+	// Well Known Types.
+	WellKnownTypesProtoPrefix = "google/protobuf"
 	// WellKnownTypesGoPrefix is the import path for the Go repository containing
 	// pre-generated code for the Well Known Types.
 	WellKnownTypesGoPrefix = "github.com/golang/protobuf"
+	// WellKnownTypesPkg is the package name for the predefined WKTs in rules_go.
+	WellKnownTypesPkg = "proto/wkt"
 
 	// GazelleImportsKey is an internal attribute that lists imported packages
 	// on generated rules. It is replaced with "deps" during import resolution.

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -456,3 +456,21 @@ func TestResolveProto(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveGoWKT(t *testing.T) {
+	c := &config.Config{}
+	l := label.NewLabeler(c)
+	ix := NewRuleIndex()
+	r := NewResolver(c, l, ix, nil)
+
+	want := label.Label{
+		Repo: config.RulesGoRepoName,
+		Pkg:  config.WellKnownTypesPkg,
+		Name: "any_go_proto",
+	}
+	if got, err := r.resolveGo("github.com/golang/protobuf/ptypes/any", label.NoLabel); err != nil {
+		t.Error(err)
+	} else if !got.Equal(want) {
+		t.Errorf("got %s; want %s", got, want)
+	}
+}


### PR DESCRIPTION
Gazelle will now resolve imports of
github.com/golang/protobuf/ptypes/X to
@io_bazel_rules_go//proto/wkt:x_go_proto.

Fixes #159, bazelbuild/rules_go#1386