### PR TITLE
cmd/gazelle: fix panics when generating help text

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -114,6 +114,23 @@ func runGazelle(wd string, args []string) error {
 	return run(args)
 }
 
+// TestHelp checks that help commands do not panic due to nil flag values.
+// Verifies #256.
+func TestHelp(t *testing.T) {
+	for _, args := range [][]string{
+		{"help"},
+		{"fix", "-h"},
+		{"update", "-h"},
+		{"update-repos", "-h"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			if err := runGazelle(".", args); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func TestNoRepoRootOrWorkspace(t *testing.T) {
 	dir, err := createFiles(nil)
 	if err != nil {

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -32,7 +32,7 @@ func (m *MultiFlag) Set(v string) error {
 }
 
 func (m *MultiFlag) String() string {
-	if m == nil {
+	if m == nil || m.Values == nil {
 		return ""
 	}
 	return strings.Join(*m.Values, ",")
@@ -53,7 +53,7 @@ func (f *ExplicitFlag) Set(value string) error {
 }
 
 func (f *ExplicitFlag) String() string {
-	if f == nil {
+	if f == nil || f.Value == nil {
 		return ""
 	}
 	return *f.Value

--- a/internal/language/go/config.go
+++ b/internal/language/go/config.go
@@ -144,7 +144,7 @@ func (f *externalFlag) Set(value string) error {
 }
 
 func (f *externalFlag) String() string {
-	if f == nil {
+	if f == nil || f.depMode == nil {
 		return "external"
 	}
 	return f.depMode.String()

--- a/internal/language/proto/config.go
+++ b/internal/language/proto/config.go
@@ -153,7 +153,7 @@ func (f *modeFlag) Set(value string) error {
 
 func (f *modeFlag) String() string {
 	var mode Mode
-	if f != nil {
+	if f != nil && f.mode != nil {
 		mode = *f.mode
 	}
 	return mode.String()


### PR DESCRIPTION
flag documentation states that Value.String may be called with a zero
valued receiver, such as a nil pointer. In fact, these methods may be
called with a non-nil receiver that points to a zero-valued object.

Fixes #256