### PR TITLE
internal/language/go: ignore "race" and "msan" tags

### DIFF
--- a/internal/language/go/fileinfo.go
+++ b/internal/language/go/fileinfo.go
@@ -621,7 +621,7 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, f
 // Gazelle won't consider whether an ignored tag is satisfied when evaluating
 // build constraints for a file.
 func isIgnoredTag(tag string) bool {
-	if tag == "cgo" {
+	if tag == "cgo" || tag == "race" || tag == "msan" {
 		return true
 	}
 	if len(tag) < 5 || !strings.HasPrefix(tag, "go") {

--- a/internal/language/go/fileinfo_test.go
+++ b/internal/language/go/fileinfo_test.go
@@ -487,6 +487,14 @@ import "C"
 			desc:    "cgo tag negated",
 			content: "// +build !cgo",
 			want:    true,
+		}, {
+			desc:    "race msan tags",
+			content: "// +build msan race",
+			want:    true,
+		}, {
+			desc:    "race msan tags negated",
+			content: "//+ build !msan,!race",
+			want:    true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
"race" and "msan" may or may not be enabled, and the compile builder
will filter these sources appropriately. We should ignore these tags,
just like we ignore cgo and release tags.

Fixes #233