### PR TITLE
rule: separate private attributes from regular attributes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,11 @@
 workspace(name = "bazel_gazelle")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_go",
-    sha256 = "c1f52b8789218bb1542ed362c4f7de7052abcf254d865d96fb7ba6d44bc15ee3",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz"],
+    commit = "1903997d0945ce92848447528718c7026b728f30",
+    remote = "https://github.com/bazelbuild/rules_go",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -109,7 +109,7 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []*rule.Rule) 
 	}
 	imports := pkg.Proto.Imports
 	if !imports.IsEmpty() {
-		protoLibrary.SetAttr(config.GazelleImportsKey, imports)
+		protoLibrary.SetPrivateAttr(config.GazelleImportsKey, imports)
 	}
 
 	goProtoLibrary := rule.NewRule("go_proto_library", goProtoName)
@@ -123,7 +123,7 @@ func (g *Generator) generateProto(pkg *packages.Package) (string, []*rule.Rule) 
 		goProtoLibrary.SetAttr("visibility", visibility)
 	}
 	if !imports.IsEmpty() {
-		goProtoLibrary.SetAttr(config.GazelleImportsKey, imports)
+		goProtoLibrary.SetPrivateAttr(config.GazelleImportsKey, imports)
 	}
 
 	return goProtoName, []*rule.Rule{protoLibrary, goProtoLibrary}
@@ -222,7 +222,7 @@ func (g *Generator) setCommonAttrs(r *rule.Rule, pkgRel, visibility string, targ
 	}
 	imports := target.Imports
 	if !imports.IsEmpty() {
-		r.SetAttr(config.GazelleImportsKey, imports)
+		r.SetPrivateAttr(config.GazelleImportsKey, imports)
 	}
 }
 

--- a/internal/merger/BUILD.bazel
+++ b/internal/merger/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/config:go_default_library",
-        "//internal/label:go_default_library",
         "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
@@ -27,6 +26,5 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -110,7 +110,6 @@ func init() {
 			},
 			attrs: []string{
 				"deps",
-				config.GazelleImportsKey,
 			},
 		}, {
 			mergeableAttrs: RepoAttrs,

--- a/internal/packages/BUILD.bazel
+++ b/internal/packages/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//internal/config:go_default_library",
         "//internal/pathtools:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )
 
@@ -34,6 +33,5 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/rule:go_default_library",
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+        "//internal/rule:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )

--- a/internal/resolve/BUILD.bazel
+++ b/internal/resolve/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//internal/config:go_default_library",
         "//internal/label:go_default_library",
         "//internal/repos:go_default_library",
+        "//internal/rule:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/internal/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 // Resolver resolves import strings in source files (import paths in Go,
@@ -85,9 +86,12 @@ func (rslv *Resolver) ResolveRule(r *rule.Rule, pkgRel string) {
 		return
 	}
 
-	imports := r.Attr(config.GazelleImportsKey)
-	r.DelAttr(config.GazelleImportsKey)
 	r.DelAttr("deps")
+	importsRaw := r.PrivateAttr(config.GazelleImportsKey)
+	var imports bzl.Expr
+	if importsRaw != nil {
+		imports = rule.ExprFromValue(importsRaw)
+	}
 	deps := rule.MapExprStrings(imports, func(imp string) string {
 		label, err := resolve(imp, from)
 		if err != nil {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -127,18 +127,10 @@ func ScanAST(bzlFile *bzl.File) *File {
 // Sync writes all changes back to the wrapped syntax tree. This should be
 // called after editing operations, before reading the syntax tree again.
 func (f *File) Sync() {
-	f.sync(false)
+	f.sync()
 }
 
-// SyncIncludingHiddenAttrs writes changes back to the wrapped syntax tree,
-// including hidden attributes (those starting with "_") on rules. This should
-// only be used for testing since hidden attributes should never be written to a
-// build file.
-func (f *File) SyncIncludingHiddenAttrs() {
-	f.sync(true)
-}
-
-func (f *File) sync(includeHidden bool) {
+func (f *File) sync() {
 	var inserts, deletes []stmt
 	var r, w int
 	for r, w = 0, 0; r < len(f.Loads); r++ {
@@ -158,7 +150,7 @@ func (f *File) sync(includeHidden bool) {
 	f.Loads = f.Loads[:w]
 	for r, w = 0, 0; r < len(f.Rules); r++ {
 		s := f.Rules[r]
-		s.sync(includeHidden)
+		s.sync()
 		if s.deleted {
 			deletes = append(deletes, s)
 			continue
@@ -386,9 +378,10 @@ func (l *Load) sync() {
 // Rule represents a rule statement within a build file.
 type Rule struct {
 	baseStmt
-	kind  string
-	args  []bzl.Expr
-	attrs map[string]*bzl.BinaryExpr
+	kind    string
+	args    []bzl.Expr
+	attrs   map[string]*bzl.BinaryExpr
+	private map[string]interface{}
 }
 
 // NewRule creates a new, empty rule with the given kind and name.
@@ -405,8 +398,9 @@ func NewRule(kind, name string) *Rule {
 				List: []bzl.Expr{nameAttr},
 			},
 		},
-		kind:  kind,
-		attrs: map[string]*bzl.BinaryExpr{"name": nameAttr},
+		kind:    kind,
+		attrs:   map[string]*bzl.BinaryExpr{"name": nameAttr},
+		private: map[string]interface{}{},
 	}
 	return r
 }
@@ -467,14 +461,11 @@ func (r *Rule) SetName(name string) {
 	r.SetAttr("name", name)
 }
 
-// AttrKeys returns a sorted list of attribute keys used in this rule. This
-// list will not include hidden keys (starting with "_").
+// AttrKeys returns a sorted list of attribute keys used in this rule.
 func (r *Rule) AttrKeys() []string {
 	keys := make([]string, 0, len(r.attrs))
 	for k := range r.attrs {
-		if !isHiddenKey(k) {
-			keys = append(keys, k)
-		}
+		keys = append(keys, k)
 	}
 	sort.SliceStable(keys, func(i, j int) bool {
 		if cmp := bt.NamePriority[keys[i]] - bt.NamePriority[keys[j]]; cmp != 0 {
@@ -537,8 +528,7 @@ func (r *Rule) DelAttr(key string) {
 }
 
 // SetAttr adds or replaces the named attribute with an expression produced
-// by ExprFromValue. Note that this may be used to set hidden attributes
-// (with keys starting with "_") which will not be written to the build file.
+// by ExprFromValue.
 func (r *Rule) SetAttr(key string, value interface{}) {
 	y := ExprFromValue(value)
 	if attr, ok := r.attrs[key]; ok {
@@ -551,6 +541,28 @@ func (r *Rule) SetAttr(key string, value interface{}) {
 		}
 	}
 	r.updated = true
+}
+
+// PrivateAttrKeys returns a sorted list of private attribute names.
+func (r *Rule) PrivateAttrKeys() []string {
+	keys := make([]string, 0, len(r.private))
+	for k := range r.private {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// PrivateAttr return the private value associated with a key.
+func (r *Rule) PrivateAttr(key string) interface{} {
+	return r.private[key]
+}
+
+// SetPrivateAttr associates a value with a key. Unlike SetAttr, this value
+// is not converted to a build syntax tree and will not be written to a build
+// file.
+func (r *Rule) SetPrivateAttr(key string, value interface{}) {
+	r.private[key] = value
 }
 
 // Insert marks this statement for insertion at the end of the file. Multiple
@@ -579,8 +591,8 @@ func (r *Rule) IsEmpty(attrs config.MergeableAttrs) bool {
 	return true
 }
 
-func (r *Rule) sync(includeHidden bool) {
-	if !r.updated && !includeHidden {
+func (r *Rule) sync() {
+	if !r.updated {
 		return
 	}
 	r.updated = false
@@ -596,10 +608,8 @@ func (r *Rule) sync(includeHidden bool) {
 
 	list := make([]bzl.Expr, 0, len(r.args)+len(r.attrs))
 	list = append(list, r.args...)
-	for k, attr := range r.attrs {
-		if !isHiddenKey(k) || includeHidden {
-			list = append(list, attr)
-		}
+	for _, attr := range r.attrs {
+		list = append(list, attr)
 	}
 	sortedAttrs := list[len(r.args):]
 	key := func(e bzl.Expr) string { return e.(*bzl.BinaryExpr).X.(*bzl.LiteralExpr).Token }
@@ -626,10 +636,6 @@ func ShouldKeep(e bzl.Expr) bool {
 		}
 	}
 	return false
-}
-
-func isHiddenKey(key string) bool {
-	return strings.HasPrefix(key, "_")
 }
 
 type byAttrName []KeyValue

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -206,31 +206,3 @@ func TestShouldKeepExpr(t *testing.T) {
 		})
 	}
 }
-
-func TestRuleAttrKeysDoesNotReturnHiddenSymbols(t *testing.T) {
-	r := NewRule("go_library", "go_default_library")
-	r.SetAttr("_hidden", true)
-	got := r.AttrKeys()
-	want := []string{"name"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v; want %#v", got, want)
-	}
-}
-
-func TestRuleHiddenAttrsNotSynced(t *testing.T) {
-	f := EmptyFile("BUILD")
-	r := NewRule("go_library", "go_default_library")
-	r.SetAttr("srcs", []string{"x.go"})
-	r.SetAttr("_hidden", []string{"x.go"})
-	r.Insert(f)
-	got := strings.TrimSpace(string(f.Format()))
-	want := strings.TrimSpace(`
-go_library(
-    name = "go_default_library",
-    srcs = ["x.go"],
-)
-`)
-	if got != want {
-		t.Errorf("got:\n%s\nwant:\n%s", got, want)
-	}
-}

--- a/vendor/github.com/bazelbuild/buildtools/build/BUILD.bazel
+++ b/vendor/github.com/bazelbuild/buildtools/build/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "syntax.go",
         "walk.go",
     ],
-    importmap = "bazel_gazelle/vendor/github.com/bazelbuild/buildtools/build",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/bazelbuild/buildtools/build",
     importpath = "github.com/bazelbuild/buildtools/build",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/bazelbuild/buildtools/tables:go_default_library"],

--- a/vendor/github.com/bazelbuild/buildtools/tables/BUILD.bazel
+++ b/vendor/github.com/bazelbuild/buildtools/tables/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "jsonparser.go",
         "tables.go",
     ],
-    importmap = "bazel_gazelle/vendor/github.com/bazelbuild/buildtools/tables",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/bazelbuild/buildtools/tables",
     importpath = "github.com/bazelbuild/buildtools/tables",
     visibility = ["//visibility:public"],
 )

--- a/vendor/github.com/pelletier/go-toml/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/BUILD.bazel
@@ -33,7 +33,7 @@ go_library(
         "tomltree_create.go",
         "tomltree_write.go",
     ],
-    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/pelletier/go-toml",
     importpath = "github.com/pelletier/go-toml",
     visibility = ["//visibility:public"],
 )

--- a/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["test_program.go"],
-    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/pelletier/go-toml/cmd",
     importpath = "github.com/pelletier/go-toml/cmd",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomljson/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd/tomljson",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/pelletier/go-toml/cmd/tomljson",
     importpath = "github.com/pelletier/go-toml/cmd/tomljson",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/cmd/tomll/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/cmd/tomll",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/pelletier/go-toml/cmd/tomll",
     importpath = "github.com/pelletier/go-toml/cmd/tomll",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],

--- a/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
+++ b/vendor/github.com/pelletier/go-toml/query/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "query.go",
         "tokens.go",
     ],
-    importmap = "bazel_gazelle/vendor/github.com/pelletier/go-toml/query",
+    importmap = "github.com/bazelbuild/bazel-gazelle/vendor/github.com/pelletier/go-toml/query",
     importpath = "github.com/pelletier/go-toml/query",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/pelletier/go-toml:go_default_library"],


### PR DESCRIPTION
Private attributes are now stored in a separate map and are accessed
through separate methods. They no longer need a special prefix and no
longer need to be convertible to bzl.Expr.

Also:

* Update io_bazel_rules_go in WORKSPACE to get a bazel_test that
  doesn't use --nomaster_blazerc, which causes an error in Bazel 0.14.
* Update build files.