### PR TITLE
Evaluate symlinks in repo root

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -232,6 +232,10 @@ func newFixUpdateConfiguration(cmd command, args []string) (*updateConfig, error
 			return nil, fmt.Errorf("-repo_root not specified, and WORKSPACE cannot be found: %v", err)
 		}
 	}
+	uc.c.RepoRoot, err = filepath.EvalSymlinks(uc.c.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate symlinks for repo root: %v", err)
+	}
 
 	for _, dir := range uc.c.Dirs {
 		if !isDescendingDir(dir, uc.c.RepoRoot) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,8 @@ type Config struct {
 	// Dirs is a list of absolute paths to directories where Gazelle should run.
 	Dirs []string
 
-	// RepoRoot is the absolute path to the root directory of the repository.
+	// RepoRoot is the absolute, canonical path to the root directory of the
+	// repository with all symlinks resolved.
 	RepoRoot string
 
 	// RepoName is the name of the repository.


### PR DESCRIPTION
Gazelle usually ignores symlinks, but it may follow them if they point
to directories outside of the repo root (after all symlinks are
resolved).

With this change, Gazelle evaluates symlinks in the repo root. Without
this, Gazelle incorrectly decides to follow symlinks.