### PR TITLE
internal/resolve: provide self-import check including embeds

### DIFF
--- a/internal/language/go/resolve.go
+++ b/internal/language/go/resolve.go
@@ -205,7 +205,7 @@ func resolveWithIndexGo(ix *resolve.RuleIndex, imp string, from label.Label) (la
 	if bestMatch.Label.Equal(label.NoLabel) {
 		return label.NoLabel, notFoundError
 	}
-	if bestMatch.Label.Equal(from) {
+	if bestMatch.IsSelfImport(from) {
 		return label.NoLabel, skipImportError
 	}
 	return bestMatch.Label, nil
@@ -291,9 +291,7 @@ func resolveWithIndexProto(ix *resolve.RuleIndex, imp string, from label.Label) 
 	if len(matches) > 1 {
 		return label.NoLabel, fmt.Errorf("multiple rules (%s and %s) may be imported with %q from %s", matches[0].Label, matches[1].Label, imp, from)
 	}
-	// TODO(#247): this check is not sufficient. We should check whether the
-	// match embeds this library (possibly transitively).
-	if from.Equal(matches[0].Label) {
+	if matches[0].IsSelfImport(from) {
 		return label.NoLabel, skipImportError
 	}
 	return matches[0].Label, nil

--- a/internal/language/go/resolve_test.go
+++ b/internal/language/go/resolve_test.go
@@ -78,6 +78,33 @@ go_library(
 )
 `,
 		}, {
+			desc: "self_import_embed",
+			old: buildFile{content: `
+go_library(
+    name = "a",
+    embeds = [":b"],
+    importpath = "x",
+)
+
+go_library(
+    name = "b",
+    importpath = "x",
+    _imports = ["x"],
+)
+`},
+			want: `
+go_library(
+    name = "a",
+    embeds = [":b"],
+    importpath = "x",
+)
+
+go_library(
+    name = "b",
+    importpath = "x",
+)
+`,
+		}, {
 			desc: "same_package",
 			old: buildFile{content: `
 go_library(
@@ -666,6 +693,12 @@ go_proto_library(
     proto = ":foo_proto",
     _imports = ["a.proto"],
 )
+
+go_library(
+    name = "go_default_library",
+    embed = [":foo_go_proto"],
+    importpath = "foo",
+)
 `},
 			want: `
 proto_library(
@@ -680,6 +713,12 @@ go_proto_library(
     name = "foo_go_proto",
     importpath = "foo",
     proto = ":foo_proto",
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":foo_go_proto"],
+    importpath = "foo",
 )
 `,
 		},

--- a/internal/language/proto/resolve.go
+++ b/internal/language/proto/resolve.go
@@ -109,7 +109,7 @@ func resolveWithIndex(ix *resolve.RuleIndex, imp string, from label.Label) (labe
 	if len(matches) > 1 {
 		return label.NoLabel, fmt.Errorf("multiple rules (%s and %s) may be imported with %q from %s", matches[0].Label, matches[1].Label, imp, from)
 	}
-	if from.Equal(matches[0].Label) {
+	if matches[0].IsSelfImport(from) {
 		return label.NoLabel, skipImportError
 	}
 	return matches[0].Label, nil

--- a/internal/repos/remote_test.go
+++ b/internal/repos/remote_test.go
@@ -17,7 +17,6 @@ package repos
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -75,7 +74,6 @@ func TestRootSpecialCases(t *testing.T) {
 		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
-			fmt.Fprintf(os.Stderr, "testing %s\n", tc.in)
 			rc := newStubRemoteCache(tc.repos)
 			if gotRoot, gotName, err := rc.Root(tc.in); err != nil {
 				if !tc.wantError {


### PR DESCRIPTION
The FindResult struct returned by RuleIndex.FindRulesByImport now
includes Embeds, a list of labels of embedded rules. This includes
transitive embeds.

FindResult.IsSelfImport returns whether a FindResult matches a given
label or contains the label in Embeds. When this is true, callers
should report an error or omit the dependency.

Fixes #247