### PR TITLE
Refactor configuration to support multiple languages

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/config:go_default_library",
         "//internal/generator:go_default_library",
         "//internal/label:go_default_library",
+        "//internal/labeler:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
         "//internal/repos:go_default_library",

--- a/cmd/gazelle/gazelle.go
+++ b/cmd/gazelle/gazelle.go
@@ -39,6 +39,18 @@ var commandFromName = map[string]command{
 	"update-repos": updateReposCmd,
 }
 
+var nameFromCommand = []string{
+	// keep in sync with definition above
+	"update",
+	"fix",
+	"update-repos",
+	"help",
+}
+
+func (cmd command) String() string {
+	return nameFromCommand[cmd]
+}
+
 func main() {
 	log.SetPrefix("gazelle: ")
 	log.SetFlags(0) // don't print timestamps

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -6,12 +6,13 @@ go_library(
         "config.go",
         "constants.go",
         "directives.go",
-        "platform.go",
-        "types.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/config",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/bazelbuild/buildtools/build:go_default_library"],
+    deps = [
+        "//internal/rule:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+    ],
 )
 
 go_test(
@@ -22,5 +23,8 @@ go_test(
         "directives_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/bazelbuild/buildtools/build:go_default_library"],
+    deps = [
+        "//internal/rule:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+    ],
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,15 +16,26 @@ limitations under the License.
 package config
 
 import (
+	"flag"
 	"fmt"
 	"go/build"
 	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 )
 
-// Config holds information about how Gazelle should run. This is mostly
-// based on command-line arguments.
+// Config holds information about how Gazelle should run. This is based on
+// command line arguments, directives, other hints in build files.
+//
+// A Config applies to a single directory. A Config is created for the
+// repository root directory, then copied and modified for each subdirectory.
+//
+// Config itself contains only general information. Most configuration
+// information is language-specific and is stored in Exts. This information
+// is modified by extensions that implement Configurer.
 type Config struct {
-	// Dirs is a list of absolute paths to directories where Gazelle should run.
+	// Dirs is a list of absolute, canonical paths to directories where Gazelle
+	// should run.
 	Dirs []string
 
 	// RepoRoot is the absolute, canonical path to the root directory of the
@@ -38,6 +49,9 @@ type Config struct {
 	// build files. Some repositories may have files named "BUILD" that are not
 	// used by Bazel and should be ignored. Must contain at least one string.
 	ValidBuildFileNames []string
+
+	// TODO(jayconrod): move language-specific values below this point into
+	// extensions.
 
 	// GenericTags is a set of build constraints that are true on all platforms.
 	// It should not be nil.
@@ -63,6 +77,9 @@ type Config struct {
 
 	// ShouldFix determines whether Gazelle attempts to remove and replace
 	// usage of deprecated rules.
+	// TODO(jayconrod): move into extension defined in fix-update.go. This is
+	// used to infer the proto mode, but we'll stop supporting the legacy proto
+	// mode in the future.
 	ShouldFix bool
 
 	// DepMode determines how imports outside of GoPrefix are resolved.
@@ -73,6 +90,31 @@ type Config struct {
 
 	// ProtoModeExplicit indicates whether the proto mode was set explicitly.
 	ProtoModeExplicit bool
+
+	// Exts is a set of configurable extensions. Generally, each language
+	// has its own set of extensions, but other modules may provide their own
+	// extensions as well. Values in here may be populated by command line
+	// arguments, directives in build files, or other mechanisms.
+	Exts map[string]interface{}
+}
+
+func New() *Config {
+	return &Config{
+		ValidBuildFileNames: DefaultValidBuildFileNames,
+		Exts:                make(map[string]interface{}),
+	}
+}
+
+// Clone creates a copy of the configuration for use in a subdirectory.
+// Note that the Exts map is copied, but its contents are not.
+// Configurer.Configure should do this, if needed.
+func (c *Config) Clone() *Config {
+	cc := *c
+	cc.Exts = make(map[string]interface{})
+	for k, v := range c.Exts {
+		cc.Exts[k] = v
+	}
+	return &cc
 }
 
 var DefaultValidBuildFileNames = []string{"BUILD.bazel", "BUILD"}
@@ -117,6 +159,70 @@ func (c *Config) PreprocessTags() {
 		c.GenericTags = make(BuildTags)
 	}
 	c.GenericTags["gc"] = true
+}
+
+// Configurer is the interface for language or library-specific configuration
+// extensions. Most (ideally all) modifications to Config should happen
+// via this interface.
+type Configurer interface {
+	// RegisterFlags registers command-line flags used by the extension. This
+	// method is called once with the root configuration when Gazelle
+	// starts. RegisterFlags may set an initial values in Config.Exts. When flags
+	// are set, they should modify these values.
+	RegisterFlags(fs *flag.FlagSet, cmd string, c *Config)
+
+	// CheckFlags validates the configuration after command line flags are parsed.
+	// This is called once with the root configuration when Gazelle starts.
+	// CheckFlags may set default values in flags or make implied changes.
+	CheckFlags(c *Config) error
+
+	// KnownDirectives returns a list of directive keys that this Configurer can
+	// interpret. Gazelle prints errors for directives that are not recoginized by
+	// any Configurer.
+	KnownDirectives() []string
+
+	// Configure modifies the configuration using directives and other information
+	// extracted from a build file. Configure is called in each directory.
+	//
+	// c is the configuration for the current directory. It starts out as a copy
+	// of the configuration for the parent directory.
+	//
+	// rel is the slash-separated relative path from the repository root to
+	// the current directory. It is "" for the root directory itself.
+	//
+	// f is the build file for the current directory or nil if there is no
+	// existing build file.
+	Configure(c *Config, rel string, f *rule.File)
+}
+
+// CommonConfigurer handles language-agnostic command-line flags and directives,
+// i.e., those that apply to Config itself and not to Config.Exts.
+type CommonConfigurer struct {
+	buildFileNames string
+}
+
+func (cc *CommonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *Config) {
+	fs.StringVar(&cc.buildFileNames, "build_file_name", strings.Join(DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
+}
+
+func (cc *CommonConfigurer) CheckFlags(c *Config) error {
+	c.ValidBuildFileNames = strings.Split(cc.buildFileNames, ",")
+	return nil
+}
+
+func (cc *CommonConfigurer) KnownDirectives() []string {
+	return []string{"build_file_name"}
+}
+
+func (cc *CommonConfigurer) Configure(c *Config, rel string, f *rule.File) {
+	if f == nil {
+		return
+	}
+	for _, d := range f.Directives {
+		if d.Key == "build_file_name" {
+			c.ValidBuildFileNames = strings.Split(d.Value, ",")
+		}
+	}
 }
 
 // CheckPrefix checks that a string may be used as a prefix. We forbid local

--- a/internal/generator/BUILD.bazel
+++ b/internal/generator/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
-        "//internal/label:go_default_library",
+        "//internal/labeler:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
         "//internal/pathtools:go_default_library",
@@ -28,7 +28,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//internal/config:go_default_library",
-        "//internal/label:go_default_library",
+        "//internal/labeler:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/packages:go_default_library",
         "//internal/rule:go_default_library",

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
-	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 	"github.com/bazelbuild/bazel-gazelle/internal/merger"
 	"github.com/bazelbuild/bazel-gazelle/internal/packages"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
@@ -31,7 +31,7 @@ import (
 
 // NewGenerator returns a new instance of Generator.
 // "oldFile" is the existing build file. May be nil.
-func NewGenerator(c *config.Config, l *label.Labeler, oldFile *rule.File) *Generator {
+func NewGenerator(c *config.Config, l *labeler.Labeler, oldFile *rule.File) *Generator {
 	shouldSetVisibility := oldFile == nil || !hasDefaultVisibility(oldFile)
 	return &Generator{c: c, l: l, shouldSetVisibility: shouldSetVisibility}
 }
@@ -39,7 +39,7 @@ func NewGenerator(c *config.Config, l *label.Labeler, oldFile *rule.File) *Gener
 // Generator generates Bazel build rules for Go build targets.
 type Generator struct {
 	c                   *config.Config
-	l                   *label.Labeler
+	l                   *labeler.Labeler
 	shouldSetVisibility bool
 }
 

--- a/internal/label/BUILD.bazel
+++ b/internal/label/BUILD.bazel
@@ -2,24 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "label.go",
-        "labeler.go",
-    ],
+    srcs = ["label.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/label",
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//internal/config:go_default_library",
-        "//internal/pathtools:go_default_library",
-    ],
+    deps = ["//internal/pathtools:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "label_test.go",
-        "labeler_test.go",
-    ],
+    srcs = ["label_test.go"],
     embed = [":go_default_library"],
-    deps = ["//internal/config:go_default_library"],
 )

--- a/internal/labeler/BUILD.bazel
+++ b/internal/labeler/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["labeler.go"],
+    importpath = "github.com/bazelbuild/bazel-gazelle/internal/labeler",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/config:go_default_library",
+        "//internal/label:go_default_library",
+        "//internal/pathtools:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["labeler_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//internal/config:go_default_library"],
+)

--- a/internal/labeler/labeler.go
+++ b/internal/labeler/labeler.go
@@ -13,15 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package label
+package labeler
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 )
 
 // Labeler generates Bazel labels for rules, based on their locations
 // within the repository.
+//
+// TODO(jayconrod): delete this type (and this package). When we have
+// multiple rule generators for different languages, it doesn't make sense
+// to group this logic in a single place.
 type Labeler struct {
 	c *config.Config
 }
@@ -30,23 +35,23 @@ func NewLabeler(c *config.Config) *Labeler {
 	return &Labeler{c}
 }
 
-func (l *Labeler) LibraryLabel(rel string) Label {
-	return Label{Pkg: rel, Name: config.DefaultLibName}
+func (l *Labeler) LibraryLabel(rel string) label.Label {
+	return label.Label{Pkg: rel, Name: config.DefaultLibName}
 }
 
-func (l *Labeler) TestLabel(rel string) Label {
-	return Label{Pkg: rel, Name: config.DefaultTestName}
+func (l *Labeler) TestLabel(rel string) label.Label {
+	return label.Label{Pkg: rel, Name: config.DefaultTestName}
 }
 
-func (l *Labeler) BinaryLabel(rel string) Label {
+func (l *Labeler) BinaryLabel(rel string) label.Label {
 	name := pathtools.RelBaseName(rel, l.c.GoPrefix, l.c.RepoRoot)
-	return Label{Pkg: rel, Name: name}
+	return label.Label{Pkg: rel, Name: name}
 }
 
-func (l *Labeler) ProtoLabel(rel, name string) Label {
-	return Label{Pkg: rel, Name: name + "_proto"}
+func (l *Labeler) ProtoLabel(rel, name string) label.Label {
+	return label.Label{Pkg: rel, Name: name + "_proto"}
 }
 
-func (l *Labeler) GoProtoLabel(rel, name string) Label {
-	return Label{Pkg: rel, Name: name + "_go_proto"}
+func (l *Labeler) GoProtoLabel(rel, name string) label.Label {
+	return label.Label{Pkg: rel, Name: name + "_go_proto"}
 }

--- a/internal/labeler/labeler_test.go
+++ b/internal/labeler/labeler_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package label
+package labeler
 
 import (
 	"testing"
@@ -23,21 +23,21 @@ import (
 
 func TestLabelerGo(t *testing.T) {
 	for _, tc := range []struct {
-		name, rel                             string
+		name, rel                  string
 		wantLib, wantBin, wantTest string
 	}{
 		{
-			name:      "root_hierarchical",
-			rel:       "",
-			wantLib:   "//:go_default_library",
-			wantBin:   "//:root",
-			wantTest:  "//:go_default_test",
+			name:     "root_hierarchical",
+			rel:      "",
+			wantLib:  "//:go_default_library",
+			wantBin:  "//:root",
+			wantTest: "//:go_default_test",
 		}, {
-			name:      "sub_hierarchical",
-			rel:       "sub",
-			wantLib:   "//sub:go_default_library",
-			wantBin:   "//sub",
-			wantTest:  "//sub:go_default_test",
+			name:     "sub_hierarchical",
+			rel:      "sub",
+			wantLib:  "//sub:go_default_library",
+			wantBin:  "//sub",
+			wantTest: "//sub:go_default_test",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/merger/BUILD.bazel
+++ b/internal/merger/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
-        "//internal/label:go_default_library",
         "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
@@ -27,6 +26,5 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -27,31 +27,31 @@ import (
 var (
 	// PreResolveAttrs is the set of attributes that should be merged before
 	// dependency resolution, i.e., everything except deps.
-	PreResolveAttrs config.MergeableAttrs
+	PreResolveAttrs rule.MergeableAttrs
 
 	// PostResolveAttrs is the set of attributes that should be merged after
 	// dependency resolution, i.e., deps.
-	PostResolveAttrs config.MergeableAttrs
+	PostResolveAttrs rule.MergeableAttrs
 
 	// BuildAttrs is the union of PreResolveAttrs and PostResolveAttrs.
-	BuildAttrs config.MergeableAttrs
+	BuildAttrs rule.MergeableAttrs
 
 	// RepoAttrs is the set of attributes that should be merged in repository
 	// rules in WORKSPACE.
-	RepoAttrs config.MergeableAttrs
+	RepoAttrs rule.MergeableAttrs
 
 	// NonEmptyAttrs is the set of attributes that disqualify a rule from being
 	// deleted after merge.
-	NonEmptyAttrs config.MergeableAttrs
+	NonEmptyAttrs rule.MergeableAttrs
 )
 
 func init() {
-	PreResolveAttrs = make(config.MergeableAttrs)
-	PostResolveAttrs = make(config.MergeableAttrs)
-	RepoAttrs = make(config.MergeableAttrs)
-	NonEmptyAttrs = make(config.MergeableAttrs)
+	PreResolveAttrs = make(rule.MergeableAttrs)
+	PostResolveAttrs = make(rule.MergeableAttrs)
+	RepoAttrs = make(rule.MergeableAttrs)
+	NonEmptyAttrs = make(rule.MergeableAttrs)
 	for _, set := range []struct {
-		mergeableAttrs config.MergeableAttrs
+		mergeableAttrs rule.MergeableAttrs
 		kinds, attrs   []string
 	}{
 		{
@@ -180,8 +180,8 @@ func init() {
 			}
 		}
 	}
-	BuildAttrs = make(config.MergeableAttrs)
-	for _, mattrs := range []config.MergeableAttrs{PreResolveAttrs, PostResolveAttrs} {
+	BuildAttrs = make(rule.MergeableAttrs)
+	for _, mattrs := range []rule.MergeableAttrs{PreResolveAttrs, PostResolveAttrs} {
 		for kind, attrs := range mattrs {
 			if BuildAttrs[kind] == nil {
 				BuildAttrs[kind] = make(map[string]bool)
@@ -198,7 +198,7 @@ func init() {
 // rules in empty with matching rules in f and deletes rules that
 // are empty after merging. attrs is the set of attributes to merge. Attributes
 // not in this set will be left alone if they already exist.
-func MergeFile(oldFile *rule.File, emptyRules, genRules []*rule.Rule, attrs config.MergeableAttrs) {
+func MergeFile(oldFile *rule.File, emptyRules, genRules []*rule.Rule, attrs rule.MergeableAttrs) {
 	// Merge empty rules into the file and delete any rules which become empty.
 	for _, emptyRule := range emptyRules {
 		if oldRule, _ := match(oldFile.Rules, emptyRule); oldRule != nil {

--- a/internal/packages/BUILD.bazel
+++ b/internal/packages/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//internal/config:go_default_library",
         "//internal/pathtools:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )
 
@@ -34,6 +33,5 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/packages/fileinfo.go
+++ b/internal/packages/fileinfo.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 )
 
 // fileInfo holds information used to decide how to build a file. This
@@ -111,12 +112,12 @@ func (g tagGroup) check(c *config.Config, os, arch string) bool {
 			continue
 		}
 		var match bool
-		if _, ok := config.KnownOSSet[t]; ok {
+		if _, ok := rule.KnownOSSet[t]; ok {
 			if os == "" {
 				return false
 			}
 			match = os == t
-		} else if _, ok := config.KnownArchSet[t]; ok {
+		} else if _, ok := rule.KnownArchSet[t]; ok {
 			if arch == "" {
 				return false
 			}
@@ -221,12 +222,12 @@ func fileNameInfo(dir, rel, name string) fileInfo {
 		l = l[:len(l)-1]
 	}
 	switch {
-	case len(l) >= 3 && config.KnownOSSet[l[len(l)-2]] && config.KnownArchSet[l[len(l)-1]]:
+	case len(l) >= 3 && rule.KnownOSSet[l[len(l)-2]] && rule.KnownArchSet[l[len(l)-1]]:
 		goos = l[len(l)-2]
 		goarch = l[len(l)-1]
-	case len(l) >= 2 && config.KnownOSSet[l[len(l)-1]]:
+	case len(l) >= 2 && rule.KnownOSSet[l[len(l)-1]]:
 		goos = l[len(l)-1]
-	case len(l) >= 2 && config.KnownArchSet[l[len(l)-1]]:
+	case len(l) >= 2 && rule.KnownArchSet[l[len(l)-1]]:
 		goarch = l[len(l)-1]
 	}
 
@@ -334,11 +335,11 @@ func isOSArchSpecific(info fileInfo, cgoTags tagLine) (osSpecific, archSpecific 
 				if strings.HasPrefix(tag, "!") {
 					tag = tag[1:]
 				}
-				_, osOk := config.KnownOSSet[tag]
+				_, osOk := rule.KnownOSSet[tag]
 				if osOk {
 					osSpecific = true
 				}
-				_, archOk := config.KnownArchSet[tag]
+				_, archOk := rule.KnownArchSet[tag]
 				if archOk {
 					archSpecific = true
 				}

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -122,7 +122,7 @@ type platformStringInfo struct {
 	set       platformStringSet
 	oss       map[string]bool
 	archs     map[string]bool
-	platforms map[config.Platform]bool
+	platforms map[rule.Platform]bool
 }
 
 type platformStringSet int
@@ -301,7 +301,7 @@ func getPlatformStringsAddFunction(c *config.Config, info fileInfo, cgoTags tagL
 
 	case isOSSpecific && !isArchSpecific:
 		var osMatch []string
-		for _, os := range config.KnownOSs {
+		for _, os := range rule.KnownOSs {
 			if checkConstraints(c, os, "", info.goos, info.goarch, info.tags, cgoTags) {
 				osMatch = append(osMatch, os)
 			}
@@ -316,7 +316,7 @@ func getPlatformStringsAddFunction(c *config.Config, info fileInfo, cgoTags tagL
 
 	case !isOSSpecific && isArchSpecific:
 		var archMatch []string
-		for _, arch := range config.KnownArchs {
+		for _, arch := range rule.KnownArchs {
 			if checkConstraints(c, "", arch, info.goos, info.goarch, info.tags, cgoTags) {
 				archMatch = append(archMatch, arch)
 			}
@@ -330,8 +330,8 @@ func getPlatformStringsAddFunction(c *config.Config, info fileInfo, cgoTags tagL
 		}
 
 	default:
-		var platformMatch []config.Platform
-		for _, platform := range config.KnownPlatforms {
+		var platformMatch []rule.Platform
+		for _, platform := range rule.KnownPlatforms {
 			if checkConstraints(c, platform.OS, platform.Arch, info.goos, info.goarch, info.tags, cgoTags) {
 				platformMatch = append(platformMatch, platform)
 			}
@@ -374,8 +374,8 @@ func (sb *platformStringsBuilder) addOSString(s string, oss []string) {
 	default:
 		si.convertToPlatforms()
 		for _, os := range oss {
-			for _, arch := range config.KnownOSArchs[os] {
-				si.platforms[config.Platform{OS: os, Arch: arch}] = true
+			for _, arch := range rule.KnownOSArchs[os] {
+				si.platforms[rule.Platform{OS: os, Arch: arch}] = true
 			}
 		}
 	}
@@ -401,22 +401,22 @@ func (sb *platformStringsBuilder) addArchString(s string, archs []string) {
 	default:
 		si.convertToPlatforms()
 		for _, arch := range archs {
-			for _, os := range config.KnownArchOSs[arch] {
-				si.platforms[config.Platform{OS: os, Arch: arch}] = true
+			for _, os := range rule.KnownArchOSs[arch] {
+				si.platforms[rule.Platform{OS: os, Arch: arch}] = true
 			}
 		}
 	}
 	sb.strs[s] = si
 }
 
-func (sb *platformStringsBuilder) addPlatformString(s string, platforms []config.Platform) {
+func (sb *platformStringsBuilder) addPlatformString(s string, platforms []rule.Platform) {
 	if sb.strs == nil {
 		sb.strs = make(map[string]platformStringInfo)
 	}
 	si, ok := sb.strs[s]
 	if !ok {
 		si.set = platformSet
-		si.platforms = make(map[config.Platform]bool)
+		si.platforms = make(map[rule.Platform]bool)
 	}
 	switch si.set {
 	case genericSet:
@@ -452,7 +452,7 @@ func (sb *platformStringsBuilder) build() rule.PlatformStrings {
 			}
 		case platformSet:
 			if ps.Platform == nil {
-				ps.Platform = make(map[config.Platform][]string)
+				ps.Platform = make(map[rule.Platform][]string)
 			}
 			for p, _ := range si.platforms {
 				ps.Platform[p] = append(ps.Platform[p], s)
@@ -486,19 +486,19 @@ func (si *platformStringInfo) convertToPlatforms() {
 		return
 	case osSet:
 		si.set = platformSet
-		si.platforms = make(map[config.Platform]bool)
+		si.platforms = make(map[rule.Platform]bool)
 		for os, _ := range si.oss {
-			for _, arch := range config.KnownOSArchs[os] {
-				si.platforms[config.Platform{OS: os, Arch: arch}] = true
+			for _, arch := range rule.KnownOSArchs[os] {
+				si.platforms[rule.Platform{OS: os, Arch: arch}] = true
 			}
 		}
 		si.oss = nil
 	case archSet:
 		si.set = platformSet
-		si.platforms = make(map[config.Platform]bool)
+		si.platforms = make(map[rule.Platform]bool)
 		for arch, _ := range si.archs {
-			for _, os := range config.KnownArchOSs[arch] {
-				si.platforms[config.Platform{OS: os, Arch: arch}] = true
+			for _, os := range rule.KnownArchOSs[arch] {
+				si.platforms[rule.Platform{OS: os, Arch: arch}] = true
 			}
 		}
 		si.archs = nil

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -52,8 +52,8 @@ func TestAddPlatformStrings(t *testing.T) {
 			desc:     "os and arch",
 			filename: "foo_linux_amd64.go",
 			want: rule.PlatformStrings{
-				Platform: map[config.Platform][]string{
-					config.Platform{OS: "linux", Arch: "amd64"}: []string{"foo_linux_amd64.go"},
+				Platform: map[rule.Platform][]string{
+					rule.Platform{OS: "linux", Arch: "amd64"}: []string{"foo_linux_amd64.go"},
 				},
 			},
 		}, {
@@ -61,8 +61,8 @@ func TestAddPlatformStrings(t *testing.T) {
 			filename: "foo.go",
 			tags:     []tagLine{{{"solaris", "!arm"}}},
 			want: rule.PlatformStrings{
-				Platform: map[config.Platform][]string{
-					config.Platform{OS: "solaris", Arch: "amd64"}: []string{"foo.go"},
+				Platform: map[rule.Platform][]string{
+					rule.Platform{OS: "solaris", Arch: "amd64"}: []string{"foo.go"},
 				},
 			},
 		},
@@ -112,21 +112,21 @@ func TestDuplicatePlatformStrings(t *testing.T) {
 				sb.addArchString("a", []string{"mips"})
 			},
 			want: rule.PlatformStrings{
-				Platform: map[config.Platform][]string{
-					config.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
-					config.Platform{OS: "linux", Arch: "mips"}:    {"a"},
+				Platform: map[rule.Platform][]string{
+					rule.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
+					rule.Platform{OS: "linux", Arch: "mips"}:    {"a"},
 				},
 			},
 		}, {
 			desc: "platform os",
 			add: func(sb *platformStringsBuilder) {
-				sb.addPlatformString("a", []config.Platform{{OS: "linux", Arch: "mips"}})
+				sb.addPlatformString("a", []rule.Platform{{OS: "linux", Arch: "mips"}})
 				sb.addOSString("a", []string{"solaris"})
 			},
 			want: rule.PlatformStrings{
-				Platform: map[config.Platform][]string{
-					config.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
-					config.Platform{OS: "linux", Arch: "mips"}:    {"a"},
+				Platform: map[rule.Platform][]string{
+					rule.Platform{OS: "solaris", Arch: "amd64"}: {"a"},
+					rule.Platform{OS: "linux", Arch: "mips"}:    {"a"},
 				},
 			},
 		},

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+        "//internal/rule:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )

--- a/internal/resolve/BUILD.bazel
+++ b/internal/resolve/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//internal/config:go_default_library",
         "//internal/label:go_default_library",
+        "//internal/labeler:go_default_library",
         "//internal/pathtools:go_default_library",
         "//internal/repos:go_default_library",
         "//internal/rule:go_default_library",
@@ -32,7 +33,9 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/label:go_default_library",
+        "//internal/labeler:go_default_library",
         "//internal/repos:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
@@ -33,7 +34,7 @@ import (
 // import statements in protos) into Bazel labels.
 type Resolver struct {
 	c        *config.Config
-	l        *label.Labeler
+	l        *labeler.Labeler
 	ix       *RuleIndex
 	external nonlocalResolver
 }
@@ -45,7 +46,7 @@ type nonlocalResolver interface {
 	resolve(imp string) (label.Label, error)
 }
 
-func NewResolver(c *config.Config, l *label.Labeler, ix *RuleIndex, rc *repos.RemoteCache) *Resolver {
+func NewResolver(c *config.Config, l *labeler.Labeler, ix *RuleIndex, rc *repos.RemoteCache) *Resolver {
 	var e nonlocalResolver
 	switch c.DepMode {
 	case config.ExternalMode:

--- a/internal/resolve/resolve_external.go
+++ b/internal/resolve/resolve_external.go
@@ -17,6 +17,7 @@ package resolve
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 )
@@ -28,13 +29,13 @@ import (
 // guidelines in http://bazel.io/docs/be/functions.html#workspace. The remaining
 // portion of the import path is treated as the package name.
 type externalResolver struct {
-	l  *label.Labeler
+	l  *labeler.Labeler
 	rc *repos.RemoteCache
 }
 
 var _ nonlocalResolver = (*externalResolver)(nil)
 
-func newExternalResolver(l *label.Labeler, rc *repos.RemoteCache) *externalResolver {
+func newExternalResolver(l *labeler.Labeler, rc *repos.RemoteCache) *externalResolver {
 	return &externalResolver{l: l, rc: rc}
 }
 

--- a/internal/resolve/resolve_external_test.go
+++ b/internal/resolve/resolve_external_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 
 	"golang.org/x/tools/go/vcs"
@@ -68,7 +69,7 @@ func TestExternalResolver(t *testing.T) {
 }
 
 func newStubExternalResolver(knownRepos []repos.Repo) *externalResolver {
-	l := label.NewLabeler(&config.Config{})
+	l := labeler.NewLabeler(&config.Config{})
 	rc := newStubRemoteCache(knownRepos)
 	return newExternalResolver(l, rc)
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
@@ -33,7 +34,7 @@ func TestResolveGoIndex(t *testing.T) {
 		GoPrefix: "example.com/repo",
 		DepMode:  config.VendorMode,
 	}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 
 	type fileSpec struct {
 		rel, content string
@@ -237,7 +238,7 @@ func TestResolveProtoIndex(t *testing.T) {
 		GoPrefix: "example.com/repo",
 		DepMode:  config.VendorMode,
 	}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 
 	buildContent := []byte(`
 proto_library(
@@ -320,7 +321,7 @@ func TestResolveGoLocal(t *testing.T) {
 		},
 	} {
 		c := &config.Config{GoPrefix: "example.com/repo"}
-		l := label.NewLabeler(c)
+		l := labeler.NewLabeler(c)
 		ix := NewRuleIndex()
 		r := NewResolver(c, l, ix, nil)
 		label, err := r.resolveGo(spec.importpath, spec.from)
@@ -336,7 +337,7 @@ func TestResolveGoLocal(t *testing.T) {
 
 func TestResolveGoLocalError(t *testing.T) {
 	c := &config.Config{GoPrefix: "example.com/repo"}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 	ix := NewRuleIndex()
 	rc := newStubRemoteCache(nil)
 	r := NewResolver(c, l, ix, rc)
@@ -359,7 +360,7 @@ func TestResolveGoLocalError(t *testing.T) {
 
 func TestResolveGoEmptyPrefix(t *testing.T) {
 	c := &config.Config{}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 	ix := NewRuleIndex()
 	r := NewResolver(c, l, ix, nil)
 
@@ -431,7 +432,7 @@ func TestResolveProto(t *testing.T) {
 				GoPrefix: prefix,
 				DepMode:  tc.depMode,
 			}
-			l := label.NewLabeler(c)
+			l := labeler.NewLabeler(c)
 			ix := NewRuleIndex()
 			r := NewResolver(c, l, ix, nil)
 
@@ -460,7 +461,7 @@ func TestResolveProto(t *testing.T) {
 
 func TestResolveGoWKT(t *testing.T) {
 	c := &config.Config{}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 	ix := NewRuleIndex()
 	r := NewResolver(c, l, ix, nil)
 
@@ -497,7 +498,7 @@ func TestResolveGoWKT(t *testing.T) {
 
 func TestResolveGoSkipEmbeds(t *testing.T) {
 	c := &config.Config{}
-	l := label.NewLabeler(c)
+	l := labeler.NewLabeler(c)
 	ix := NewRuleIndex()
 	r := NewResolver(c, l, ix, nil)
 

--- a/internal/resolve/resolve_vendored.go
+++ b/internal/resolve/resolve_vendored.go
@@ -17,16 +17,17 @@ package resolve
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/labeler"
 )
 
 // vendoredResolver resolves external packages as packages in vendor/.
 type vendoredResolver struct {
-	l *label.Labeler
+	l *labeler.Labeler
 }
 
 var _ nonlocalResolver = (*vendoredResolver)(nil)
 
-func newVendoredResolver(l *label.Labeler) *vendoredResolver {
+func newVendoredResolver(l *labeler.Labeler) *vendoredResolver {
 	return &vendoredResolver{l}
 }
 

--- a/internal/rule/BUILD.bazel
+++ b/internal/rule/BUILD.bazel
@@ -3,17 +3,19 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "directives.go",
         "expr.go",
         "merge.go",
+        "platform.go",
         "platform_strings.go",
         "rule.go",
         "sort_labels.go",
+        "types.go",
         "value.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/rule",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/config:go_default_library",
         "//internal/label:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/tables:go_default_library",
@@ -22,7 +24,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["rule_test.go"],
+    srcs = [
+        "directives_test.go",
+        "rule_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["//vendor/github.com/bazelbuild/buildtools/build:go_default_library"],
 )

--- a/internal/rule/directives.go
+++ b/internal/rule/directives.go
@@ -1,0 +1,64 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"regexp"
+
+	bzl "github.com/bazelbuild/buildtools/build"
+)
+
+// Directive is a key-value pair extracted from a top-level comment in
+// a build file. Directives have the following format:
+//
+//     # gazelle:key value
+//
+// Keys may not contain spaces. Values may be empty and may contain spaces,
+// but surrounding space is trimmed.
+type Directive struct {
+	Key, Value string
+}
+
+// TODO(jayconrod): annotation directives will apply to an individual rule.
+// They must appear in the block of comments above that rule.
+
+// ParseDirectives scans f for Gazelle directives. The full list of directives
+// is returned. Errors are reported for unrecognized directives and directives
+// out of place (after the first statement).
+func ParseDirectives(f *bzl.File) []Directive {
+	var directives []Directive
+	parseComment := func(com bzl.Comment) {
+		match := directiveRe.FindStringSubmatch(com.Token)
+		if match == nil {
+			return
+		}
+		key, value := match[1], match[2]
+		directives = append(directives, Directive{key, value})
+	}
+
+	for _, s := range f.Stmt {
+		coms := s.Comment()
+		for _, com := range coms.Before {
+			parseComment(com)
+		}
+		for _, com := range coms.After {
+			parseComment(com)
+		}
+	}
+	return directives
+}
+
+var directiveRe = regexp.MustCompile(`^#\s*gazelle:(\w+)\s*(.*?)\s*$`)

--- a/internal/rule/directives_test.go
+++ b/internal/rule/directives_test.go
@@ -1,0 +1,63 @@
+/* Copyright 2017 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"reflect"
+	"testing"
+
+	bzl "github.com/bazelbuild/buildtools/build"
+)
+
+func TestParseDirectives(t *testing.T) {
+	for _, tc := range []struct {
+		desc, content string
+		want          []Directive
+	}{
+		{
+			desc: "empty file",
+		}, {
+			desc: "locations",
+			content: `# gazelle:ignore top
+
+#gazelle:ignore before
+foo(
+   "foo",  # gazelle:ignore inside
+) # gazelle:ignore suffix
+#gazelle:ignore after
+
+# gazelle:ignore bottom`,
+			want: []Directive{
+				{"ignore", "top"},
+				{"ignore", "before"},
+				{"ignore", "after"},
+				{"ignore", "bottom"},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := bzl.Parse("test.bazel", []byte(tc.content))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := ParseDirectives(f)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %#v ; want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rule/expr.go
+++ b/internal/rule/expr.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
@@ -273,16 +272,16 @@ func extractPlatformStringsExprs(expr bzl.Expr) (platformStringsExprs, error) {
 				if err != nil {
 					return platformStringsExprs{}, fmt.Errorf("expression could not be matched: dict key is not label: %q", k.Value)
 				}
-				if config.KnownOSSet[key.Name] {
+				if KnownOSSet[key.Name] {
 					dict = &ps.os
 					break
 				}
-				if config.KnownArchSet[key.Name] {
+				if KnownArchSet[key.Name] {
 					dict = &ps.arch
 					break
 				}
 				osArch := strings.Split(key.Name, "_")
-				if len(osArch) != 2 || !config.KnownOSSet[osArch[0]] || !config.KnownArchSet[osArch[1]] {
+				if len(osArch) != 2 || !KnownOSSet[osArch[0]] || !KnownArchSet[osArch[1]] {
 					return platformStringsExprs{}, fmt.Errorf("expression could not be matched: dict key contains unknown platform: %q", k.Value)
 				}
 				dict = &ps.platform

--- a/internal/rule/merge.go
+++ b/internal/rule/merge.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"sort"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
 
@@ -42,7 +41,7 @@ import (
 // marked with a "# keep" comment, values in the attribute not marked with
 // a "# keep" comment will be dropped. If the attribute is empty afterward,
 // it will be deleted.
-func MergeRules(src, dst *Rule, mergeable config.MergeableAttrs, filename string) {
+func MergeRules(src, dst *Rule, mergeable MergeableAttrs, filename string) {
 	if ShouldKeep(dst.call) {
 		return
 	}

--- a/internal/rule/platform.go
+++ b/internal/rule/platform.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package rule
 
 import (
 	"sort"

--- a/internal/rule/platform_strings.go
+++ b/internal/rule/platform_strings.go
@@ -18,8 +18,6 @@ package rule
 import (
 	"sort"
 	"strings"
-
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
 )
 
 // PlatformStrings contains a set of strings associated with a buildable
@@ -36,16 +34,16 @@ type PlatformStrings struct {
 	// Generic is a list of strings not specific to any platform.
 	Generic []string
 
-	// OS is a map from OS name (anything in config.KnownOSs) to
+	// OS is a map from OS name (anything in KnownOSs) to
 	// OS-specific strings.
 	OS map[string][]string
 
-	// Arch is a map from architecture name (anything in config.KnownArchs) to
+	// Arch is a map from architecture name (anything in KnownArchs) to
 	// architecture-specific strings.
 	Arch map[string][]string
 
 	// Platform is a map from platforms to OS and architecture-specific strings.
-	Platform map[config.Platform][]string
+	Platform map[Platform][]string
 }
 
 // HasExt returns whether this set contains a file with the given extension.
@@ -147,11 +145,11 @@ func (ps *PlatformStrings) MapSlice(f func([]string) ([]string, error)) (Platfor
 		return rm
 	}
 
-	mapPlatformMap := func(m map[config.Platform][]string) map[config.Platform][]string {
+	mapPlatformMap := func(m map[Platform][]string) map[Platform][]string {
 		if m == nil {
 			return nil
 		}
-		rm := make(map[config.Platform][]string)
+		rm := make(map[Platform][]string)
 		for k, ss := range m {
 			ss = mapSlice(ss)
 			if len(ss) > 0 {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -30,7 +30,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	bzl "github.com/bazelbuild/buildtools/build"
 	bt "github.com/bazelbuild/buildtools/tables"
 )
@@ -50,7 +49,7 @@ type File struct {
 
 	// Directives is a list of configuration directives found in top-level
 	// comments in the file. This should not be modified after the file is read.
-	Directives []config.Directive
+	Directives []Directive
 
 	// Loads is a list of load statements within the file. This should not
 	// be modified directly; use Load methods instead.
@@ -120,7 +119,7 @@ func ScanAST(bzlFile *bzl.File) *File {
 			}
 		}
 	}
-	f.Directives = config.ParseDirectives(bzlFile)
+	f.Directives = ParseDirectives(bzlFile)
 	return f
 }
 
@@ -566,7 +565,7 @@ func (r *Rule) Insert(f *File) {
 // IsEmpty returns true when the rule contains none of the attributes in attrs
 // for its kind. attrs should contain attributes that make the rule buildable
 // like srcs or deps and not descriptive attributes like name or visibility.
-func (r *Rule) IsEmpty(attrs config.MergeableAttrs) bool {
+func (r *Rule) IsEmpty(attrs MergeableAttrs) bool {
 	nonEmptyAttrs := attrs[r.kind]
 	if nonEmptyAttrs == nil {
 		return false

--- a/internal/rule/types.go
+++ b/internal/rule/types.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package rule
 
 // MergableAttrs is the set of attribute names for each kind of rule that
 // may be merged. When an attribute is mergeable, a generated value may

--- a/internal/rule/value.go
+++ b/internal/rule/value.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
 
@@ -86,7 +85,7 @@ func ExprFromValue(val interface{}) bzl.Expr {
 		sort.Sort(byString(rkeys))
 		args := make([]bzl.Expr, len(rkeys))
 		for i, rk := range rkeys {
-			label := fmt.Sprintf("@%s//go/platform:%s", config.RulesGoRepoName, mapKeyString(rk))
+			label := fmt.Sprintf("@io_bazel_rules_go//go/platform:%s", mapKeyString(rk))
 			k := &bzl.StringExpr{Value: label}
 			v := ExprFromValue(rv.MapIndex(rk).Interface())
 			if l, ok := v.(*bzl.ListExpr); ok {
@@ -160,7 +159,7 @@ func mapKeyString(k reflect.Value) string {
 	switch s := k.Interface().(type) {
 	case string:
 		return s
-	case config.Platform:
+	case Platform:
 		return s.String()
 	default:
 		log.Panicf("unexpected map key: %v", k)


### PR DESCRIPTION
This change makes Gazelle's configuration extensible, in preparation
for supporting multiple languages.

* Config now has an Exts field, which maps from extension names
  (usually language names) to extension values (interface{}).
* Added a Configurer interface, which allows implementors to register
  and check command-line flags and handle directives. Each language
  will implement this (as well as other modules that handle
  directives, like Walk).
* config.CommonConfigurer is an implementation of Configurer for
  language-agnostic functionality in config. Currently, it just
  handles -build_file_name.
* fix-update and Walk now use Configurer.
* Several types and constants are moved from config to rule to break
  circular dependencies, including Directive and Platform. rule no
  longer depends on config.
* label.Labeler is moved to a new package, Labeler in order to break
  circular dependencies. Labeler will be deleted later.

Related #136