### PR TITLE
internal/repos: resolve the VCS when importing from a lock file

### DIFF
--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -190,7 +190,9 @@ func updateImportPaths(c *updateReposConfig, f *rule.File, kinds map[string]rule
 }
 
 func importFromLockFile(c *updateReposConfig, f *rule.File, kinds map[string]rule.KindInfo) error {
-	genRules, err := repos.ImportRepoRules(c.lockFilename)
+	rules := repos.ListRepositories(f)
+	cache := repos.NewRemoteCache(rules)
+	genRules, err := repos.ImportRepoRules(c.lockFilename, cache)
 	if err != nil {
 		return err
 	}

--- a/internal/repos/import_test.go
+++ b/internal/repos/import_test.go
@@ -72,7 +72,8 @@ func TestImportDep(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rules, err := ImportRepoRules(lockFilename)
+	cache := NewRemoteCache(nil)
+	rules, err := ImportRepoRules(lockFilename, cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,6 +94,7 @@ go_repository(
     commit = "a93e51b5a57ef416dac8bb02d11407b6f55d8929",
     importpath = "github.com/Masterminds/semver",
     remote = "https://github.com/carolynvs/semver.git",
+    vcs = "git",
 )
 
 go_repository(


### PR DESCRIPTION
This will make the `update-repos -from_file=` actually work because it was generating `go_repository` rules potentially with a `remote` but without a `vcs`.
There is one problem tho, where the repository in the Gopkg.lock is a private repository.
`dep` will create an entry with the URL like `https://github.com/.....git`, so it will end up in the WORKSPACE with this URL, but bazel is unable to resolve this.
I don't have a solution for that particular problem, but to sed the `Gopkg.lock` to transform private repositories to `git@github.com:...`.