### PR TITLE
Windows Fixes

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -196,8 +196,8 @@ def _go_repository_tools_impl(ctx):
         ctx.symlink(ctx.path(root_file).dirname, "src/" + prefix)
 
     env = {
-        "GOROOT": go_root,
-        "GOPATH": ctx.path("."),
+        "GOROOT": str(go_root),
+        "GOPATH": str(ctx.path(".")),
         # workaround: to find gcc for go link tool on Arm platform
         "PATH": ctx.os.environ["PATH"],
     }

--- a/internal/language/go/fileinfo.go
+++ b/internal/language/go/fileinfo.go
@@ -197,7 +197,7 @@ const (
 // fileNameInfo returns information that can be inferred from the name of
 // a file. It does not read data from the file.
 func fileNameInfo(path_ string) fileInfo {
-	name := path.Base(path_)
+	name := path.Base(filepath.ToSlash(path_))
 	var ext ext
 	switch path.Ext(name) {
 	case ".go":

--- a/internal/language/go/fileinfo.go
+++ b/internal/language/go/fileinfo.go
@@ -197,7 +197,7 @@ const (
 // fileNameInfo returns information that can be inferred from the name of
 // a file. It does not read data from the file.
 func fileNameInfo(path_ string) fileInfo {
-	name := path.Base(filepath.ToSlash(path_))
+	name := filepath.Base(path_)
 	var ext ext
 	switch path.Ext(name) {
 	case ".go":


### PR DESCRIPTION
- Fix fileinfo.go to handle Windows paths.
- Pass skylark files as strings.