### PR TITLE
internal/testtools: new package for test utilities

### DIFF
--- a/internal/language/go/BUILD.bazel
+++ b/internal/language/go/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//internal/repos:go_default_library",
         "//internal/resolve:go_default_library",
         "//internal/rule:go_default_library",
+        "//internal/testtools:go_default_library",
         "//internal/walk:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/golang.org/x/tools/go/vcs:go_default_library",

--- a/internal/language/go/fileinfo_go_test.go
+++ b/internal/language/go/fileinfo_go_test.go
@@ -361,10 +361,10 @@ import "C"
 	if err := ioutil.WriteFile(goFile, content, 0644); err != nil {
 		t.Fatal(err)
 	}
-	c, _, _ := testConfig()
-	c.RepoRoot = repo
-	gc := getGoConfig(c)
-	gc.prefix = "example.com/repo"
+	c, _, _ := testConfig(
+		t,
+		"-repo_root="+repo,
+		"-go_prefix=example.com/repo")
 	pkgs, _ := buildPackages(c, sub, "sub", []string{"sub.go"}, false)
 	got, ok := pkgs["sub"]
 	if !ok {

--- a/internal/language/go/fileinfo_test.go
+++ b/internal/language/go/fileinfo_test.go
@@ -498,7 +498,7 @@ import "C"
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, _, _ := testConfig()
+			c, _, _ := testConfig(t)
 			gc := getGoConfig(c)
 			gc.genericTags = tc.genericTags
 			if gc.genericTags == nil {

--- a/internal/language/go/fix_test.go
+++ b/internal/language/go/fix_test.go
@@ -407,10 +407,11 @@ go_proto_library(name = "foo_proto")
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			testFix(t, tc, func(f *rule.File) {
-				c, _, _ := testConfig()
+				c, langs, _ := testConfig(t)
 				c.ShouldFix = true
-				lang := New()
-				lang.Fix(c, f)
+				for _, lang := range langs {
+					lang.Fix(c, f)
+				}
 			})
 		})
 	}

--- a/internal/language/go/resolve_test.go
+++ b/internal/language/go/resolve_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/label"
-	"github.com/bazelbuild/bazel-gazelle/internal/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/internal/repos"
 	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
@@ -724,10 +723,10 @@ go_library(
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, _, langs := testConfig()
-			gc := getGoConfig(c)
-			gc.prefix = "example.com/repo/resolve"
-			gc.depMode = vendorMode
+			c, langs, _ := testConfig(
+				t,
+				"-go_prefix=example.com/repo/resolve",
+				"-external=vendored")
 			kindToResolver := make(map[string]resolve.Resolver)
 			for _, lang := range langs {
 				for kind := range lang.Kinds() {
@@ -771,11 +770,10 @@ go_library(
 }
 
 func TestResolveDisableGlobal(t *testing.T) {
-	c, _, langs := testConfig()
-	gc := getGoConfig(c)
-	gc.prefix = "example.com/repo"
-	gc.prefixSet = true
-	proto.GetProtoConfig(c).Mode = proto.DisableGlobalMode
+	c, langs, _ := testConfig(
+		t,
+		"-go_prefix=example.com/repo",
+		"-proto=disable_global")
 	ix := resolve.NewRuleIndex(nil)
 	ix.Finish()
 	rc := testRemoteCache([]repos.Repo{
@@ -856,9 +854,9 @@ go_library(
 }
 
 func TestResolveExternal(t *testing.T) {
-	c, _, langs := testConfig()
-	gc := getGoConfig(c)
-	gc.prefix = "example.com/local"
+	c, langs, _ := testConfig(
+		t,
+		"-go_prefix=example.com/local")
 	ix := resolve.NewRuleIndex(nil)
 	ix.Finish()
 	gl := langs[1].(*goLang)

--- a/internal/language/proto/BUILD.bazel
+++ b/internal/language/proto/BUILD.bazel
@@ -48,10 +48,12 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/label:go_default_library",
+        "//internal/language:go_default_library",
         "//internal/merger:go_default_library",
         "//internal/repos:go_default_library",
         "//internal/resolve:go_default_library",
         "//internal/rule:go_default_library",
+        "//internal/testtools:go_default_library",
         "//internal/walk:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],

--- a/internal/testtools/BUILD.bazel
+++ b/internal/testtools/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    testonly = True,
+    srcs = ["config.go"],
+    importpath = "github.com/bazelbuild/bazel-gazelle/internal/testtools",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/config:go_default_library",
+        "//internal/language:go_default_library",
+    ],
+)

--- a/internal/testtools/config.go
+++ b/internal/testtools/config.go
@@ -1,0 +1,53 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testtools
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/language"
+)
+
+// NewTestConfig returns a Config used for tests in any language extension.
+// cexts is a list of configuration extensions to use. langs is a list of
+// language extensions to use (languages are also configuration extensions,
+// but it may be convenient to keep them separate). args is a list of
+// command line arguments to apply. NewTestConfig calls t.Fatal if any
+// error is encountered while processing flags.
+func NewTestConfig(t *testing.T, cexts []config.Configurer, langs []language.Language, args []string) *config.Config {
+	c := config.New()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	for _, lang := range langs {
+		cexts = append(cexts, lang)
+	}
+	for _, cext := range cexts {
+		cext.RegisterFlags(fs, "update", c)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	for _, cext := range cexts {
+		if err := cext.CheckFlags(fs, c); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return c
+}

--- a/internal/walk/BUILD.bazel
+++ b/internal/walk/BUILD.bazel
@@ -22,5 +22,6 @@ go_test(
     deps = [
         "//internal/config:go_default_library",
         "//internal/rule:go_default_library",
+        "//internal/testtools:go_default_library",
     ],
 )


### PR DESCRIPTION
testtools currently provides one function, NewTestConfig, which
produces a config.Config for tests in other packages. internal/walk,
internal/language/proto, and internal/language/go are migrated to use
this. This should reduce the amount of hackery around test
configuration.