### PR TITLE
internal/language/proto: package mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,77 +230,82 @@ Subdirectories will be processed recursively.
 
 The following flags are accepted:
 
-+------------------------------------------+-----------------------------------+
-| **Name**                                 | **Default value**                 |
-+==========================================+===================================+
-| :flag:`-build_file_name file1,file2,...` | :value:`BUILD.bazel,BUILD`        |
-+------------------------------------------+-----------------------------------+
-| Comma-separated list of file names. Gazelle recognizes these files as Bazel  |
-| build files. New files will use the first name in this list. Use this if     |
-| your project contains non-Bazel files named ``BUILD`` (or ``build`` on       |
-| case-insensitive file systems).                                              |
-+------------------------------------------+-----------------------------------+
-| :flag:`-build_tags tag1,tag2`            |                                   |
-+------------------------------------------+-----------------------------------+
-| List of Go build tags Gazelle will consider to be true. Gazelle applies      |
-| constraints when generating Go rules. It assumes certain tags are true on    |
-| certain platforms (for example, ``amd64,linux``). It assumes all Go release  |
-| tags are true (for example, ``go1.8``). It considers other tags to be false  |
-| (for example, ``ignore``). This flag overrides that behavior.                |
-|                                                                              |
-| Bazel may still filter sources with these tags. Use                          |
-| ``bazel build --features gotags=foo,bar`` to set tags at build time.         |
-+------------------------------------------+-----------------------------------+
-| :flag:`-external external|vendored`      | :value:`external`                 |
-+------------------------------------------+-----------------------------------+
-| Determines how Gazelle resolves import paths. May be :value:`external` or    |
-| :value:`vendored`. Gazelle translates Go import paths to Bazel labels when   |
-| resolving library dependencies. Import paths that start with the             |
-| ``go_prefix`` are resolved to local labels, but other imports                |
-| are resolved based on this mode. In :value:`external` mode, paths are        |
-| resolved using an external dependency in the WORKSPACE file (Gazelle does    |
-| not create or maintain these dependencies yet). In :value:`vendored` mode,   |
-| paths are resolved to a library in the vendor directory.                     |
-+------------------------------------------+-----------------------------------+
-| :flag:`-go_prefix example.com/repo`      |                                   |
-+------------------------------------------+-----------------------------------+
-| A prefix of import paths for libraries in the repository that corresponds to |
-| the repository root. Gazelle infers this from the ``go_prefix`` rule in the  |
-| root BUILD.bazel file, if it exists. If not, this option is mandatory.       |
-|                                                                              |
-| This prefix is used to determine whether an import path refers to a library  |
-| in the current repository or an external dependency.                         |
-+------------------------------------------+-----------------------------------+
-| :flag:`-known_import example.com`        |                                   |
-+------------------------------------------+-----------------------------------+
-| Skips import path resolution for a known domain. May be repeated.            |
-|                                                                              |
-| When Gazelle resolves an import path to an external dependency, it attempts  |
-| to discover the remote repository root over HTTP. Gazelle skips this         |
-| discovery step for a few well-known domains with predictable structure, like |
-| golang.org and github.com. This flag specifies additional domains to skip,   |
-| which is useful in situations where the lookup would fail for some reason.   |
-+------------------------------------------+-----------------------------------+
-| :flag:`-mode fix|print|diff`             | :value:`fix`                      |
-+------------------------------------------+-----------------------------------+
-| Method for emitting merged build files.                                      |
-|                                                                              |
-| In ``fix`` mode, Gazelle writes generated and merged files to disk. In       |
-| ``print`` mode, it prints them to stdout. In ``diff`` mode, it prints a      |
-| unified diff.                                                                |
-+------------------------------------------+-----------------------------------+
-| :flag:`-proto default|legacy|disable`    | :value:`default`                  |
-+------------------------------------------+-----------------------------------+
-| Determines how Gazelle should generate rules for .proto files. See details   |
-| in `Directives`_ below.                                                      |
-+------------------------------------------+-----------------------------------+
-| :flag:`-repo_root dir`                   |                                   |
-+------------------------------------------+-----------------------------------+
-| The root directory of the repository. Gazelle normally infers this to be the |
-| directory containing the WORKSPACE file.                                     |
-|                                                                              |
-| Gazelle will not process packages outside this directory.                    |
-+------------------------------------------+-----------------------------------+
++-----------------------------------------------+-----------------------------------+
+| **Name**                                      | **Default value**                 |
++===============================================+===================================+
+| :flag:`-build_file_name file1,file2,...`      | :value:`BUILD.bazel,BUILD`        |
++-----------------------------------------------+-----------------------------------+
+| Comma-separated list of file names. Gazelle recognizes these files as Bazel       |
+| build files. New files will use the first name in this list. Use this if          |
+| your project contains non-Bazel files named ``BUILD`` (or ``build`` on            |
+| case-insensitive file systems).                                                   |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-build_tags tag1,tag2`                 |                                   |
++-----------------------------------------------+-----------------------------------+
+| List of Go build tags Gazelle will consider to be true. Gazelle applies           |
+| constraints when generating Go rules. It assumes certain tags are true on         |
+| certain platforms (for example, ``amd64,linux``). It assumes all Go release       |
+| tags are true (for example, ``go1.8``). It considers other tags to be false       |
+| (for example, ``ignore``). This flag overrides that behavior.                     |
+|                                                                                   |
+| Bazel may still filter sources with these tags. Use                               |
+| ``bazel build --features gotags=foo,bar`` to set tags at build time.              |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-external external|vendored`           | :value:`external`                 |
++-----------------------------------------------+-----------------------------------+
+| Determines how Gazelle resolves import paths. May be :value:`external` or         |
+| :value:`vendored`. Gazelle translates Go import paths to Bazel labels when        |
+| resolving library dependencies. Import paths that start with the                  |
+| ``go_prefix`` are resolved to local labels, but other imports                     |
+| are resolved based on this mode. In :value:`external` mode, paths are             |
+| resolved using an external dependency in the WORKSPACE file (Gazelle does         |
+| not create or maintain these dependencies yet). In :value:`vendored` mode,        |
+| paths are resolved to a library in the vendor directory.                          |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-go_prefix example.com/repo`           |                                   |
++-----------------------------------------------+-----------------------------------+
+| A prefix of import paths for libraries in the repository that corresponds to      |
+| the repository root. Gazelle infers this from the ``go_prefix`` rule in the       |
+| root BUILD.bazel file, if it exists. If not, this option is mandatory.            |
+|                                                                                   |
+| This prefix is used to determine whether an import path refers to a library       |
+| in the current repository or an external dependency.                              |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-known_import example.com`             |                                   |
++-----------------------------------------------+-----------------------------------+
+| Skips import path resolution for a known domain. May be repeated.                 |
+|                                                                                   |
+| When Gazelle resolves an import path to an external dependency, it attempts       |
+| to discover the remote repository root over HTTP. Gazelle skips this              |
+| discovery step for a few well-known domains with predictable structure, like      |
+| golang.org and github.com. This flag specifies additional domains to skip,        |
+| which is useful in situations where the lookup would fail for some reason.        |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-mode fix|print|diff`                  | :value:`fix`                      |
++-----------------------------------------------+-----------------------------------+
+| Method for emitting merged build files.                                           |
+|                                                                                   |
+| In ``fix`` mode, Gazelle writes generated and merged files to disk. In            |
+| ``print`` mode, it prints them to stdout. In ``diff`` mode, it prints a           |
+| unified diff.                                                                     |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-proto default|package|legacy|disable` | :value:`default`                  |
++-----------------------------------------------+-----------------------------------+
+| Determines how Gazelle should generate rules for .proto files. See details        |
+| in `Directives`_ below.                                                           |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-proto_group group`                    | :value:`""`                       |
++-----------------------------------------------+-----------------------------------+
+| Determines the proto option Gazelle uses to group .proto files into rules         |
+| when in ``package`` mode. See details in `Directives`_ below.                     |
++-----------------------------------------------+-----------------------------------+
+| :flag:`-repo_root dir`                        |                                   |
++-----------------------------------------------+-----------------------------------+
+| The root directory of the repository. Gazelle normally infers this to be the      |
+| directory containing the WORKSPACE file.                                          |
+|                                                                                   |
+| Gazelle will not process packages outside this directory.                         |
++-----------------------------------------------+-----------------------------------+
 
 ``update-repos``
 ~~~~~~~~~~~~~~~~
@@ -475,9 +480,12 @@ The following directives are recognized:
 +------------------------------------------+-----------------------------------+
 | Tells Gazelle how to generate rules for .proto files. Valid values are:      |
 |                                                                              |
-| * ``default``: ``proto_library``, ``go_proto_library``, ``go_grpc_library``, |
-|   and ``go_library`` rules are generated using                               |
-|   ``@io_bazel_rules_go//proto:def.bzl``. This is the default mode.           |
+| * ``default``: ``proto_library``, ``go_proto_library``, and ``go_library``   |
+|   rules are generated using ``@io_bazel_rules_go//proto:def.bzl``. Only one  |
+|   of each rule may be generated per directory. This is the default mode.     |
+| * ``package``: multiple ``proto_library`` and ``go_proto_library`` rules     |
+|   may be generated in the same directory. .proto files are grouped into      |
+|   rules based on their package name or another option (see ``proto_group``). |
 | * ``legacy``: ``filegroup`` rules are generated for use by                   |
 |   ``@io_bazel_rules_go//proto:go_proto_library.bzl``. ``go_proto_library``   |
 |   rules must be written by hand. Gazelle will run in this mode automatically |
@@ -493,6 +501,19 @@ The following directives are recognized:
 | Gazelle will run in ``disable`` mode. Additionally, if the file              |
 | ``@io_bazel_rules_go//proto:go_proto_library.bzl`` is loaded, Gazelle        |
 | will run in ``legacy`` mode.                                                 |
++------------------------------------------+-----------------------------------+
+| :direc:`proto_group`                     | :value:`""`                       |
++------------------------------------------+-----------------------------------+
+| Specifies an option that Gazelle can use to group .proto files into rules    |
+| when in ``package`` mode. For example, when set to ``go_package``, .proto    |
+| files with the same ``option go_package`` will be grouped together.          |
+|                                                                              |
+| When this directive is set to the empty string, Gazelle will group packages  |
+| by their proto package statement.                                            |
+|                                                                              |
+| Rule names are generated based on the last run of identifier characters      |
+| in the package name. For example, if the package is ``"foo/bar/baz"``, the   |
+| ``proto_library`` rule will be named ``baz_proto``.                          |
 +------------------------------------------+-----------------------------------+
 
 Keep comments

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -164,6 +164,7 @@ go_repository = repository_rule(
             values = [
                 "",
                 "default",
+                "package",
                 "disable",
                 "legacy",
             ],

--- a/internal/language/go/constants.go
+++ b/internal/language/go/constants.go
@@ -19,4 +19,9 @@ const (
 	// legacyProtoFilegroupName is the anme of a filegroup created in legacy
 	// mode for libraries that contained .pb.go files and .proto files.
 	legacyProtoFilegroupName = "go_default_library_protos"
+	// wellKnownTypesGoPrefix is the import path for the Go repository containing
+	// pre-generated code for the Well Known Types.
+	wellKnownTypesGoPrefix = "github.com/golang/protobuf"
+	// wellKnownTypesPkg is the package name for the predefined WKTs in rules_go.
+	wellKnownTypesPkg = "proto/wkt"
 )

--- a/internal/language/go/fileinfo_go_test.go
+++ b/internal/language/go/fileinfo_go_test.go
@@ -365,13 +365,16 @@ import "C"
 	c.RepoRoot = repo
 	gc := getGoConfig(c)
 	gc.prefix = "example.com/repo"
-	got := buildPackage(c, sub, "sub", []string{"sub.go"}, nil, nil, false, "", nil)
+	pkgs, _ := buildPackages(c, sub, "sub", []string{"sub.go"}, false)
+	got, ok := pkgs["sub"]
+	if !ok {
+		t.Fatal("did not build package 'sub'")
+	}
 	want := &goPackage{
-		name:       "sub",
-		dir:        sub,
-		rel:        "sub",
-		importPath: "example.com/repo/sub",
-		library:    goTarget{cgo: true},
+		name:    "sub",
+		dir:     sub,
+		rel:     "sub",
+		library: goTarget{cgo: true},
 	}
 	want.library.sources.addGenericString("sub.go")
 	want.library.copts.addGenericString("-Isub/..")

--- a/internal/language/go/testdata/proto_package_mode/BUILD.old
+++ b/internal/language/go/testdata/proto_package_mode/BUILD.old
@@ -1,0 +1,1 @@
+# gazelle:proto package

--- a/internal/language/go/testdata/proto_package_mode/BUILD.want
+++ b/internal/language/go/testdata/proto_package_mode/BUILD.want
@@ -1,0 +1,43 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "bar_proto",
+    srcs = [
+        "bar1.proto",
+        "bar2.proto",
+    ],
+    _gazelle_imports = [],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = [
+        "foo1.proto",
+        "foo2.proto",
+    ],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode/bar1.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "bar_go_proto",
+    _gazelle_imports = [],
+    importpath = "example.com/repo/proto_package_mode/bar",
+    proto = ":bar_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "foo_go_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode/bar1.proto",
+    ],
+    importpath = "example.com/repo/proto_package_mode",
+    proto = ":foo_proto",
+    visibility = ["//visibility:public"],
+)

--- a/internal/language/go/testdata/proto_package_mode/bar1.proto
+++ b/internal/language/go/testdata/proto_package_mode/bar1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package bar;
+
+option go_package = "example.com/repo/proto_package_mode/bar";

--- a/internal/language/go/testdata/proto_package_mode/bar2.proto
+++ b/internal/language/go/testdata/proto_package_mode/bar2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package bar;

--- a/internal/language/go/testdata/proto_package_mode/foo1.proto
+++ b/internal/language/go/testdata/proto_package_mode/foo1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package foo;
+
+import "google/protobuf/any.proto";

--- a/internal/language/go/testdata/proto_package_mode/foo2.proto
+++ b/internal/language/go/testdata/proto_package_mode/foo2.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package foo;
+
+import "proto_package_mode/bar1.proto";

--- a/internal/language/go/testdata/proto_package_mode_extras/BUILD.old
+++ b/internal/language/go/testdata/proto_package_mode_extras/BUILD.old
@@ -1,0 +1,3 @@
+# gazelle:proto package
+
+package(default_visibility = ["//visibility:public"])

--- a/internal/language/go/testdata/proto_package_mode_extras/BUILD.want
+++ b/internal/language/go/testdata/proto_package_mode_extras/BUILD.want
@@ -1,0 +1,54 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "bar_proto",
+    srcs = [
+        "bar1.proto",
+        "bar2.proto",
+    ],
+    _gazelle_imports = [],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = [
+        "foo1.proto",
+        "foo2.proto",
+    ],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode_extras/bar1.proto",
+    ],
+)
+
+go_proto_library(
+    name = "bar_go_proto",
+    _gazelle_imports = [],
+    importpath = "example.com/repo/proto_package_mode_extras/bar",
+    proto = ":bar_proto",
+)
+
+go_proto_library(
+    name = "foo_go_proto",
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode_extras/bar1.proto",
+    ],
+    importpath = "example.com/repo/proto_package_mode_extras",
+    proto = ":foo_proto",
+)
+
+go_library(
+    name = "go_default_library",
+    _gazelle_imports = [],
+    embed = [":foo_go_proto"],
+    importpath = "example.com/repo/proto_package_mode_extras",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    _gazelle_imports = [],
+    embed = [":go_default_library"],
+)

--- a/internal/language/go/testdata/proto_package_mode_extras/bar1.proto
+++ b/internal/language/go/testdata/proto_package_mode_extras/bar1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package bar;
+
+option go_package = "example.com/repo/proto_package_mode_extras/bar";

--- a/internal/language/go/testdata/proto_package_mode_extras/bar2.proto
+++ b/internal/language/go/testdata/proto_package_mode_extras/bar2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package bar;

--- a/internal/language/go/testdata/proto_package_mode_extras/foo1.proto
+++ b/internal/language/go/testdata/proto_package_mode_extras/foo1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package foo;
+
+import "google/protobuf/any.proto";

--- a/internal/language/go/testdata/proto_package_mode_extras/foo2.proto
+++ b/internal/language/go/testdata/proto_package_mode_extras/foo2.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package foo;
+
+import "proto_package_mode_extras/bar1.proto";

--- a/internal/language/go/testdata/proto_package_mode_extras/foo_test.go
+++ b/internal/language/go/testdata/proto_package_mode_extras/foo_test.go
@@ -1,0 +1,1 @@
+package foo

--- a/internal/language/proto/constants.go
+++ b/internal/language/proto/constants.go
@@ -16,10 +16,11 @@ limitations under the License.
 package proto
 
 const (
-	// FileInfoKey is the name of a private attribute set on generate
-	// proto_library rules. This attribute contains a slice of FileInfo
-	// records, one for each .proto file.
-	FileInfoKey = "_fileinfo"
+	// PackageInfoKey is the name of a private attribute set on generated
+	// proto_library rules. This attribute contains a Package record which
+	// describes the library and its sources.
+	PackageKey = "_package"
+
 	// wellKnownTypesGoPrefix is the import path for the Go repository containing
 	// pre-generated code for the Well Known Types.
 	wellKnownTypesGoPrefix = "github.com/golang/protobuf"

--- a/internal/language/proto/package.go
+++ b/internal/language/proto/package.go
@@ -17,36 +17,38 @@ package proto
 
 import "path/filepath"
 
-// protoPackage contains metadata for a set of .proto files that have the
+// Package contains metadata for a set of .proto files that have the
 // same package name. This translates to a proto_library rule.
-type protoPackage struct {
-	name    string
-	files   map[string]FileInfo
-	imports map[string]bool
-	options map[string]string
+type Package struct {
+	Name        string
+	Files       map[string]FileInfo
+	Imports     map[string]bool
+	Options     map[string]string
+	HasServices bool
 }
 
-func newProtoPackage(name string) *protoPackage {
-	return &protoPackage{
-		name:    name,
-		files:   map[string]FileInfo{},
-		imports: map[string]bool{},
-		options: map[string]string{},
+func newPackage(name string) *Package {
+	return &Package{
+		Name:    name,
+		Files:   map[string]FileInfo{},
+		Imports: map[string]bool{},
+		Options: map[string]string{},
 	}
 }
 
-func (p *protoPackage) addFile(info FileInfo) {
-	p.files[info.Name] = info
+func (p *Package) addFile(info FileInfo) {
+	p.Files[info.Name] = info
 	for _, imp := range info.Imports {
-		p.imports[imp] = true
+		p.Imports[imp] = true
 	}
 	for _, opt := range info.Options {
-		p.options[opt.Key] = opt.Value
+		p.Options[opt.Key] = opt.Value
 	}
+	p.HasServices = p.HasServices || info.HasServices
 }
 
-func (p *protoPackage) addGenFile(dir, name string) {
-	p.files[name] = FileInfo{
+func (p *Package) addGenFile(dir, name string) {
+	p.Files[name] = FileInfo{
 		Name: name,
 		Path: filepath.Join(dir, filepath.FromSlash(name)),
 	}

--- a/internal/language/proto/testdata/multiple_packages/default_mode/BUILD.want
+++ b/internal/language/proto/testdata/multiple_packages/default_mode/BUILD.want
@@ -1,0 +1,5 @@
+proto_library(
+    name = "multiple_packages_default_mode_proto",
+    srcs = ["foo.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/internal/language/proto/testdata/multiple_packages/default_mode/bar.proto
+++ b/internal/language/proto/testdata/multiple_packages/default_mode/bar.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package bar;

--- a/internal/language/proto/testdata/multiple_packages/default_mode/foo.proto
+++ b/internal/language/proto/testdata/multiple_packages/default_mode/foo.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package multiple_packages.default_mode;

--- a/internal/language/proto/testdata/multiple_packages/package_mode/BUILD.old
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/BUILD.old
@@ -1,0 +1,6 @@
+# gazelle:proto package
+
+genrule(
+    name = "genproto",
+    outs ["gen.proto"],
+)

--- a/internal/language/proto/testdata/multiple_packages/package_mode/BUILD.want
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/BUILD.want
@@ -1,0 +1,17 @@
+proto_library(
+    name = "bar_proto",
+    srcs = [
+        "bar1.proto",
+        "bar2.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = [
+        "foo1.proto",
+        "foo2.proto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/internal/language/proto/testdata/multiple_packages/package_mode/bar1.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/bar1.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package bar;

--- a/internal/language/proto/testdata/multiple_packages/package_mode/bar2.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/bar2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package bar;

--- a/internal/language/proto/testdata/multiple_packages/package_mode/foo1.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/foo1.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package foo;

--- a/internal/language/proto/testdata/multiple_packages/package_mode/foo2.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode/foo2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package foo;

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/BUILD.old
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/BUILD.old
@@ -1,0 +1,2 @@
+# gazelle:proto package
+# gazelle:proto_group x_package

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
@@ -1,0 +1,17 @@
+proto_library(
+    name = "bar_proto",
+    srcs = [
+        "bar1.proto",
+        "bar2.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = [
+        "foo1.proto",
+        "foo2.proto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/bar1.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/bar1.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+option x_package = "x/bar";

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/bar2.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/bar2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+option x_package = "x/bar";

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/foo1.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/foo1.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+option x_package = "111@foo";

--- a/internal/language/proto/testdata/multiple_packages/package_mode_group/foo2.proto
+++ b/internal/language/proto/testdata/multiple_packages/package_mode_group/foo2.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+option x_package = "111@foo";


### PR DESCRIPTION
The proto extension now supports "package" mode. This can be enabled
with -proto=package on the command line or "# gazelle:proto package"
in a build file. In package mode, multiple proto_libraries will be
generated in a directory. Source files will be grouped by package.

To group source files by an option instead (i.e., option go_package),
the proto extension recognizes the proto_group command line flag and
directive.

The go extension generates go_proto_library rules based on the
proto_library rules generated by the proto extension (independent of
proto mode when possible).

Related bazelbuild/rules_go#1548