### PR TITLE
Squash internal and external go_tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,9 @@
 
 load("//:def.bzl", "gazelle")
 
-gazelle(name = "gazelle")
+gazelle(
+    name = "gazelle",
+    command = "fix",
+)
 
 exports_files(["WORKSPACE"])

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -38,6 +38,7 @@ go_binary(
     name = "gazelle_pure",
     embed = [":go_default_library"],
     pure = "on",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/internal/label/labeler.go
+++ b/internal/label/labeler.go
@@ -34,14 +34,8 @@ func (l *Labeler) LibraryLabel(rel string) Label {
 	return Label{Pkg: rel, Name: config.DefaultLibName}
 }
 
-func (l *Labeler) TestLabel(rel string, isXTest bool) Label {
-	var name string
-	if isXTest {
-		name = config.DefaultXTestName
-	} else {
-		name = config.DefaultTestName
-	}
-	return Label{Pkg: rel, Name: name}
+func (l *Labeler) TestLabel(rel string) Label {
+	return Label{Pkg: rel, Name: config.DefaultTestName}
 }
 
 func (l *Labeler) BinaryLabel(rel string) Label {

--- a/internal/label/labeler_test.go
+++ b/internal/label/labeler_test.go
@@ -24,7 +24,7 @@ import (
 func TestLabelerGo(t *testing.T) {
 	for _, tc := range []struct {
 		name, rel                             string
-		wantLib, wantBin, wantTest, wantXTest string
+		wantLib, wantBin, wantTest string
 	}{
 		{
 			name:      "root_hierarchical",
@@ -32,14 +32,12 @@ func TestLabelerGo(t *testing.T) {
 			wantLib:   "//:go_default_library",
 			wantBin:   "//:root",
 			wantTest:  "//:go_default_test",
-			wantXTest: "//:go_default_xtest",
 		}, {
 			name:      "sub_hierarchical",
 			rel:       "sub",
 			wantLib:   "//sub:go_default_library",
 			wantBin:   "//sub",
 			wantTest:  "//sub:go_default_test",
-			wantXTest: "//sub:go_default_xtest",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -52,11 +50,8 @@ func TestLabelerGo(t *testing.T) {
 			if got := l.BinaryLabel(tc.rel).String(); got != tc.wantBin {
 				t.Errorf("for binary in %s: got %q ; want %q", tc.rel, got, tc.wantBin)
 			}
-			if got := l.TestLabel(tc.rel, false).String(); got != tc.wantTest {
+			if got := l.TestLabel(tc.rel).String(); got != tc.wantTest {
 				t.Errorf("for test in %s: got %q ; want %q", tc.rel, got, tc.wantTest)
-			}
-			if got := l.TestLabel(tc.rel, true).String(); got != tc.wantXTest {
-				t.Errorf("for test in %s: got %q ; want %q", tc.rel, got, tc.wantXTest)
 			}
 		})
 	}

--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -16,6 +16,8 @@ limitations under the License.
 package merger
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"sort"
 
@@ -45,6 +47,7 @@ func FixFile(c *config.Config, f *bf.File) {
 	removeBinaryImportPath(c, f)
 	flattenSrcs(c, f)
 	squashCgoLibrary(c, f)
+	squashXtest(c, f)
 	removeLegacyProto(c, f)
 }
 
@@ -184,20 +187,119 @@ func squashCgoLibrary(c *config.Config, f *bf.File) {
 	}
 }
 
-// squashExpr combines two expressions. Unlike mergeExpr, squashExpr does not
-// discard information from an "old" expression. It does not sort or de-duplicate
-// elements. Any non-scalar expressions that mergeExpr understands can be
-// squashed.
-func squashExpr(x, y bf.Expr) (bf.Expr, error) {
-	xExprs, err := extractPlatformStringsExprs(x)
+// squashXtest removes go_test rules with the default external name and merges
+// their attributes with a go_test rule with the default internal name. If
+// no internal go_test rule exists, a new one will be created (effectively
+// renaming the old rule).
+func squashXtest(c *config.Config, f *bf.File) {
+	// Search for internal and external tests.
+	var itest, xtest bf.Rule
+	xtestIndex := -1
+	for i, stmt := range f.Stmt {
+		call, ok := stmt.(*bf.CallExpr)
+		if !ok {
+			continue
+		}
+		rule := bf.Rule{Call: call}
+		if rule.Kind() != "go_test" {
+			continue
+		}
+		if name := rule.Name(); name == config.DefaultTestName {
+			itest = rule
+		} else if name == config.DefaultXTestName {
+			xtest = rule
+			xtestIndex = i
+		}
+	}
+
+	if xtest.Call == nil || shouldKeep(xtest.Call) || (itest.Call != nil && shouldKeep(itest.Call)) {
+		return
+	}
+	if !c.ShouldFix {
+		if itest.Call == nil {
+			log.Printf("%s: go_default_xtest is no longer necessary. Run 'gazelle fix' to rename to go_default_test.", f.Path)
+		} else {
+			log.Printf("%s: go_default_xtest is no longer necessary. Run 'gazelle fix' to squash with go_default_test.", f.Path)
+		}
+		return
+	}
+
+	// If there was no internal test, we can just rename the external test.
+	if itest.Call == nil {
+		xtest.SetAttr("name", &bf.StringExpr{Value: config.DefaultTestName})
+		return
+	}
+
+	// Attempt to squash.
+	if err := squashRule(xtest.Call, itest.Call, f.Path); err != nil {
+		log.Print(err)
+		return
+	}
+
+	// Delete the external test.
+	f.Stmt = append(f.Stmt[:xtestIndex], f.Stmt[xtestIndex+1:]...)
+
+	// Copy comments and attributes from external test to internal test.
+	itest.Call.Comments.Before = append(itest.Call.Comments.Before, xtest.Call.Comments.Before...)
+	itest.Call.Comments.Suffix = append(itest.Call.Comments.Suffix, xtest.Call.Comments.Suffix...)
+	itest.Call.Comments.After = append(itest.Call.Comments.After, xtest.Call.Comments.After...)
+}
+
+// squashRule copies information in mergeable attributes from src into dst. This
+// works similarly to mergeRule, but it doesn't discard information from dst. It
+// detects duplicate elements, but it doesn't sort elements after squashing.
+// If squashing fails because the expression is understood, an error is
+// returned, and neither rule is modified.
+func squashRule(src, dst *bf.CallExpr, filename string) error {
+	srcRule := bf.Rule{Call: src}
+	dstRule := bf.Rule{Call: dst}
+	kind := dstRule.Kind()
+	type squashedAttr struct {
+		key  string
+		attr bf.Expr
+	}
+	var squashedAttrs []squashedAttr
+	for _, k := range srcRule.AttrKeys() {
+		srcExpr := srcRule.Attr(k)
+		dstExpr := dstRule.Attr(k)
+		if dstExpr == nil {
+			dstRule.SetAttr(k, srcExpr)
+			continue
+		}
+		if !PreResolveAttrs[kind][k] && !PostResolveAttrs[kind][k] {
+			// keep non-mergeable attributes in dst (e.g., name, visibility)
+			continue
+		}
+		squashedExpr, err := squashExpr(srcExpr, dstExpr)
+		if err != nil {
+			start, end := dstExpr.Span()
+			return fmt.Errorf("%s:%d.%d-%d.%d: could not squash expression", filename, start.Line, start.LineRune, end.Line, end.LineRune)
+		}
+		squashedAttrs = append(squashedAttrs, squashedAttr{key: k, attr: squashedExpr})
+	}
+	for _, a := range squashedAttrs {
+		dstRule.SetAttr(a.key, a.attr)
+	}
+	return nil
+}
+
+func squashExpr(src, dst bf.Expr) (bf.Expr, error) {
+	if shouldKeep(dst) {
+		return dst, nil
+	}
+	if isScalar(dst) {
+		// may lose src, but they should always be the same.
+		return dst, nil
+	}
+	srcExprs, err := extractPlatformStringsExprs(src)
 	if err != nil {
 		return nil, err
 	}
-	yExprs, err := extractPlatformStringsExprs(y)
+	dstExprs, err := extractPlatformStringsExprs(dst)
 	if err != nil {
 		return nil, err
 	}
-	squashedExprs, err := squashPlatformStringsExprs(xExprs, yExprs)
+	squashedExprs, err := squashPlatformStringsExprs(srcExprs, dstExprs)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +309,9 @@ func squashExpr(x, y bf.Expr) (bf.Expr, error) {
 func squashPlatformStringsExprs(x, y platformStringsExprs) (platformStringsExprs, error) {
 	var ps platformStringsExprs
 	var err error
-	ps.generic = squashList(x.generic, y.generic)
+	if ps.generic, err = squashList(x.generic, y.generic); err != nil {
+		return platformStringsExprs{}, err
+	}
 	if ps.os, err = squashDict(x.os, y.os); err != nil {
 		return platformStringsExprs{}, err
 	}
@@ -220,19 +324,34 @@ func squashPlatformStringsExprs(x, y platformStringsExprs) (platformStringsExprs
 	return ps, nil
 }
 
-func squashList(x, y *bf.ListExpr) *bf.ListExpr {
+func squashList(x, y *bf.ListExpr) (*bf.ListExpr, error) {
 	if x == nil {
-		return y
+		return y, nil
 	}
 	if y == nil {
-		return x
+		return x, nil
 	}
-	squashed := *x
+
+	ls := makeListSquasher()
+	for _, e := range x.List {
+		s, ok := e.(*bf.StringExpr)
+		if !ok {
+			return nil, errors.New("could not squash non-string")
+		}
+		ls.add(s)
+	}
+	for _, e := range y.List {
+		s, ok := e.(*bf.StringExpr)
+		if !ok {
+			return nil, errors.New("could not squash non-string")
+		}
+		ls.add(s)
+	}
+	squashed := ls.list()
 	squashed.Comments.Before = append(x.Comments.Before, y.Comments.Before...)
 	squashed.Comments.Suffix = append(x.Comments.Suffix, y.Comments.Suffix...)
 	squashed.Comments.After = append(x.Comments.After, y.Comments.After...)
-	squashed.List = append(x.List, y.List...)
-	return &squashed
+	return squashed, nil
 }
 
 func squashDict(x, y *bf.DictExpr) (*bf.DictExpr, error) {
@@ -243,47 +362,62 @@ func squashDict(x, y *bf.DictExpr) (*bf.DictExpr, error) {
 		return x, nil
 	}
 
+	cases := make(map[string]*bf.KeyValueExpr)
+	addCase := func(e bf.Expr) error {
+		kv := e.(*bf.KeyValueExpr)
+		key, ok := kv.Key.(*bf.StringExpr)
+		if !ok {
+			return errors.New("could not squash non-string dict key")
+		}
+		if _, ok := kv.Value.(*bf.ListExpr); !ok {
+			return errors.New("could not squash non-list dict value")
+		}
+		if c, ok := cases[key.Value]; ok {
+			if sq, err := squashList(kv.Value.(*bf.ListExpr), c.Value.(*bf.ListExpr)); err != nil {
+				return err
+			} else {
+				c.Value = sq
+			}
+		} else {
+			kvCopy := *kv
+			cases[key.Value] = &kvCopy
+		}
+		return nil
+	}
+
+	for _, e := range x.List {
+		if err := addCase(e); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range y.List {
+		if err := addCase(e); err != nil {
+			return nil, err
+		}
+	}
+
+	keys := make([]string, 0, len(cases))
+	haveDefault := false
+	for k := range cases {
+		if k == "//conditions:default" {
+			haveDefault = true
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if haveDefault {
+		keys = append(keys, "//conditions:default") // must be last
+	}
+
 	squashed := *x
 	squashed.Comments.Before = append(x.Comments.Before, y.Comments.Before...)
 	squashed.Comments.Suffix = append(x.Comments.Suffix, y.Comments.Suffix...)
 	squashed.Comments.After = append(x.Comments.After, y.Comments.After...)
-
-	xCaseIndex := make(map[string]int)
-	for i, e := range x.List {
-		kv, ok := e.(*bf.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		key, ok := kv.Key.(*bf.StringExpr)
-		if !ok {
-			continue
-		}
-		xCaseIndex[key.Value] = i
+	squashed.List = make([]bf.Expr, 0, len(cases))
+	for _, k := range keys {
+		squashed.List = append(squashed.List, cases[k])
 	}
-
-	for _, e := range y.List {
-		kv, ok := e.(*bf.KeyValueExpr)
-		if !ok {
-			squashed.List = append(squashed.List, e)
-			continue
-		}
-		key, ok := e.(*bf.StringExpr)
-		if !ok {
-			squashed.List = append(squashed.List, e)
-			continue
-		}
-		i, ok := xCaseIndex[key.Value]
-		if !ok {
-			squashed.List = append(squashed.List, e)
-			continue
-		}
-		squashedElem, err := squashExpr(x.List[i], kv.Value)
-		if err != nil {
-			return nil, err
-		}
-		x.List[i] = squashedElem
-	}
-
 	return &squashed, nil
 }
 
@@ -377,37 +511,13 @@ func flattenSrcsExpr(oldSrcs bf.Expr) bf.Expr {
 		return oldSrcs
 	}
 
-	unique := make(map[string]*bf.StringExpr)
-	type elemComment struct{ elem, com string }
-	seenComments := make(map[elemComment]bool)
+	ls := makeListSquasher()
 	addElem := func(e bf.Expr) bool {
 		s, ok := e.(*bf.StringExpr)
 		if !ok {
 			return false
 		}
-		sCopy, ok := unique[s.Value]
-		if !ok {
-			// Make a copy of s. We may modify it when we consolidate comments from
-			// duplicate strings. We don't want to modify the original in case this
-			// function fails (due to a later failed pattern match).
-			sCopy = new(bf.StringExpr)
-			*sCopy = *s
-			sCopy.Comments.Before = make([]bf.Comment, 0, len(s.Comments.Before))
-			sCopy.Comments.Suffix = make([]bf.Comment, 0, len(s.Comments.Suffix))
-			unique[s.Value] = sCopy
-		}
-		for _, c := range s.Comment().Before {
-			if key := (elemComment{s.Value, c.Token}); !seenComments[key] {
-				sCopy.Comments.Before = append(sCopy.Comments.Before, c)
-				seenComments[key] = true
-			}
-		}
-		for _, c := range s.Comment().Suffix {
-			if key := (elemComment{s.Value, c.Token}); !seenComments[key] {
-				sCopy.Comments.Suffix = append(sCopy.Comments.Suffix, c)
-				seenComments[key] = true
-			}
-		}
+		ls.add(s)
 		return true
 	}
 	addList := func(e bf.Expr) bool {
@@ -445,14 +555,7 @@ func flattenSrcsExpr(oldSrcs bf.Expr) bf.Expr {
 		}
 	}
 
-	sortedExprs := make([]bf.Expr, 0, len(unique))
-	for _, e := range unique {
-		sortedExprs = append(sortedExprs, e)
-	}
-	sort.Slice(sortedExprs, func(i, j int) bool {
-		return sortedExprs[i].(*bf.StringExpr).Value < sortedExprs[j].(*bf.StringExpr).Value
-	})
-	return &bf.ListExpr{List: sortedExprs}
+	return ls.list()
 }
 
 // FixLoads removes loads of unused go rules and adds loads of newly used rules.
@@ -784,6 +887,62 @@ func removeLegacyGoRepository(f *bf.File) {
 		}
 	}
 	f.Stmt = deleteIndices(f.Stmt, deletedStmtIndices)
+}
+
+// listSquasher builds a sorted, deduplicated list of string expressions. If
+// a string expression is added multiple times, comments are consolidated.
+// The original expressions are not modified.
+type listSquasher struct {
+	unique       map[string]*bf.StringExpr
+	seenComments map[elemComment]bool
+}
+
+type elemComment struct {
+	elem, com string
+}
+
+func makeListSquasher() listSquasher {
+	return listSquasher{
+		unique:       make(map[string]*bf.StringExpr),
+		seenComments: make(map[elemComment]bool),
+	}
+}
+
+func (ls *listSquasher) add(s *bf.StringExpr) {
+	sCopy, ok := ls.unique[s.Value]
+	if !ok {
+		// Make a copy of s. We may modify it when we consolidate comments from
+		// duplicate strings. We don't want to modify the original in case this
+		// function fails (due to a later failed pattern match).
+		sCopy = new(bf.StringExpr)
+		*sCopy = *s
+		sCopy.Comments.Before = make([]bf.Comment, 0, len(s.Comments.Before))
+		sCopy.Comments.Suffix = make([]bf.Comment, 0, len(s.Comments.Suffix))
+		ls.unique[s.Value] = sCopy
+	}
+	for _, c := range s.Comment().Before {
+		if key := (elemComment{s.Value, c.Token}); !ls.seenComments[key] {
+			sCopy.Comments.Before = append(sCopy.Comments.Before, c)
+			ls.seenComments[key] = true
+		}
+	}
+	for _, c := range s.Comment().Suffix {
+		if key := (elemComment{s.Value, c.Token}); !ls.seenComments[key] {
+			sCopy.Comments.Suffix = append(sCopy.Comments.Suffix, c)
+			ls.seenComments[key] = true
+		}
+	}
+}
+
+func (ls *listSquasher) list() *bf.ListExpr {
+	sortedExprs := make([]bf.Expr, 0, len(ls.unique))
+	for _, e := range ls.unique {
+		sortedExprs = append(sortedExprs, e)
+	}
+	sort.Slice(sortedExprs, func(i, j int) bool {
+		return sortedExprs[i].(*bf.StringExpr).Value < sortedExprs[j].(*bf.StringExpr).Value
+	})
+	return &bf.ListExpr{List: sortedExprs}
 }
 
 type byString []*bf.StringExpr

--- a/internal/merger/fix_test.go
+++ b/internal/merger/fix_test.go
@@ -283,20 +283,20 @@ cgo_library(
 go_library(
     name = "go_default_library",
     srcs = [
-        "pure.go",
         "cgo.go",
+        "pure.go",
     ],
     deps = [
-        "pure_deps",
         "cgo_deps",
+        "pure_deps",
     ],
     data = [
-        "pure_data",
         "cgo_data",
+        "pure_data",
     ],
     gc_goopts = [
-        "pure_gc_goopts",
         "cgo_gc_goopts",
+        "pure_gc_goopts",
     ],
     cgo = True,
     cdeps = ["cdeps"],
@@ -304,6 +304,63 @@ go_library(
 )
 # after go_library
 # after cgo_library
+`,
+		},
+		// squashXtest tests
+		{
+			desc: "rename xtest",
+			old: `load("@io_bazel_rules_go//go:def.bzl", "go_test")
+go_test(
+    name = "go_default_xtest",
+    srcs = ["x_test.go"],
+)
+`,
+			want: `load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["x_test.go"],
+)
+`,
+		}, {
+			desc: "squash xtest",
+			old: `load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["i_test.go"],
+    deps = [
+        ":i_dep",
+        ":shared_dep",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["x_test.go"],
+    deps = [
+        ":x_dep",
+        ":shared_dep",
+    ],
+    visibility = ["//visibility:public"],
+)
+`,
+			want: `load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "i_test.go",
+        "x_test.go",
+    ],
+    deps = [
+        ":i_dep",
+        ":shared_dep",
+        ":x_dep",
+    ],
+    visibility = ["//visibility:public"],
+)
 `,
 		},
 		// removeLegacyProto tests

--- a/internal/packages/BUILD.bazel
+++ b/internal/packages/BUILD.bazel
@@ -27,17 +27,10 @@ go_test(
         "fileinfo_proto_test.go",
         "fileinfo_test.go",
         "package_test.go",
+        "walk_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//internal/config:go_default_library"],
-)
-
-go_test(
-    name = "go_default_xtest",
-    size = "small",
-    srcs = ["walk_test.go"],
     deps = [
-        ":go_default_library",
         "//internal/config:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],

--- a/internal/packages/fileinfo.go
+++ b/internal/packages/fileinfo.go
@@ -49,10 +49,6 @@ type fileInfo struct {
 	// ends with "_test.go". This is never true for non-Go files.
 	isTest bool
 
-	// isXTest is true for test Go files whose declared package name ends
-	// with "_test".
-	isXTest bool
-
 	// imports is a list of packages imported by a file. It does not include
 	// "C" or anything from the standard library.
 	imports []string

--- a/internal/packages/fileinfo_go.go
+++ b/internal/packages/fileinfo_go.go
@@ -49,7 +49,6 @@ func goFileInfo(c *config.Config, dir, rel, name string) fileInfo {
 
 	info.packageName = pf.Name.Name
 	if info.isTest && strings.HasSuffix(info.packageName, "_test") {
-		info.isXTest = true
 		info.packageName = info.packageName[:len(info.packageName)-len("_test")]
 	}
 

--- a/internal/packages/fileinfo_go_test.go
+++ b/internal/packages/fileinfo_go_test.go
@@ -49,7 +49,6 @@ func TestGoFileInfo(t *testing.T) {
 			fileInfo{
 				packageName: "foo",
 				isTest:      true,
-				isXTest:     true,
 			},
 		},
 		{
@@ -59,7 +58,6 @@ func TestGoFileInfo(t *testing.T) {
 			fileInfo{
 				packageName: "foo_test",
 				isTest:      false,
-				isXTest:     false,
 			},
 		},
 		{
@@ -155,7 +153,6 @@ package route
 		got = fileInfo{
 			packageName: got.packageName,
 			isTest:      got.isTest,
-			isXTest:     got.isXTest,
 			imports:     got.imports,
 			isCgo:       got.isCgo,
 			tags:        got.tags,

--- a/internal/packages/fileinfo_test.go
+++ b/internal/packages/fileinfo_test.go
@@ -247,18 +247,16 @@ func TestFileNameInfo(t *testing.T) {
 			"ignored test file",
 			"foo_test.py",
 			fileInfo{
-				ext:     ".py",
-				isTest:  false,
-				isXTest: false,
+				ext:    ".py",
+				isTest: false,
 			},
 		},
 		{
 			"ignored xtest file",
 			"foo_xtest.py",
 			fileInfo{
-				ext:     ".py",
-				isTest:  false,
-				isXTest: false,
+				ext:    ".py",
+				isTest: false,
 			},
 		},
 		{

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -45,8 +45,8 @@ type Package struct {
 	// ImportPath is the string used to import this package in Go.
 	ImportPath string
 
-	Library, Binary, Test, XTest GoTarget
-	Proto                        ProtoTarget
+	Library, Binary, Test GoTarget
+	Proto                 ProtoTarget
 
 	HasTestdata bool
 }
@@ -188,11 +188,11 @@ func (ps *PlatformStrings) firstGoFile() string {
 }
 
 type packageBuilder struct {
-	name, dir, rel               string
-	library, binary, test, xtest goTargetBuilder
-	proto                        protoTargetBuilder
-	hasTestdata                  bool
-	importPath, importPathFile   string
+	name, dir, rel             string
+	library, binary, test      goTargetBuilder
+	proto                      protoTargetBuilder
+	hasTestdata                bool
+	importPath, importPathFile string
 }
 
 type goTargetBuilder struct {
@@ -240,11 +240,6 @@ func (pb *packageBuilder) addFile(c *config.Config, info fileInfo, cgo bool) err
 		!cgo && (info.category == cExt || info.category == csExt) ||
 		c.ProtoMode == config.DisableProtoMode && info.category == protoExt:
 		return nil
-	case info.isXTest:
-		if info.isCgo {
-			return fmt.Errorf("%s: use of cgo in test not supported", info.path)
-		}
-		pb.xtest.addFile(c, info)
 	case info.isTest:
 		if info.isCgo {
 			return fmt.Errorf("%s: use of cgo in test not supported", info.path)
@@ -286,7 +281,6 @@ func (pb *packageBuilder) firstGoFile() string {
 		pb.library.sources,
 		pb.binary.sources,
 		pb.test.sources,
-		pb.xtest.sources,
 	}
 	for _, sb := range goSrcs {
 		if sb.strs != nil {
@@ -325,7 +319,6 @@ func (pb *packageBuilder) build() *Package {
 		Library:     pb.library.build(),
 		Binary:      pb.binary.build(),
 		Test:        pb.test.build(),
-		XTest:       pb.xtest.build(),
 		Proto:       pb.proto.build(),
 		HasTestdata: pb.hasTestdata,
 	}

--- a/internal/rules/BUILD.bazel
+++ b/internal/rules/BUILD.bazel
@@ -23,12 +23,12 @@ go_library(
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     size = "small",
     srcs = ["generator_test.go"],
     data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//internal/config:go_default_library",
         "//internal/label:go_default_library",
         "//internal/merger:go_default_library",

--- a/internal/rules/generator.go
+++ b/internal/rules/generator.go
@@ -55,8 +55,7 @@ func (g *Generator) GenerateRules(pkg *packages.Package) (rules []bf.Expr, empty
 
 	rs = append(rs,
 		g.generateBin(pkg, libName),
-		g.generateTest(pkg, libName, false),
-		g.generateTest(pkg, "", true))
+		g.generateTest(pkg, libName))
 
 	for _, r := range rs {
 		if isEmpty(r) {
@@ -200,16 +199,12 @@ func checkInternalVisibility(rel, visibility string) string {
 	return visibility
 }
 
-func (g *Generator) generateTest(pkg *packages.Package, library string, isXTest bool) bf.Expr {
-	name := g.l.TestLabel(pkg.Rel, isXTest).Name
-	target := pkg.Test
-	if isXTest {
-		target = pkg.XTest
-	}
-	if !target.HasGo() {
+func (g *Generator) generateTest(pkg *packages.Package, library string) bf.Expr {
+	name := g.l.TestLabel(pkg.Rel).Name
+	if !pkg.Test.HasGo() {
 		return EmptyRule("go_test", name)
 	}
-	attrs := g.commonAttrs(pkg.Rel, name, "", target)
+	attrs := g.commonAttrs(pkg.Rel, name, "", pkg.Test)
 	if library != "" {
 		attrs = append(attrs, KeyValue{"embed", []string{":" + library}})
 	}

--- a/internal/rules/generator_test.go
+++ b/internal/rules/generator_test.go
@@ -119,8 +119,6 @@ go_library(name = "go_default_library")
 go_binary(name = "repo")
 
 go_test(name = "go_default_test")
-
-go_test(name = "go_default_xtest")
 `
 	_, empty, err := g.GenerateRules(&pkg)
 	if err != nil {

--- a/internal/rules/testdata/repo/lib/BUILD.want
+++ b/internal/rules/testdata/repo/lib/BUILD.want
@@ -20,16 +20,13 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["lib_test.go"],
-    _gazelle_imports = ["testing"],
-    embed = [":go_default_library"],
-)
-
-go_test(
-    name = "go_default_xtest",
-    srcs = ["lib_external_test.go"],
+    srcs = [
+        "lib_external_test.go",
+        "lib_test.go",
+    ],
     _gazelle_imports = [
         "example.com/repo/lib",
         "testing",
     ],
+    embed = [":go_default_library"],
 )

--- a/internal/rules/testdata/repo/platforms/BUILD.want
+++ b/internal/rules/testdata/repo/platforms/BUILD.want
@@ -43,9 +43,10 @@ go_library(
 )
 
 go_test(
-    name = "go_default_xtest",
+    name = "go_default_test",
     srcs = [
         "generic_test.go",
         "suffix_linux_test.go",
     ],
+    embed = [":go_default_library"],
 )

--- a/internal/rules/testdata/repo/tests_import_testdata/BUILD.want
+++ b/internal/rules/testdata/repo/tests_import_testdata/BUILD.want
@@ -2,16 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["internal_test.go"],
-    _gazelle_imports = [
-        "example.com/repo/tests_import_testdata/testdata",
-        "testing",
+    srcs = [
+        "external_test.go",
+        "internal_test.go",
     ],
-)
-
-go_test(
-    name = "go_default_xtest",
-    srcs = ["external_test.go"],
     _gazelle_imports = [
         "example.com/repo/tests_import_testdata/testdata",
         "testing",

--- a/internal/rules/testdata/repo/tests_with_testdata/BUILD.want
+++ b/internal/rules/testdata/repo/tests_with_testdata/BUILD.want
@@ -2,14 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["internal_test.go"],
-    _gazelle_imports = ["testing"],
-    data = glob(["testdata/**"]),
-)
-
-go_test(
-    name = "go_default_xtest",
-    srcs = ["external_test.go"],
+    srcs = [
+        "external_test.go",
+        "internal_test.go",
+    ],
     _gazelle_imports = ["testing"],
     data = glob(["testdata/**"]),
 )

--- a/vendor/github.com/bazelbuild/buildtools/build/BUILD.bazel
+++ b/vendor/github.com/bazelbuild/buildtools/build/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "syntax.go",
         "walk.go",
     ],
+    importmap = "bazel_gazelle/vendor/github.com/bazelbuild/buildtools/build",
     importpath = "github.com/bazelbuild/buildtools/build",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/bazelbuild/buildtools/tables:go_default_library"],

--- a/vendor/github.com/bazelbuild/buildtools/tables/BUILD.bazel
+++ b/vendor/github.com/bazelbuild/buildtools/tables/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "jsonparser.go",
         "tables.go",
     ],
+    importmap = "bazel_gazelle/vendor/github.com/bazelbuild/buildtools/tables",
     importpath = "github.com/bazelbuild/buildtools/tables",
     visibility = ["//visibility:public"],
 )

--- a/vendor/github.com/pelletier/go-toml/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "tomltree_create.go",
         "tomltree_write.go",
     ],
+    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml",
     importpath = "github.com/pelletier/go-toml",
     visibility = ["//visibility:public"],
 )

--- a/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["test_program.go"],
+    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd",
     importpath = "github.com/pelletier/go-toml/cmd",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd/tomljson",
     importpath = "github.com/pelletier/go-toml/cmd/tomljson",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd/tomll",
     importpath = "github.com/pelletier/go-toml/cmd/tomll",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "query.go",
         "tokens.go",
     ],
+    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/query",
     importpath = "github.com/pelletier/go-toml/query",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],


### PR DESCRIPTION
* Gazelle no longer generates separate `go_default_test` and `go_default_xtest` targets for internal tests. A single `go_test` is generated containing sources for both internal and external parts. rules_go has been able to sort these out for a while.
* `gazelle fix` will squash existing `go_default_xtest` rules into `go_default_test` (or just rename if there is no `go_default_test`).
* That required a fair amount of refactoring to the squash functionality. I'm still not happy with this though; we need a replacement for `build.Rule` so we can work at a higher level of abstraction.
* `Resolver.ResolveRule` now treats imports provided by embeds as self-imports, so they won't show up in `deps`. Before this fix, tests got broken when they listed the library under test in `embeds` and `deps`.

Fixes #102