### PR TITLE
Experimental: read and write build files in alternate directories

### DIFF
--- a/cmd/gazelle/diff.go
+++ b/cmd/gazelle/diff.go
@@ -20,21 +20,18 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
-	bzl "github.com/bazelbuild/buildtools/build"
+	"path/filepath"
 )
 
-func diffFile(c *config.Config, file *bzl.File, path string) error {
-	oldContents, err := ioutil.ReadFile(file.Path)
+func diffFile(path string, newContents []byte) error {
+	oldContents, err := ioutil.ReadFile(path)
 	if err != nil {
 		oldContents = nil
 	}
-	newContents := bzl.Format(file)
 	if bytes.Equal(oldContents, newContents) {
 		return nil
 	}
-	f, err := ioutil.TempFile("", c.DefaultBuildFileName())
+	f, err := ioutil.TempFile("", filepath.Base(path))
 	if err != nil {
 		return err
 	}

--- a/cmd/gazelle/fix.go
+++ b/cmd/gazelle/fix.go
@@ -19,17 +19,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
-	bzl "github.com/bazelbuild/buildtools/build"
 )
 
-func fixFile(c *config.Config, file *bzl.File, path string) error {
+func fixFile(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, bzl.Format(file), 0666); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(path, data, 0666)
 }

--- a/cmd/gazelle/gazelle.go
+++ b/cmd/gazelle/gazelle.go
@@ -18,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -76,7 +77,7 @@ func run(args []string) error {
 	case fixCmd, updateCmd:
 		return runFixUpdate(cmd, args)
 	case helpCmd:
-		help()
+		return help()
 	case updateReposCmd:
 		return updateRepos(args)
 	default:
@@ -85,7 +86,7 @@ func run(args []string) error {
 	return nil
 }
 
-func help() {
+func help() error {
 	fmt.Fprint(os.Stderr, `usage: gazelle <command> [args...]
 
 Gazelle is a BUILD file generator for Go projects. It can create new BUILD files
@@ -115,4 +116,5 @@ Gazelle is under active delevopment, and its interface may change
 without notice.
 
 `)
+	return flag.ErrHelp
 }

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -83,19 +84,15 @@ func checkFiles(t *testing.T, dir string, files []fileSpec) {
 				t.Errorf("not a directory: %s", f.path)
 			}
 		} else {
-			want := f.content
-			if len(want) > 0 && want[0] == '\n' {
-				// Strip leading newline, added for readability.
-				want = want[1:]
-			}
+			want := strings.TrimSpace(f.content)
 			gotBytes, err := ioutil.ReadFile(filepath.Join(dir, f.path))
 			if err != nil {
 				t.Errorf("could not read %s: %v", f.path, err)
 				continue
 			}
-			got := string(gotBytes)
+			got := strings.TrimSpace(string(gotBytes))
 			if got != want {
-				t.Errorf("%s: got %s ; want %s", f.path, got, f.content)
+				t.Errorf("%s: got:\n%s\nwant:\n %s", f.path, gotBytes, f.content)
 			}
 		}
 	}
@@ -124,8 +121,10 @@ func TestHelp(t *testing.T) {
 		{"update-repos", "-h"},
 	} {
 		t.Run(args[0], func(t *testing.T) {
-			if err := runGazelle(".", args); err != nil {
-				t.Error(err)
+			if err := runGazelle(".", args); err == nil {
+				t.Errorf("%s: got success, want flag.ErrHelp", args[0])
+			} else if err != flag.ErrHelp {
+				t.Errorf("%s: got %v, want flag.ErrHelp", args[0], err)
 			}
 		})
 	}

--- a/cmd/gazelle/print.go
+++ b/cmd/gazelle/print.go
@@ -17,12 +17,9 @@ package main
 
 import (
 	"os"
-
-	"github.com/bazelbuild/bazel-gazelle/internal/config"
-	bzl "github.com/bazelbuild/buildtools/build"
 )
 
-func printFile(c *config.Config, f *bzl.File, _ string) error {
-	_, err := os.Stdout.Write(bzl.Format(f))
+func printFile(_ string, data []byte) error {
+	_, err := os.Stdout.Write(data)
 	return err
 }

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -93,7 +93,7 @@ func updateRepos(args []string) error {
 	uc := getUpdateReposConfig(c)
 
 	workspacePath := filepath.Join(c.RepoRoot, "WORKSPACE")
-	f, err := rule.LoadFile(workspacePath)
+	f, err := rule.LoadFile(workspacePath, "")
 	if err != nil {
 		return fmt.Errorf("error loading %q: %v", workspacePath, err)
 	}
@@ -106,7 +106,7 @@ func updateRepos(args []string) error {
 	if err := merger.CheckGazelleLoaded(f); err != nil {
 		return err
 	}
-	if err := f.Save(); err != nil {
+	if err := f.Save(f.Path); err != nil {
 		return fmt.Errorf("error writing %q: %v", f.Path, err)
 	}
 	return nil
@@ -124,7 +124,7 @@ func newUpdateReposConfiguration(args []string, cexts []config.Configurer) (*con
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			updateReposUsage(fs)
-			os.Exit(0)
+			return nil, err
 		}
 		// flag already prints the error; don't print it again.
 		return nil, errors.New("Try -help for more information")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,14 @@ type Config struct {
 	// RepoName is the name of the repository.
 	RepoName string
 
+	// ReadBuildFilesDir is the absolute path to a directory where
+	// build files should be read from instead of RepoRoot.
+	ReadBuildFilesDir string
+
+	// WriteBuildFilesDir is the absolute path to a directory where
+	// build files should be written to instead of RepoRoot.
+	WriteBuildFilesDir string
+
 	// ValidBuildFileNames is a list of base names that are considered valid
 	// build files. Some repositories may have files named "BUILD" that are not
 	// used by Bazel and should be ignored. Must contain at least one string.
@@ -134,12 +142,14 @@ type Configurer interface {
 // CommonConfigurer handles language-agnostic command-line flags and directives,
 // i.e., those that apply to Config itself and not to Config.Exts.
 type CommonConfigurer struct {
-	repoRoot, buildFileNames string
+	repoRoot, buildFileNames, readBuildFilesDir, writeBuildFilesDir string
 }
 
 func (cc *CommonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *Config) {
 	fs.StringVar(&cc.repoRoot, "repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
 	fs.StringVar(&cc.buildFileNames, "build_file_name", strings.Join(DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
+	fs.StringVar(&cc.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
+	fs.StringVar(&cc.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
 }
 
 func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
@@ -159,6 +169,19 @@ func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
 		return fmt.Errorf("%s: failed to resolve symlinks: %v", cc.repoRoot, err)
 	}
 	c.ValidBuildFileNames = strings.Split(cc.buildFileNames, ",")
+	if cc.readBuildFilesDir != "" {
+		c.ReadBuildFilesDir, err = filepath.Abs(cc.readBuildFilesDir)
+		if err != nil {
+			return fmt.Errorf("%s: failed to find absolute path of -read_build_files_dir: %v", cc.readBuildFilesDir, err)
+		}
+	}
+	if cc.writeBuildFilesDir != "" {
+		c.WriteBuildFilesDir, err = filepath.Abs(cc.writeBuildFilesDir)
+		if err != nil {
+			return fmt.Errorf("%s: failed to find absolute path of -write_build_files_dir: %v", cc.writeBuildFilesDir, err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,7 +66,7 @@ func TestCommonConfigurerDirectives(t *testing.T) {
 	c := New()
 	cc := &CommonConfigurer{}
 	buildData := []byte(`# gazelle:build_file_name x,y`)
-	f, err := rule.LoadData("test", buildData)
+	f, err := rule.LoadData("test", "", buildData)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/language/go/config_test.go
+++ b/internal/language/go/config_test.go
@@ -69,7 +69,7 @@ func TestDirectives(t *testing.T) {
 # gazelle:importmap_prefix x
 # gazelle:prefix y
 `)
-	f, err := rule.LoadData(filepath.FromSlash("test/BUILD.bazel"), content)
+	f, err := rule.LoadData(filepath.FromSlash("test/BUILD.bazel"), "test", content)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 			var f *rule.File
 			if tc.content != "" {
 				var err error
-				f, err = rule.LoadData(path.Join(tc.rel, "BUILD.bazel"), []byte(tc.content))
+				f, err = rule.LoadData(path.Join(tc.rel, "BUILD.bazel"), tc.rel, []byte(tc.content))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -243,7 +243,7 @@ gazelle(
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			f, err := rule.LoadData("BUILD.bazel", []byte(tc.content))
+			f, err := rule.LoadData("BUILD.bazel", "", []byte(tc.content))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/language/go/fix_test.go
+++ b/internal/language/go/fix_test.go
@@ -632,7 +632,7 @@ go_repository(name = "foo")
 }
 
 func testFix(t *testing.T, tc fixTestCase, fix func(*rule.File)) {
-	f, err := rule.LoadData("old", []byte(tc.old))
+	f, err := rule.LoadData("old", "", []byte(tc.old))
 	if err != nil {
 		t.Fatalf("%s: parse error: %v", tc.desc, err)
 	}

--- a/internal/language/go/generate_test.go
+++ b/internal/language/go/generate_test.go
@@ -64,7 +64,7 @@ func TestGenerateRules(t *testing.T) {
 				// there's no test.
 				return
 			}
-			f := rule.EmptyFile("test")
+			f := rule.EmptyFile("test", "")
 			for _, r := range gen {
 				r.Insert(f)
 			}
@@ -93,7 +93,7 @@ func TestGenerateRulesEmpty(t *testing.T) {
 	if len(gen) > 0 {
 		t.Errorf("got %d generated rules; want 0", len(gen))
 	}
-	f := rule.EmptyFile("test")
+	f := rule.EmptyFile("test", "")
 	for _, r := range empty {
 		r.Insert(f)
 	}
@@ -138,7 +138,7 @@ proto_library(
     srcs = ["dead.proto"],
 )
 `)
-	old, err := rule.LoadData("BUILD.bazel", oldContent)
+	old, err := rule.LoadData("BUILD.bazel", "", oldContent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ proto_library(
 		es, _ := lang.GenerateRules(c, "./foo", "foo", old, nil, nil, nil, empty, nil)
 		empty = append(empty, es...)
 	}
-	f := rule.EmptyFile("test")
+	f := rule.EmptyFile("test", "")
 	for _, r := range empty {
 		r.Insert(f)
 	}

--- a/internal/language/go/resolve_test.go
+++ b/internal/language/go/resolve_test.go
@@ -739,7 +739,7 @@ go_library(
 
 			for _, bf := range tc.index {
 				buildPath := filepath.Join(filepath.FromSlash(bf.rel), "BUILD.bazel")
-				f, err := rule.LoadData(buildPath, []byte(bf.content))
+				f, err := rule.LoadData(buildPath, bf.rel, []byte(bf.content))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -748,7 +748,7 @@ go_library(
 				}
 			}
 			buildPath := filepath.Join(filepath.FromSlash(tc.old.rel), "BUILD.bazel")
-			f, err := rule.LoadData(buildPath, []byte(tc.old.content))
+			f, err := rule.LoadData(buildPath, tc.old.rel, []byte(tc.old.content))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -814,7 +814,7 @@ go_library(
     ],
 )
 `)
-	f, err := rule.LoadData("BUILD.bazel", oldContent)
+	f, err := rule.LoadData("BUILD.bazel", "", oldContent)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/language/proto/generate_test.go
+++ b/internal/language/proto/generate_test.go
@@ -50,7 +50,7 @@ func TestGenerateRules(t *testing.T) {
 			if len(empty) > 0 {
 				t.Errorf("got %d empty rules; want 0", len(empty))
 			}
-			f := rule.EmptyFile("test")
+			f := rule.EmptyFile("test", "")
 			for _, r := range gen {
 				r.Insert(f)
 			}
@@ -94,7 +94,7 @@ proto_library(
     srcs = COMPLICATED_SRCS,
 )
 `)
-	old, err := rule.LoadData("BUILD.bazel", oldContent)
+	old, err := rule.LoadData("BUILD.bazel", "", oldContent)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ proto_library(
 	if len(gen) > 0 {
 		t.Errorf("got %d generated rules; want 0", len(gen))
 	}
-	f := rule.EmptyFile("test")
+	f := rule.EmptyFile("test", "")
 	for _, r := range empty {
 		r.Insert(f)
 	}

--- a/internal/language/proto/resolve.go
+++ b/internal/language/proto/resolve.go
@@ -30,7 +30,7 @@ import (
 )
 
 func (_ *protoLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	rel := f.Rel(c.RepoRoot)
+	rel := f.Pkg
 	srcs := r.AttrStrings("srcs")
 	imports := make([]resolve.ImportSpec, len(srcs))
 	for i, src := range srcs {

--- a/internal/language/proto/resolve_test.go
+++ b/internal/language/proto/resolve_test.go
@@ -179,7 +179,7 @@ proto_library(
 			ix := resolve.NewRuleIndex(map[string]resolve.Resolver{"proto_library": lang})
 			rc := (*repos.RemoteCache)(nil)
 			for _, bf := range tc.index {
-				f, err := rule.LoadData(filepath.Join(bf.rel, "BUILD.bazel"), []byte(bf.content))
+				f, err := rule.LoadData(filepath.Join(bf.rel, "BUILD.bazel"), bf.rel, []byte(bf.content))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -187,7 +187,7 @@ proto_library(
 					ix.AddRule(c, r, f)
 				}
 			}
-			f, err := rule.LoadData("test/BUILD.bazel", []byte(tc.old))
+			f, err := rule.LoadData("test/BUILD.bazel", "test", []byte(tc.old))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -56,6 +56,9 @@ func MergeFile(oldFile *rule.File, emptyRules, genRules []*rule.Rule, phase Phas
 	// Merge empty rules into the file and delete any rules which become empty.
 	for _, emptyRule := range emptyRules {
 		if oldRule, _ := match(oldFile.Rules, emptyRule, kinds[emptyRule.Kind()]); oldRule != nil {
+			if oldRule.ShouldKeep() {
+				continue
+			}
 			rule.MergeRules(emptyRule, oldRule, getMergeAttrs(emptyRule), oldFile.Path)
 			if oldRule.IsEmpty(kinds[oldRule.Kind()]) {
 				oldRule.Delete()

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -870,15 +870,15 @@ go_proto_library(
 func TestMergeFile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			genFile, err := rule.LoadData("current", []byte(tc.current))
+			genFile, err := rule.LoadData("current", "", []byte(tc.current))
 			if err != nil {
 				t.Fatalf("%s: %v", tc.desc, err)
 			}
-			f, err := rule.LoadData("previous", []byte(tc.previous))
+			f, err := rule.LoadData("previous", "", []byte(tc.previous))
 			if err != nil {
 				t.Fatalf("%s: %v", tc.desc, err)
 			}
-			emptyFile, err := rule.LoadData("empty", []byte(tc.empty))
+			emptyFile, err := rule.LoadData("empty", "", []byte(tc.empty))
 			if err != nil {
 				t.Fatalf("%s: %v", tc.desc, err)
 			}
@@ -970,11 +970,11 @@ go_binary(name = "z")
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			genFile, err := rule.LoadData("gen", []byte(tc.gen))
+			genFile, err := rule.LoadData("gen", "", []byte(tc.gen))
 			if err != nil {
 				t.Fatal(err)
 			}
-			oldFile, err := rule.LoadData("old", []byte(tc.old))
+			oldFile, err := rule.LoadData("old", "", []byte(tc.old))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -987,7 +987,7 @@ go_binary(name = "z")
 			} else if tc.wantError {
 				t.Error("unexpected success")
 			} else if got == nil && tc.wantIndex >= 0 {
-				t.Error("got nil; want index %d", tc.wantIndex)
+				t.Errorf("got nil; want index %d", tc.wantIndex)
 			} else if got != nil && got.Index() != tc.wantIndex {
 				t.Fatalf("got index %d ; want %d", got.Index(), tc.wantIndex)
 			}

--- a/internal/repos/import_test.go
+++ b/internal/repos/import_test.go
@@ -76,7 +76,7 @@ func TestImportDep(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := rule.EmptyFile("test")
+	f := rule.EmptyFile("test", "")
 	for _, r := range rules {
 		r.Insert(f)
 	}

--- a/internal/repos/repo_test.go
+++ b/internal/repos/repo_test.go
@@ -33,7 +33,7 @@ func TestGenerateRepoRules(t *testing.T) {
 		Commit:   "123456",
 	}
 	r := GenerateRule(repo)
-	f := rule.EmptyFile("test")
+	f := rule.EmptyFile("test", "")
 	r.Insert(f)
 	got := strings.TrimSpace(string(f.Format()))
 	want := `go_repository(
@@ -110,7 +110,7 @@ go_repository(
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			workspace, err := rule.LoadData("WORKSPACE", []byte(tc.workspace))
+			workspace, err := rule.LoadData("WORKSPACE", "", []byte(tc.workspace))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/resolve/index.go
+++ b/internal/resolve/index.go
@@ -119,10 +119,9 @@ func (ix *RuleIndex) AddRule(c *config.Config, r *rule.Rule, f *rule.File) {
 		return
 	}
 
-	rel := f.Rel(c.RepoRoot)
 	record := &ruleRecord{
 		rule:       r,
-		label:      label.New(c.RepoName, rel, r.Name()),
+		label:      label.New(c.RepoName, f.Pkg, r.Name()),
 		importedAs: imps,
 	}
 	if _, ok := ix.labelMap[record.label]; ok {

--- a/internal/rule/merge.go
+++ b/internal/rule/merge.go
@@ -42,7 +42,7 @@ import (
 // a "# keep" comment will be dropped. If the attribute is empty afterward,
 // it will be deleted.
 func MergeRules(src, dst *Rule, mergeable map[string]bool, filename string) {
-	if ShouldKeep(dst.call) {
+	if dst.ShouldKeep() {
 		return
 	}
 
@@ -270,7 +270,7 @@ type dictEntry struct {
 // fails because the expression is not understood, an error is returned,
 // and neither rule is modified.
 func SquashRules(src, dst *Rule, filename string) error {
-	if ShouldKeep(dst.call) {
+	if dst.ShouldKeep() {
 		return nil
 	}
 

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -37,7 +37,7 @@ load("b.bzl", y_library = "y")
 
 y_library(name = "bar")
 `)
-	f, err := LoadData("old", old)
+	f, err := LoadData("old", "", old)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ x_library(name = "foo")
 
 x_library(name = "bar")
 `)
-	f, err := LoadData("old", old)
+	f, err := LoadData("old", "", old)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ x_library(name = "bar")
 }
 
 func TestSymbolsReturnsKeys(t *testing.T) {
-	f, err := LoadData("load", []byte(`load("a.bzl", "y", z = "a")`))
+	f, err := LoadData("load", "", []byte(`load("a.bzl", "y", z = "a")`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ x_library(name = "x")
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			f, err := LoadData(tc.desc, []byte(tc.src))
+			f, err := LoadData(tc.desc, "", []byte(tc.src))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
* The flags -experimental_{read,write}_build_files_dir may now be used
  to read and write build files to alternate directories, which may be
  outside of the repository root.
* When a build file is read from an alternate directory, the build
  file in the source directory is ignored.
* When a build file is written to an alternate directory, any existing
  build file in that directory is replaced. The build file in the
  source directory is not updated.