### PR TITLE
internal/language/go: special cases for ptypes and other libs

### DIFF
--- a/internal/language/go/generate.go
+++ b/internal/language/go/generate.go
@@ -371,7 +371,7 @@ func newGenerator(c *config.Config, f *rule.File, rel string) *generator {
 }
 
 func (g *generator) generateProto(mode proto.Mode, target protoTarget, importPath string) (string, []*rule.Rule) {
-	if !mode.ShouldGenerateRules() {
+	if !mode.ShouldGenerateRules() && mode != proto.LegacyMode {
 		// Don't create or delete proto rules in this mode. Any existing rules
 		// are likely hand-written.
 		return "", nil

--- a/internal/language/go/resolve_test.go
+++ b/internal/language/go/resolve_test.go
@@ -628,6 +628,28 @@ go_library(
 )
 `,
 		}, {
+			desc: "proto_ptypes",
+			old: buildFile{content: `
+go_library(
+    name = "go_default_library",
+    _imports = [
+        "github.com/golang/protobuf/jsonpb",
+        "github.com/golang/protobuf/descriptor",
+        "github.com/golang/protobuf/ptypes",
+    ],
+)
+`},
+			want: `
+go_library(
+    name = "go_default_library",
+    deps = [
+        "@com_github_golang_protobuf//descriptor:go_default_library_gen",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+    ],
+)
+`,
+		}, {
 			desc: "proto_self_import",
 			old: buildFile{content: `
 proto_library(
@@ -747,6 +769,9 @@ go_library(
         "google.golang.org/genproto/googleapis/api/annotations",
         "google.golang.org/genproto/googleapis/rpc/status",
         "google.golang.org/genproto/googleapis/type/latlng",
+        "github.com/golang/protobuf/jsonpb",
+        "github.com/golang/protobuf/descriptor",
+        "github.com/golang/protobuf/ptypes",
     ],
 )
 `)
@@ -765,8 +790,11 @@ go_library(
     name = "go_default_library",
     importpath = "foo",
     deps = [
+        "@com_github_golang_protobuf//descriptor:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
         "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",


### PR DESCRIPTION
Several commonly used libraries in github.com/golang/protobuf depend
on WKTs. We have two versions of these libraries: one that depends on
pre-generated WKT libraries, and one that depends on
build-time-generated WKT libraries. This change adds special cases for
these import paths.