### PR TITLE
Remove fix transformation removing go_binary, go_test importpath

### DIFF
--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -45,7 +45,6 @@ import (
 func FixFile(c *config.Config, f *bf.File) {
 	migrateLibraryEmbed(c, f)
 	migrateGrpcCompilers(c, f)
-	removeBinaryImportPath(c, f)
 	flattenSrcs(c, f)
 	squashCgoLibrary(c, f)
 	squashXtest(c, f)
@@ -90,22 +89,6 @@ func migrateGrpcCompilers(c *config.Config, f *bf.File) {
 		rule.SetAttr("compilers", &bf.ListExpr{
 			List: []bf.Expr{&bf.StringExpr{Value: config.GrpcCompilerLabel}},
 		})
-	}
-}
-
-// removeBinaryImportPath removes "importpath" attributes from "go_binary"
-// and "go_test" rules. These are now deprecated.
-func removeBinaryImportPath(c *config.Config, f *bf.File) {
-	for _, stmt := range f.Stmt {
-		call, ok := stmt.(*bf.CallExpr)
-		if !ok {
-			continue
-		}
-		rule := bf.Rule{Call: call}
-		if rule.Kind() != "go_binary" && rule.Kind() != "go_test" {
-			continue
-		}
-		rule.DelAttr("importpath")
 	}
 }
 

--- a/internal/merger/fix_test.go
+++ b/internal/merger/fix_test.go
@@ -93,36 +93,6 @@ go_proto_library(
 )
 `,
 		},
-		// removeBinaryImportPath tests
-		{
-			desc: "binary importpath removed",
-			old: `load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
-
-go_binary(
-    name = "cmd",
-    srcs = ["main.go"],
-    importpath = "example.com/repo",
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["main_test.go"],
-    importpath = "example.com/repo",
-)
-`,
-			want: `load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
-
-go_binary(
-    name = "cmd",
-    srcs = ["main.go"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["main_test.go"],
-)
-`,
-		},
 		// flattenSrcs tests
 		{
 			desc: "flatten srcs",


### PR DESCRIPTION
The importpath attribute on go_binary and go_test was recently
un-deprecated, and Gazelle should not remove it anymore. It's used by
go_path and potentially other tools to place source files.