### PR TITLE
fix: only migrate library attributes for Go rules

### DIFF
--- a/internal/merger/fix.go
+++ b/internal/merger/fix.go
@@ -55,6 +55,9 @@ func FixFile(c *config.Config, f *rule.File) {
 // no keep comment on "library" and no existing "embed" attribute.
 func migrateLibraryEmbed(c *config.Config, f *rule.File) {
 	for _, r := range f.Rules {
+		if !isGoRule(r.Kind()) {
+			continue
+		}
 		libExpr := r.Attr("library")
 		if libExpr == nil || rule.ShouldKeep(libExpr) || r.Attr("embed") != nil {
 			continue

--- a/internal/merger/fix_test.go
+++ b/internal/merger/fix_test.go
@@ -57,6 +57,35 @@ go_test(
     embed = [":go_default_library"],
 )
 `,
+		}, {
+			// verifies #211
+			desc: "other library not migrated",
+			old: `
+gomock(
+    name = "stripe_mock",
+    out = "stripe_mock_test.go",
+    library = ":go_default_library",
+    interfaces = [
+        "stSubscriptions",
+        "stCustomers",
+    ],
+    package = "main",
+    source = "stripe.go",
+)
+`,
+			want: `
+gomock(
+    name = "stripe_mock",
+    out = "stripe_mock_test.go",
+    library = ":go_default_library",
+    interfaces = [
+        "stSubscriptions",
+        "stCustomers",
+    ],
+    package = "main",
+    source = "stripe.go",
+)
+`,
 		},
 		// migrateGrpcCompilers tests
 		{


### PR DESCRIPTION
migrateLibraryEmbed was converting library attributes to embed in all
rules, including rules not generated by Gazelle. We should only do
this for Go rules.

Fixes #211