### PR TITLE
Explicitly specify build mode for Gazelle binary

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -34,13 +34,20 @@ go_library(
 go_binary(
     name = "gazelle",
     embed = [":go_default_library"],
+    msan = "off",
+    pure = "off",
+    race = "off",
+    static = "off",
     visibility = ["//visibility:public"],
 )
 
 go_binary(
     name = "gazelle_pure",
     embed = [":go_default_library"],
+    msan = "off",
     pure = "on",
+    race = "off",
+    static = "off",
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This avoids the dependency on bazel --feature flags and system libc. The idea is the same as in https://github.com/bazelbuild/rules_go/pull/1615.