### PR TITLE
Set importmap in vendor to prefix concatenated with relative path

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -558,7 +558,7 @@ go_library(
 go_library(
     name = "go_default_library",
     srcs = ["bar.go"],
-    importmap = "banana/vendor/golang.org/x/bar",
+    importmap = "example.com/foo/vendor/golang.org/x/bar",
     importpath = "golang.org/x/bar",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/baz:go_default_library"],
@@ -967,7 +967,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["foo.go"],
-    importmap = "sub/vendor/example.com/foo",
+    importmap = "example.com/repo/sub/vendor/example.com/foo",
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
 )

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -207,16 +207,19 @@ func (pb *packageBuilder) inferImportPath(c *config.Config) error {
 	if pb.importPath != "" {
 		log.Panic("importPath already set")
 	}
-	if pb.rel == c.GoPrefixRel {
-		if c.GoPrefix == "" {
-			return fmt.Errorf("in directory %q, prefix is empty, so importpath would be empty for rules. Set a prefix with a '# gazelle:prefix' comment or with -go_prefix on the command line.", pb.dir)
-		}
-		pb.importPath = c.GoPrefix
-	} else {
-		fromPrefixRel := strings.TrimPrefix(pb.rel, c.GoPrefixRel+"/")
-		pb.importPath = path.Join(c.GoPrefix, fromPrefixRel)
+	pb.importPath = inferImportPath(c, pb.rel)
+	if pb.importPath == "" {
+		return fmt.Errorf("in directory %q, prefix is empty, so importpath would be empty for rules. Set a prefix with a '# gazelle:prefix' comment or with -go_prefix on the command line.", pb.dir)
 	}
 	return nil
+}
+
+func inferImportPath(c *config.Config, rel string) string {
+	if rel == c.GoPrefixRel {
+		return c.GoPrefix
+	}
+	fromPrefixRel := strings.TrimPrefix(rel, c.GoPrefixRel+"/")
+	return path.Join(c.GoPrefix, fromPrefixRel)
 }
 
 func (pb *packageBuilder) build() *Package {

--- a/internal/packages/walk.go
+++ b/internal/packages/walk.go
@@ -127,10 +127,12 @@ func Walk(c *config.Config, root string, f WalkFunc) {
 		// set an empty prefix.
 		if path.Base(rel) == "vendor" {
 			cCopy := *c
+			if cCopy.GoImportMapPrefix == "" {
+				cCopy.GoImportMapPrefix = inferImportPath(c, rel)
+				cCopy.GoImportMapPrefixRel = rel
+			}
 			cCopy.GoPrefix = ""
 			cCopy.GoPrefixRel = rel
-			cCopy.GoImportMapPrefix = path.Join(c.RepoName, rel)
-			cCopy.GoImportMapPrefixRel = rel
 			c = &cCopy
 		}
 		var directives []config.Directive


### PR DESCRIPTION
Previously, when entering a vendor directory, the importmap prefix was
set to the workspace name (read from WORKSPACE) concatenated with the
relative path in the repository. This was originally intended to be
just a unique value for disambiguating packages.

importmap is now used when formatting source file names. In
particular, it is used to place files in go_path. Gazelle should make
importmaps match what is expected in a GOPATH directory as much as
possible.

Unfortunately, this will result in some build file churn, but it seems
much better to fix this here than to add convoluted, error-prone logic
to go_path and anything else that uses importmap.

Fixes bazelbuild/rules_go#1509
Fixes bazelbuild/rules_go#1450
Fixes bazelbuild/rules_go#1406