### PR TITLE
 internal/language/proto: disable_global mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,82 +230,82 @@ Subdirectories will be processed recursively.
 
 The following flags are accepted:
 
-+-----------------------------------------------+-----------------------------------+
-| **Name**                                      | **Default value**                 |
-+===============================================+===================================+
-| :flag:`-build_file_name file1,file2,...`      | :value:`BUILD.bazel,BUILD`        |
-+-----------------------------------------------+-----------------------------------+
-| Comma-separated list of file names. Gazelle recognizes these files as Bazel       |
-| build files. New files will use the first name in this list. Use this if          |
-| your project contains non-Bazel files named ``BUILD`` (or ``build`` on            |
-| case-insensitive file systems).                                                   |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-build_tags tag1,tag2`                 |                                   |
-+-----------------------------------------------+-----------------------------------+
-| List of Go build tags Gazelle will consider to be true. Gazelle applies           |
-| constraints when generating Go rules. It assumes certain tags are true on         |
-| certain platforms (for example, ``amd64,linux``). It assumes all Go release       |
-| tags are true (for example, ``go1.8``). It considers other tags to be false       |
-| (for example, ``ignore``). This flag overrides that behavior.                     |
-|                                                                                   |
-| Bazel may still filter sources with these tags. Use                               |
-| ``bazel build --features gotags=foo,bar`` to set tags at build time.              |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-external external|vendored`           | :value:`external`                 |
-+-----------------------------------------------+-----------------------------------+
-| Determines how Gazelle resolves import paths. May be :value:`external` or         |
-| :value:`vendored`. Gazelle translates Go import paths to Bazel labels when        |
-| resolving library dependencies. Import paths that start with the                  |
-| ``go_prefix`` are resolved to local labels, but other imports                     |
-| are resolved based on this mode. In :value:`external` mode, paths are             |
-| resolved using an external dependency in the WORKSPACE file (Gazelle does         |
-| not create or maintain these dependencies yet). In :value:`vendored` mode,        |
-| paths are resolved to a library in the vendor directory.                          |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-go_prefix example.com/repo`           |                                   |
-+-----------------------------------------------+-----------------------------------+
-| A prefix of import paths for libraries in the repository that corresponds to      |
-| the repository root. Gazelle infers this from the ``go_prefix`` rule in the       |
-| root BUILD.bazel file, if it exists. If not, this option is mandatory.            |
-|                                                                                   |
-| This prefix is used to determine whether an import path refers to a library       |
-| in the current repository or an external dependency.                              |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-known_import example.com`             |                                   |
-+-----------------------------------------------+-----------------------------------+
-| Skips import path resolution for a known domain. May be repeated.                 |
-|                                                                                   |
-| When Gazelle resolves an import path to an external dependency, it attempts       |
-| to discover the remote repository root over HTTP. Gazelle skips this              |
-| discovery step for a few well-known domains with predictable structure, like      |
-| golang.org and github.com. This flag specifies additional domains to skip,        |
-| which is useful in situations where the lookup would fail for some reason.        |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-mode fix|print|diff`                  | :value:`fix`                      |
-+-----------------------------------------------+-----------------------------------+
-| Method for emitting merged build files.                                           |
-|                                                                                   |
-| In ``fix`` mode, Gazelle writes generated and merged files to disk. In            |
-| ``print`` mode, it prints them to stdout. In ``diff`` mode, it prints a           |
-| unified diff.                                                                     |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-proto default|package|legacy|disable` | :value:`default`                  |
-+-----------------------------------------------+-----------------------------------+
-| Determines how Gazelle should generate rules for .proto files. See details        |
-| in `Directives`_ below.                                                           |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-proto_group group`                    | :value:`""`                       |
-+-----------------------------------------------+-----------------------------------+
-| Determines the proto option Gazelle uses to group .proto files into rules         |
-| when in ``package`` mode. See details in `Directives`_ below.                     |
-+-----------------------------------------------+-----------------------------------+
-| :flag:`-repo_root dir`                        |                                   |
-+-----------------------------------------------+-----------------------------------+
-| The root directory of the repository. Gazelle normally infers this to be the      |
-| directory containing the WORKSPACE file.                                          |
-|                                                                                   |
-| Gazelle will not process packages outside this directory.                         |
-+-----------------------------------------------+-----------------------------------+
++--------------------------------------------------------------+-----------------------------------+
+| **Name**                                                     | **Default value**                 |
++==============================================================+===================================+
+| :flag:`-build_file_name file1,file2,...`                     | :value:`BUILD.bazel,BUILD`        |
++--------------------------------------------------------------+-----------------------------------+
+| Comma-separated list of file names. Gazelle recognizes these files as Bazel                      |
+| build files. New files will use the first name in this list. Use this if                         |
+| your project contains non-Bazel files named ``BUILD`` (or ``build`` on                           |
+| case-insensitive file systems).                                                                  |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-build_tags tag1,tag2`                                |                                   |
++--------------------------------------------------------------+-----------------------------------+
+| List of Go build tags Gazelle will consider to be true. Gazelle applies                          |
+| constraints when generating Go rules. It assumes certain tags are true on                        |
+| certain platforms (for example, ``amd64,linux``). It assumes all Go release                      |
+| tags are true (for example, ``go1.8``). It considers other tags to be false                      |
+| (for example, ``ignore``). This flag overrides that behavior.                                    |
+|                                                                                                  |
+| Bazel may still filter sources with these tags. Use                                              |
+| ``bazel build --features gotags=foo,bar`` to set tags at build time.                             |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-external external|vendored`                          | :value:`external`                 |
++--------------------------------------------------------------+-----------------------------------+
+| Determines how Gazelle resolves import paths. May be :value:`external` or                        |
+| :value:`vendored`. Gazelle translates Go import paths to Bazel labels when                       |
+| resolving library dependencies. Import paths that start with the                                 |
+| ``go_prefix`` are resolved to local labels, but other imports                                    |
+| are resolved based on this mode. In :value:`external` mode, paths are                            |
+| resolved using an external dependency in the WORKSPACE file (Gazelle does                        |
+| not create or maintain these dependencies yet). In :value:`vendored` mode,                       |
+| paths are resolved to a library in the vendor directory.                                         |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-go_prefix example.com/repo`                          |                                   |
++--------------------------------------------------------------+-----------------------------------+
+| A prefix of import paths for libraries in the repository that corresponds to                     |
+| the repository root. Gazelle infers this from the ``go_prefix`` rule in the                      |
+| root BUILD.bazel file, if it exists. If not, this option is mandatory.                           |
+|                                                                                                  |
+| This prefix is used to determine whether an import path refers to a library                      |
+| in the current repository or an external dependency.                                             |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-known_import example.com`                            |                                   |
++--------------------------------------------------------------+-----------------------------------+
+| Skips import path resolution for a known domain. May be repeated.                                |
+|                                                                                                  |
+| When Gazelle resolves an import path to an external dependency, it attempts                      |
+| to discover the remote repository root over HTTP. Gazelle skips this                             |
+| discovery step for a few well-known domains with predictable structure, like                     |
+| golang.org and github.com. This flag specifies additional domains to skip,                       |
+| which is useful in situations where the lookup would fail for some reason.                       |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-mode fix|print|diff`                                 | :value:`fix`                      |
++--------------------------------------------------------------+-----------------------------------+
+| Method for emitting merged build files.                                                          |
+|                                                                                                  |
+| In ``fix`` mode, Gazelle writes generated and merged files to disk. In                           |
+| ``print`` mode, it prints them to stdout. In ``diff`` mode, it prints a                          |
+| unified diff.                                                                                    |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-proto default|package|legacy|disable|disable_global` | :value:`default`                  |
++--------------------------------------------------------------+-----------------------------------+
+| Determines how Gazelle should generate rules for .proto files. See details                       |
+| in `Directives`_ below.                                                                          |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-proto_group group`                                   | :value:`""`                       |
++--------------------------------------------------------------+-----------------------------------+
+| Determines the proto option Gazelle uses to group .proto files into rules                        |
+| when in ``package`` mode. See details in `Directives`_ below.                                    |
++--------------------------------------------------------------+-----------------------------------+
+| :flag:`-repo_root dir`                                       |                                   |
++--------------------------------------------------------------+-----------------------------------+
+| The root directory of the repository. Gazelle normally infers this to be the                     |
+| directory containing the WORKSPACE file.                                                         |
+|                                                                                                  |
+| Gazelle will not process packages outside this directory.                                        |
++--------------------------------------------------------------+-----------------------------------+
 
 ``update-repos``
 ~~~~~~~~~~~~~~~~
@@ -494,6 +494,9 @@ The following directives are recognized:
 | * ``disable``: .proto files are ignored. Gazelle will run in this mode       |
 |   automatically if ``go_proto_library`` is loaded from any other source,     |
 |   but this can be overridden with a directive.                               |
+| * ``disable_global``: like ``disable`` mode, but also prevents Gazelle from  |
+|   using any special cases in dependency resolution for Well Known Types and  |
+|   Google APIs. Useful for avoiding build-time dependencies on protoc.        |
 |                                                                              |
 | This directive applies to the current directory and subdirectories. As a     |
 | special case, when Gazelle enters a directory named ``vendor``, if the proto |

--- a/internal/language/proto/generate.go
+++ b/internal/language/proto/generate.go
@@ -27,7 +27,7 @@ import (
 
 func (_ *protoLang) GenerateRules(c *config.Config, dir, rel string, f *rule.File, subdirs, regularFiles, genFiles []string, otherEmpty, otherGen []*rule.Rule) (empty, gen []*rule.Rule) {
 	pc := GetProtoConfig(c)
-	if pc.Mode == DisableMode || pc.Mode == LegacyMode {
+	if !pc.Mode.ShouldGenerateRules() {
 		// Don't create or delete proto rules in this mode. Any existing rules
 		// are likely hand-written.
 		return nil, nil


### PR DESCRIPTION
Similar to disable mode in that no proto_library or go_proto_library
rules will be generated. Additionally, all special cases for WKTs and
Google APIs in the dependency resolution will be disabled. This is
useful for avoiding build-time dependencies on protoc.

Related bazelbuild/rules_go#1548