### PR TITLE
go_repository should allow the env var GIT_SSL_CAINFO

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -58,6 +58,8 @@ def _go_repository_impl(ctx):
             fetch_repo_env["HTTP_PROXY"] = ctx.os.environ["HTTP_PROXY"]
         if "HTTPS_PROXY" in ctx.os.environ:
             fetch_repo_env["HTTPS_PROXY"] = ctx.os.environ["HTTPS_PROXY"]
+        if "GIT_SSL_CAINFO" in ctx.os.environ:
+            fetch_repo_env["GIT_SSL_CAINFO"] = ctx.os.environ["GIT_SSL_CAINFO"]
 
         _fetch_repo = "@bazel_gazelle_go_repository_tools//:bin/fetch_repo{}".format(executable_extension(ctx))
         args = [


### PR DESCRIPTION
I'm trying to package up Bazel watcher for Nix, but I'm running into an issue where the SSL certificate fails. It fails because nix builds in a sandbox that has no /etc in path. I need to export GIT_SSL_CAINFO in order for git to find the tls certs.