### PR TITLE
More config refactoring

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,11 @@
 workspace(name = "bazel_gazelle")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_go",
-    sha256 = "c1f52b8789218bb1542ed362c4f7de7052abcf254d865d96fb7ba6d44bc15ee3",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz"],
+    commit = "1903997d0945ce92848447528718c7026b728f30",
+    remote = "https://github.com/bazelbuild/rules_go",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//internal/resolve:go_default_library",
         "//internal/rule:go_default_library",
         "//internal/version:go_default_library",
-        "//internal/wspace:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/rule:go_default_library",
+        "//internal/wspace:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/packages/walk.go
+++ b/internal/packages/walk.go
@@ -430,7 +430,7 @@ type walkConfigurer struct{}
 func (_ *walkConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 }
 
-func (_ *walkConfigurer) CheckFlags(c *config.Config) error {
+func (_ *walkConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 	return nil
 }
 


### PR DESCRIPTION
* Move handling of -repo_root to config.CommonConfigurer. -repo_root
  now behaves the same across commands: in fix and update, if
  -repo_root is unspecified, and one positional argument is given, we
  no longer search that for the repository root.
* Move fix, update, and update-repos flags into Configurers. This
  makes flag handling a lot more uniform. There are still a lot of Go
  flags in fix-update that will be moved later.
* Update to a new version of rules_go (bazel_test was broken with
  bazel 0.14. This has been fixed on master).