### PR TITLE
Run gazelle inside local_repository

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -47,6 +47,7 @@ def _gazelle_runner_impl(ctx):
 """.format(label = str(ctx.label)),
         "@@RUNNER_LABEL@@": shell.quote(str(ctx.label)),
         "@@GOTOOL@@": shell.quote(go.go.path),
+        "@@WORKSPACE@@": shell.quote(ctx.file.workspace.short_path),
     }
     ctx.actions.expand_template(
         template = ctx.file._template,

--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -24,6 +24,7 @@ GAZELLE_SHORT_PATH=@@GAZELLE_SHORT_PATH@@
 GAZELLE_LABEL=@@GAZELLE_LABEL@@
 ARGS=@@ARGS@@
 GOTOOL=@@GOTOOL@@
+WORKSPACE=@@WORKSPACE@@
 
 # find_repo_root prints the absolute path to the repository root. This is
 # discovered by locating the WORKSPACE file in a parent directory, and
@@ -39,7 +40,7 @@ function find_repo_root {
     exit 1
   fi
   if [ "$is_bazel_run" = true ]; then
-    dirname $(readlink WORKSPACE)
+    readlink WORKSPACE
   else
     pwd
   fi
@@ -70,13 +71,19 @@ if [ $# -ne 0 ]; then
   ARGS=("$@")
 fi
 
+if [ ! -f "$WORKSPACE" ] || [ ! -L "$WORKSPACE" ]; then
+  WORKSPACE="$(find_repo_root)"
+else
+  WORKSPACE="$(readlink $WORKSPACE)"
+fi
+
 if [ "$is_bazel_run" = true ]; then
   # If the script was invoked by "bazel run", jump out of the execroot, into
   # the workspace before running Gazelle.
   # TODO(jayconrod): detect when a command can't be run this way.
   export GOROOT=$(cd "$(dirname "$GOTOOL")/.."; pwd)
   gazelle_short_path=$(readlink "$GAZELLE_SHORT_PATH")
-  cd $(find_repo_root)
+  cd $(dirname "$WORKSPACE")
   "$gazelle_short_path" "${ARGS[@]}"
 else
   # If the script was invoked directly, check whether the script is out of


### PR DESCRIPTION
This change makes it possible to use gazelle inside a vendored repository, which currently fails with
```
gazelle: -repo_root not specified, and WORKSPACE cannot be found: file does not exist
```

To use this feature, one must:
- Copy all files of the library into `<repo_root>/third_party/com_github_external_library`
- Add (1) to `<repo_root>/WORKSPACE`
- Create `<repo_root>/third_party/com_github_external_library/WORKSPACE` (can be empty)
- Create `<repo_root>/third_party/com_github_external_library/BUILD.bazel` with (2).
- Run `bazel run @com_github_external_library//:gazelle`

(1)
```
local_repository(
    name = "com_github_external_library",
    path = "third_party/com_github_external_library",
)
```

(2)
```
# gazelle:prefix github.com/external/library

load("@bazel_gazelle//:def.bzl", "gazelle")

gazelle(name = "gazelle")

exports_files(["WORKSPACE"])
```