### PR TITLE
Extract types from generator and packages into new rule package

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/packages:go_default_library",
         "//internal/repos:go_default_library",
         "//internal/resolve:go_default_library",
+        "//internal/rule:go_default_library",
         "//internal/version:go_default_library",
         "//internal/wspace:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	"github.com/bazelbuild/bazel-gazelle/internal/wspace"
 	bf "github.com/bazelbuild/buildtools/build"
 )
@@ -161,7 +162,7 @@ func runFixUpdate(cmd command, args []string) error {
 
 	// Emit merged files.
 	for _, v := range visits {
-		generator.SortLabels(v.file)
+		rule.SortLabels(v.file)
 		merger.FixLoads(v.file)
 		bf.Rewrite(v.file, nil) // have buildifier 'format' our rules.
 

--- a/internal/generator/BUILD.bazel
+++ b/internal/generator/BUILD.bazel
@@ -5,10 +5,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "construct.go",
         "doc.go",
         "generator.go",
-        "sort_labels.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/generator",
     visibility = ["//visibility:public"],
@@ -17,8 +15,8 @@ go_library(
         "//internal/label:go_default_library",
         "//internal/packages:go_default_library",
         "//internal/pathtools:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/tables:go_default_library",
     ],
 )
 
@@ -33,6 +31,7 @@ go_test(
         "//internal/label:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/merger"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
@@ -84,7 +85,7 @@ func TestGenerator(t *testing.T) {
 				t.Fatal(err)
 			}
 			f := &bf.File{Stmt: rs}
-			generator.SortLabels(f)
+			rule.SortLabels(f)
 			merger.FixLoads(f)
 			got := string(bf.Format(f))
 

--- a/internal/packages/BUILD.bazel
+++ b/internal/packages/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//internal/config:go_default_library",
         "//internal/pathtools:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )
@@ -32,6 +33,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//internal/config:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/packages/fileinfo_go_test.go
+++ b/internal/packages/fileinfo_go_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 )
 
 func TestGoFileInfo(t *testing.T) {
@@ -365,10 +366,10 @@ import "C"
 		Rel:        "sub",
 		ImportPath: "example.com/repo/sub",
 		Library: GoTarget{
-			Sources: PlatformStrings{
+			Sources: rule.PlatformStrings{
 				Generic: []string{"sub.go"},
 			},
-			COpts: PlatformStrings{
+			COpts: rule.PlatformStrings{
 				Generic: []string{"-Isub/.."},
 			},
 			Cgo: true,

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 )
 
 func TestAddPlatformStrings(t *testing.T) {
@@ -27,30 +28,30 @@ func TestAddPlatformStrings(t *testing.T) {
 	for _, tc := range []struct {
 		desc, filename string
 		tags           []tagLine
-		want           PlatformStrings
+		want           rule.PlatformStrings
 	}{
 		{
 			desc:     "generic",
 			filename: "foo.go",
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Generic: []string{"foo.go"},
 			},
 		}, {
 			desc:     "os",
 			filename: "foo_linux.go",
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				OS: map[string][]string{"linux": []string{"foo_linux.go"}},
 			},
 		}, {
 			desc:     "arch",
 			filename: "foo_amd64.go",
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Arch: map[string][]string{"amd64": []string{"foo_amd64.go"}},
 			},
 		}, {
 			desc:     "os and arch",
 			filename: "foo_linux_amd64.go",
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Platform: map[config.Platform][]string{
 					config.Platform{OS: "linux", Arch: "amd64"}: []string{"foo_linux_amd64.go"},
 				},
@@ -59,7 +60,7 @@ func TestAddPlatformStrings(t *testing.T) {
 			desc:     "os not arch",
 			filename: "foo.go",
 			tags:     []tagLine{{{"solaris", "!arm"}}},
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Platform: map[config.Platform][]string{
 					config.Platform{OS: "solaris", Arch: "amd64"}: []string{"foo.go"},
 				},
@@ -84,7 +85,7 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
 		add  func(sb *platformStringsBuilder)
-		want PlatformStrings
+		want rule.PlatformStrings
 	}{
 		{
 			desc: "both generic",
@@ -92,7 +93,7 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 				sb.addGenericString("a")
 				sb.addGenericString("a")
 			},
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Generic: []string{"a"},
 			},
 		}, {
@@ -101,7 +102,7 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 				sb.addOSString("a", []string{"linux"})
 				sb.addGenericString("a")
 			},
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Generic: []string{"a"},
 			},
 		}, {
@@ -110,7 +111,7 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 				sb.addOSString("a", []string{"solaris"})
 				sb.addArchString("a", []string{"mips"})
 			},
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Platform: map[config.Platform][]string{
 					config.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
 					config.Platform{OS: "linux", Arch: "mips"}:    {"a"},
@@ -122,7 +123,7 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 				sb.addPlatformString("a", []config.Platform{{OS: "linux", Arch: "mips"}})
 				sb.addOSString("a", []string{"solaris"})
 			},
-			want: PlatformStrings{
+			want: rule.PlatformStrings{
 				Platform: map[config.Platform][]string{
 					config.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
 					config.Platform{OS: "linux", Arch: "mips"}:    {"a"},

--- a/internal/packages/walk_test.go
+++ b/internal/packages/walk_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
@@ -134,7 +135,7 @@ func TestWalkSimple(t *testing.T) {
 			Name:       "lib",
 			ImportPath: "example.com/repo",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"lib.go"},
 				},
 			},
@@ -155,7 +156,7 @@ func TestWalkNested(t *testing.T) {
 			Rel:        "a",
 			ImportPath: "example.com/repo/a",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"foo.go"},
 				},
 			},
@@ -165,7 +166,7 @@ func TestWalkNested(t *testing.T) {
 			Rel:        "b/c",
 			ImportPath: "example.com/repo/b/c",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"bar.go"},
 				},
 			},
@@ -175,7 +176,7 @@ func TestWalkNested(t *testing.T) {
 			Rel:        "b/d",
 			ImportPath: "example.com/repo/b/d",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"baz.go"},
 				},
 			},
@@ -194,7 +195,7 @@ func TestProtoOnly(t *testing.T) {
 			Rel:        "a",
 			ImportPath: "example.com/repo/a",
 			Proto: packages.ProtoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.proto"},
 				},
 			},
@@ -214,7 +215,7 @@ func TestMultiplePackagesWithDefault(t *testing.T) {
 			Rel:        "a",
 			ImportPath: "example.com/repo/a",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -258,7 +259,7 @@ package a;
 			Rel:        "a",
 			ImportPath: "example.com/repo/a",
 			Proto: packages.ProtoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.proto"},
 				},
 			},
@@ -277,7 +278,7 @@ func TestRootWithPrefix(t *testing.T) {
 			Name:       "a",
 			ImportPath: "example.com/a",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -361,7 +362,7 @@ option go_package = "example.com/repo/foo";
 		Name:       "foo",
 		ImportPath: "example.com/repo/foo",
 		Proto: packages.ProtoTarget{
-			Sources: packages.PlatformStrings{
+			Sources: rule.PlatformStrings{
 				Generic: []string{"foo.proto"},
 			},
 		},
@@ -388,7 +389,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "raw",
 			ImportPath: "example.com/repo/raw",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -399,7 +400,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "with_build",
 			ImportPath: "example.com/repo/with_build",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -410,7 +411,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "with_build_bazel",
 			ImportPath: "example.com/repo/with_build_bazel",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -421,7 +422,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "with_build_nested",
 			ImportPath: "example.com/repo/with_build_nested",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -432,7 +433,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "with_go/testdata",
 			ImportPath: "example.com/repo/with_go/testdata",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -442,7 +443,7 @@ func TestTestdata(t *testing.T) {
 			Rel:        "with_go",
 			ImportPath: "example.com/repo/with_go",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -482,10 +483,10 @@ import "github.com/jr_hacker/stuff"
 			Rel:        "gen",
 			ImportPath: "example.com/repo/gen",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"bar.go", "baz.go", "foo.go", "y.s"},
 				},
-				Imports: packages.PlatformStrings{
+				Imports: rule.PlatformStrings{
 					Generic: []string{"github.com/jr_hacker/stuff"},
 				},
 			},
@@ -526,10 +527,10 @@ import "github.com/jr_hacker/stuff"
 			Rel:        "gen",
 			ImportPath: "example.com/repo/gen",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"bar.go", "baz.go", "foo.go", "x.c", "y.s", "z.S"},
 				},
-				Imports: packages.PlatformStrings{
+				Imports: rule.PlatformStrings{
 					Generic: []string{"github.com/jr_hacker/stuff"},
 				},
 				Cgo: true,
@@ -558,7 +559,7 @@ func TestIgnore(t *testing.T) {
 			Rel:        "bar",
 			ImportPath: "example.com/repo/bar",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"bar.go"},
 				},
 			},
@@ -608,7 +609,7 @@ genrule(
 			Rel:        "exclude",
 			ImportPath: "example.com/repo/exclude",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"real.go"},
 				},
 			},
@@ -651,12 +652,12 @@ package exclude;
 			Rel:        "exclude",
 			ImportPath: "example.com/repo/exclude",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.pb.go"},
 				},
 			},
 			Proto: packages.ProtoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"b.proto"},
 				},
 				HasPbGo: true,
@@ -697,12 +698,12 @@ package proto_only;`,
 			Rel:        "have_pbgo",
 			ImportPath: "example.com/repo/have_pbgo",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.pb.go"},
 				},
 			},
 			Proto: packages.ProtoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.proto"},
 				},
 				HasPbGo: true,
@@ -712,12 +713,12 @@ package proto_only;`,
 			Rel:        "no_pbgo",
 			ImportPath: "example.com/repo/no_pbgo",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"other.go"},
 				},
 			},
 			Proto: packages.ProtoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"b.proto"},
 				},
 				HasPbGo: false,
@@ -756,7 +757,7 @@ func TestMalformedGoFile(t *testing.T) {
 			Name:       "foo",
 			ImportPath: "example.com/repo",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go", "b.go"},
 				},
 			},
@@ -789,7 +790,7 @@ func TestSymlinksBasic(t *testing.T) {
 			Rel:        "b/d",
 			ImportPath: "example.com/repo/b/d",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"d.go"},
 				},
 			},
@@ -800,7 +801,7 @@ func TestSymlinksBasic(t *testing.T) {
 			Rel:        "b",
 			ImportPath: "example.com/repo/b",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"b.go"},
 				},
 			},
@@ -810,7 +811,7 @@ func TestSymlinksBasic(t *testing.T) {
 			Dir:        dir + "/root",
 			ImportPath: "example.com/repo",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"a.go"},
 				},
 			},
@@ -871,7 +872,7 @@ func TestSymlinksMixIgnoredAndNonIgnored(t *testing.T) {
 			Rel:        "b2",
 			ImportPath: "example.com/repo/b2",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"b.go"},
 				},
 			},
@@ -905,7 +906,7 @@ func TestSymlinksChained(t *testing.T) {
 			Rel:        "b",
 			ImportPath: "example.com/repo/b",
 			Library: packages.GoTarget{
-				Sources: packages.PlatformStrings{
+				Sources: rule.PlatformStrings{
 					Generic: []string{"b.go"},
 				},
 			},

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/repos",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/generator:go_default_library",
         "//internal/label:go_default_library",
         "//internal/pathtools:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/github.com/pelletier/go-toml:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",

--- a/internal/repos/repo.go
+++ b/internal/repos/repo.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/generator"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	bf "github.com/bazelbuild/buildtools/build"
 )
 
@@ -103,18 +103,18 @@ func getLockFileFormat(filename string) lockFileFormat {
 // GenerateRule returns a repository rule for the given repository that can
 // be written in a WORKSPACE file.
 func GenerateRule(repo Repo) bf.Expr {
-	attrs := []generator.KeyValue{
+	attrs := []rule.KeyValue{
 		{Key: "name", Value: repo.Name},
 		{Key: "commit", Value: repo.Commit},
 		{Key: "importpath", Value: repo.GoPrefix},
 	}
 	if repo.Remote != "" {
-		attrs = append(attrs, generator.KeyValue{Key: "remote", Value: repo.Remote})
+		attrs = append(attrs, rule.KeyValue{Key: "remote", Value: repo.Remote})
 	}
 	if repo.VCS != "" {
-		attrs = append(attrs, generator.KeyValue{Key: "vcs", Value: repo.VCS})
+		attrs = append(attrs, rule.KeyValue{Key: "vcs", Value: repo.VCS})
 	}
-	return generator.NewRule("go_repository", attrs)
+	return rule.NewRule("go_repository", attrs)
 }
 
 // FindExternalRepo attempts to locate the directory where Bazel has fetched

--- a/internal/rule/BUILD.bazel
+++ b/internal/rule/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "platform_strings.go",
+        "rule.go",
+        "sort_labels.go",
+        "value.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-gazelle/internal/rule",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/config:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/tables:go_default_library",
+    ],
+)

--- a/internal/rule/platform_strings.go
+++ b/internal/rule/platform_strings.go
@@ -1,0 +1,172 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/config"
+)
+
+// PlatformStrings contains a set of strings associated with a buildable
+// Go target in a package. This is used to store source file names,
+// import paths, and flags.
+//
+// Strings are stored in four sets: generic strings, OS-specific strings,
+// arch-specific strings, and OS-and-arch-specific strings. A string may not
+// be duplicated within a list or across sets; however, a string may appear
+// in more than one list within a set (e.g., in "linux" and "windows" within
+// the OS set). Strings within each list should be sorted, though this may
+// not be relied upon.
+type PlatformStrings struct {
+	// Generic is a list of strings not specific to any platform.
+	Generic []string
+
+	// OS is a map from OS name (anything in config.KnownOSs) to
+	// OS-specific strings.
+	OS map[string][]string
+
+	// Arch is a map from architecture name (anything in config.KnownArchs) to
+	// architecture-specific strings.
+	Arch map[string][]string
+
+	// Platform is a map from platforms to OS and architecture-specific strings.
+	Platform map[config.Platform][]string
+}
+
+func (ps *PlatformStrings) HasExt(ext string) bool {
+	return ps.firstExtFile(ext) != ""
+}
+
+func (ps *PlatformStrings) IsEmpty() bool {
+	return len(ps.Generic) == 0 && len(ps.OS) == 0 && len(ps.Arch) == 0 && len(ps.Platform) == 0
+}
+
+func (ps *PlatformStrings) Flat() []string {
+	unique := make(map[string]struct{})
+	for _, s := range ps.Generic {
+		unique[s] = struct{}{}
+	}
+	for _, ss := range ps.OS {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	for _, ss := range ps.Arch {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	for _, ss := range ps.Platform {
+		for _, s := range ss {
+			unique[s] = struct{}{}
+		}
+	}
+	flat := make([]string, 0, len(unique))
+	for s := range unique {
+		flat = append(flat, s)
+	}
+	sort.Strings(flat)
+	return flat
+}
+
+func (ps *PlatformStrings) firstExtFile(ext string) string {
+	for _, f := range ps.Generic {
+		if strings.HasSuffix(f, ext) {
+			return f
+		}
+	}
+	for _, fs := range ps.OS {
+		for _, f := range fs {
+			if strings.HasSuffix(f, ext) {
+				return f
+			}
+		}
+	}
+	for _, fs := range ps.Arch {
+		for _, f := range fs {
+			if strings.HasSuffix(f, ext) {
+				return f
+			}
+		}
+	}
+	for _, fs := range ps.Platform {
+		for _, f := range fs {
+			if strings.HasSuffix(f, ext) {
+				return f
+			}
+		}
+	}
+	return ""
+}
+
+// MapSlice applies a function that processes slices of strings to the strings
+// in "ps" and returns a new PlatformStrings with the results.
+func (ps *PlatformStrings) MapSlice(f func([]string) ([]string, error)) (PlatformStrings, []error) {
+	var errors []error
+
+	mapSlice := func(ss []string) []string {
+		rs, err := f(ss)
+		if err != nil {
+			errors = append(errors, err)
+			return nil
+		}
+		return rs
+	}
+
+	mapStringMap := func(m map[string][]string) map[string][]string {
+		if m == nil {
+			return nil
+		}
+		rm := make(map[string][]string)
+		for k, ss := range m {
+			ss = mapSlice(ss)
+			if len(ss) > 0 {
+				rm[k] = ss
+			}
+		}
+		if len(rm) == 0 {
+			return nil
+		}
+		return rm
+	}
+
+	mapPlatformMap := func(m map[config.Platform][]string) map[config.Platform][]string {
+		if m == nil {
+			return nil
+		}
+		rm := make(map[config.Platform][]string)
+		for k, ss := range m {
+			ss = mapSlice(ss)
+			if len(ss) > 0 {
+				rm[k] = ss
+			}
+		}
+		if len(rm) == 0 {
+			return nil
+		}
+		return rm
+	}
+
+	result := PlatformStrings{
+		Generic:  mapSlice(ps.Generic),
+		OS:       mapStringMap(ps.OS),
+		Arch:     mapStringMap(ps.Arch),
+		Platform: mapPlatformMap(ps.Platform),
+	}
+	return result, errors
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -1,0 +1,67 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"sort"
+
+	bzl "github.com/bazelbuild/buildtools/build"
+	bt "github.com/bazelbuild/buildtools/tables"
+)
+
+// EmptyRule generates an empty rule with the given kind and name.
+func EmptyRule(kind, name string) *bzl.CallExpr {
+	return NewRule(kind, []KeyValue{{"name", name}})
+}
+
+// NewRule generates a rule of the given kind with the given attributes.
+func NewRule(kind string, kwargs []KeyValue) *bzl.CallExpr {
+	sort.Sort(byAttrName(kwargs))
+
+	var list []bzl.Expr
+	for _, arg := range kwargs {
+		expr := ExprFromValue(arg.Value)
+		list = append(list, &bzl.BinaryExpr{
+			X:  &bzl.LiteralExpr{Token: arg.Key},
+			Op: "=",
+			Y:  expr,
+		})
+	}
+
+	return &bzl.CallExpr{
+		X:    &bzl.LiteralExpr{Token: kind},
+		List: list,
+	}
+}
+
+type byAttrName []KeyValue
+
+var _ sort.Interface = byAttrName{}
+
+func (s byAttrName) Len() int {
+	return len(s)
+}
+
+func (s byAttrName) Less(i, j int) bool {
+	if cmp := bt.NamePriority[s[i].Key] - bt.NamePriority[s[j].Key]; cmp != 0 {
+		return cmp < 0
+	}
+	return s[i].Key < s[j].Key
+}
+
+func (s byAttrName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/internal/rule/sort_labels.go
+++ b/internal/rule/sort_labels.go
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generator
+package rule
 
 import (
 	"sort"
 	"strings"
 
-	bf "github.com/bazelbuild/buildtools/build"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 var (
@@ -36,13 +36,13 @@ var (
 // Go rules using the same order as buildifier. Buildifier also sorts string
 // lists, but not those involved with "select" expressions.
 // TODO(jayconrod): remove this when bazelbuild/buildtools#122 is fixed.
-func SortLabels(f *bf.File) {
+func SortLabels(f *bzl.File) {
 	for _, s := range f.Stmt {
-		c, ok := s.(*bf.CallExpr)
+		c, ok := s.(*bzl.CallExpr)
 		if !ok {
 			continue
 		}
-		r := bf.Rule{Call: c}
+		r := bzl.Rule{Call: c}
 		if !goRuleKinds[r.Kind()] {
 			continue
 		}
@@ -51,20 +51,20 @@ func SortLabels(f *bf.File) {
 			if attr == nil {
 				continue
 			}
-			bf.Walk(attr.Y, sortExprLabels)
+			bzl.Walk(attr.Y, sortExprLabels)
 		}
 	}
 }
 
-func sortExprLabels(e bf.Expr, _ []bf.Expr) {
-	list, ok := e.(*bf.ListExpr)
+func sortExprLabels(e bzl.Expr, _ []bzl.Expr) {
+	list, ok := e.(*bzl.ListExpr)
 	if !ok || len(list.List) == 0 {
 		return
 	}
 
 	keys := make([]stringSortKey, len(list.List))
 	for i, elem := range list.List {
-		s, ok := elem.(*bf.StringExpr)
+		s, ok := elem.(*bzl.StringExpr)
 		if !ok {
 			return // don't sort lists unless all elements are strings
 		}
@@ -94,10 +94,10 @@ type stringSortKey struct {
 	split    []string
 	value    string
 	original int
-	x        bf.Expr
+	x        bzl.Expr
 }
 
-func makeSortKey(index int, x *bf.StringExpr) stringSortKey {
+func makeSortKey(index int, x *bzl.StringExpr) stringSortKey {
 	key := stringSortKey{
 		value:    x.Value,
 		original: index,


### PR DESCRIPTION
* generator.KeyValue and GlobValue are moved to rule.
* generator.newValue is moved and renamed to rule.ExprFromValue.
* generator.newRule and emptyRule and removed to rule
  temporarily. These will be replaced with the new rule editing
  abstraction soon.
* generator/sort_labels.go is moved to rule temporarily. The rule
  editing abstraction will do this automatically.
* packages.PlatformStrings is moved to rule.