### PR TITLE
Check that bazel_gazelle is loaded when fixing the WORKSPACE file

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -427,6 +427,9 @@ func fixWorkspace(uc *updateConfig, workspace *bf.File) error {
 
 	merger.FixWorkspace(workspace)
 	merger.FixLoads(workspace)
+	if err := merger.CheckGazelleLoaded(workspace); err != nil {
+		return err
+	}
 	return uc.emit(uc.c, workspace, workspace.Path)
 }
 

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1303,6 +1303,34 @@ go_binary(
 	})
 }
 
+func TestFixWorkspaceWithoutGazelle(t *testing.T) {
+	files := []fileSpec{
+		{
+			path: "WORKSPACE",
+			content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+
+go_repository(
+    name = "com_example_repo",
+    importpath = "example.com/repo",
+    tag = "1.2.3",
+)
+`,
+		},
+	}
+	dir, err := createFiles(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := runGazelle(dir, []string{"fix", "-go_prefix="}); err == nil {
+		t.Error("got success; want error")
+	} else if want := "bazel_gazelle is not declared"; !strings.Contains(err.Error(), want) {
+		t.Errorf("got error %v; want error containing %q", err, want)
+	}
+}
+
 // TODO(jayconrod): more tests
 //   run in fix mode in testdata directories to create new files
 //   run in diff mode in testdata directories to update existing files (no change)

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -60,6 +60,9 @@ func updateRepos(args []string) error {
 		return err
 	}
 	merger.FixLoads(f)
+	if err := merger.CheckGazelleLoaded(f); err != nil {
+		return err
+	}
 	if err := ioutil.WriteFile(f.Path, bf.Format(f), 0666); err != nil {
 		return fmt.Errorf("error writing %q: %v", f.Path, err)
 	}

--- a/internal/config/directives.go
+++ b/internal/config/directives.go
@@ -43,6 +43,7 @@ var knownTopLevelDirectives = map[string]bool{
 	"exclude":          true,
 	"ignore":           true,
 	"importmap_prefix": true,
+	"repo":             true,
 	"prefix":           true,
 	"proto":            true,
 }


### PR DESCRIPTION
When `gazelle fix` or `gazelle update-repos` are run now, Gazelle
loads go_repository from @bazel_gazelle instead of @io_bazel_rules_go.
This is problematic for repositories that haven't updated to the new
Gazelle yet.

Gazelle now checks for @bazel_gazelle (or a gazelle:repo directive)
when modifying the WORKSPACE file. If it's needed but not present,
Gazelle will print an error.

Unfortunately, the repo can't be loaded automatically without a
hardcoding versions and sha256 sums, accessing the network, or Bazel
directory hackery.