### PR TITLE
internal/language/go: fix load of gazelle macro

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -129,12 +129,19 @@ func (vs byPkgRel) Len() int           { return len(vs) }
 func (vs byPkgRel) Less(i, j int) bool { return vs[i].pkgRel < vs[j].pkgRel }
 func (vs byPkgRel) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }
 
+var genericLoads = []rule.LoadInfo{
+	{
+		Name:    "@bazel_gazelle//:def.bzl",
+		Symbols: []string{"gazelle"},
+	},
+}
+
 func runFixUpdate(cmd command, args []string) error {
 	cexts := make([]config.Configurer, 0, len(languages)+2)
 	cexts = append(cexts, &config.CommonConfigurer{}, &updateConfigurer{})
 	kindToResolver := make(map[string]resolve.Resolver)
 	kinds := make(map[string]rule.KindInfo)
-	loads := []rule.LoadInfo{}
+	loads := genericLoads
 	for _, lang := range languages {
 		cexts = append(cexts, lang)
 		for kind, info := range lang.Kinds() {

--- a/internal/language/go/fix.go
+++ b/internal/language/go/fix.go
@@ -31,6 +31,7 @@ func (_ *goLang) Fix(c *config.Config, f *rule.File) {
 	squashCgoLibrary(c, f)
 	squashXtest(c, f)
 	removeLegacyProto(c, f)
+	removeLegacyGazelle(c, f)
 }
 
 // migrateLibraryEmbed converts "library" attributes to "embed" attributes,
@@ -226,6 +227,20 @@ func removeLegacyProto(c *config.Config, f *rule.File) {
 	if len(protoLoads) > 0 {
 		for _, r := range protoRules {
 			r.Delete()
+		}
+	}
+}
+
+// removeLegacyGazelle removes loads of the "gazelle" macro from
+// @io_bazel_rules_go//go:def.bzl. The definition has moved to
+// @bazel_gazelle//:def.bzl, and the old one will be deleted soon.
+func removeLegacyGazelle(c *config.Config, f *rule.File) {
+	for _, l := range f.Loads {
+		if l.Name() == "@io_bazel_rules_go//go:def.bzl" && l.Has("gazelle") {
+			l.Remove("gazelle")
+			if l.IsEmpty() {
+				l.Delete()
+			}
 		}
 	}
 }

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -323,6 +323,12 @@ func (l *Load) Symbols() []string {
 	return syms
 }
 
+// Has returns true if sym is loaded by this statement.
+func (l *Load) Has(sym string) bool {
+	_, ok := l.symbols[sym]
+	return ok
+}
+
 // Add inserts a new symbol into the load statement. This has no effect if
 // the symbol is already loaded. Symbols will be sorted, so the order
 // doesn't matter.


### PR DESCRIPTION
Remove loads of "gazelle" from "@io_bazel_rules_go//go:def.bzl". Load
instead from "@bazel_gazelle//:def.bzl".

Fixes #239