### PR TITLE
Update statement indices after rule.File.Sync

### DIFF
--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -76,6 +76,32 @@ z_library(name = "baz")
 	}
 }
 
+func TestDeleteSyncDelete(t *testing.T) {
+	old := []byte(`
+x_library(name = "foo")
+
+# comment
+
+x_library(name = "bar")
+`)
+	f, err := LoadData("old", old)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foo := f.Rules[0]
+	bar := f.Rules[1]
+	foo.Delete()
+	f.Sync()
+	bar.Delete()
+	f.Sync()
+	got := strings.TrimSpace(string(f.Format()))
+	want := strings.TrimSpace(`# comment`)
+	if got != want {
+		t.Errorf("got:\n%s\nwant:%s", got, want)
+	}
+}
+
 func TestSymbolsReturnsKeys(t *testing.T) {
 	f, err := LoadData("load", []byte(`load("a.bzl", "y", z = "a")`))
 	if err != nil {


### PR DESCRIPTION
Before this fix, the index of load statements and rules (stored in
baseStmt) was not updated when the file was synced. It would no longer
point to the correct statement in the build file if insertions or
deletions occurred in earlier parts of the file.