### PR TITLE
internal/walk: make Configurer public

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -134,8 +134,8 @@ var genericLoads = []rule.LoadInfo{
 }
 
 func runFixUpdate(cmd command, args []string) error {
-	cexts := make([]config.Configurer, 0, len(languages)+2)
-	cexts = append(cexts, &config.CommonConfigurer{}, &updateConfigurer{})
+	cexts := make([]config.Configurer, 0, len(languages)+3)
+	cexts = append(cexts, &config.CommonConfigurer{}, &updateConfigurer{}, &walk.Configurer{})
 	kindToResolver := make(map[string]resolve.Resolver)
 	kinds := make(map[string]rule.KindInfo)
 	loads := genericLoads

--- a/internal/language/go/config_test.go
+++ b/internal/language/go/config_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/internal/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	"github.com/bazelbuild/bazel-gazelle/internal/testtools"
+	"github.com/bazelbuild/bazel-gazelle/internal/walk"
 )
 
 func testConfig(t *testing.T, args ...string) (*config.Config, []language.Language, []config.Configurer) {
@@ -43,7 +44,7 @@ func testConfig(t *testing.T, args ...string) (*config.Config, []language.Langua
 		args = append(args, "-repo_root=.")
 	}
 
-	cexts := []config.Configurer{&config.CommonConfigurer{}}
+	cexts := []config.Configurer{&config.CommonConfigurer{}, &walk.Configurer{}}
 	langs := []language.Language{proto.New(), New()}
 	c := testtools.NewTestConfig(t, cexts, langs, args)
 	for _, lang := range langs {

--- a/internal/language/proto/generate_test.go
+++ b/internal/language/proto/generate_test.go
@@ -154,7 +154,7 @@ func TestGeneratePackage(t *testing.T) {
 }
 
 func testConfig(t *testing.T, repoRoot string) *config.Config {
-	cexts := []config.Configurer{&config.CommonConfigurer{}}
+	cexts := []config.Configurer{&config.CommonConfigurer{}, &walk.Configurer{}}
 	langs := []language.Language{New()}
 	c := testtools.NewTestConfig(t, cexts, langs, []string{
 		"-build_file_name=BUILD.old",

--- a/internal/walk/config.go
+++ b/internal/walk/config.go
@@ -18,7 +18,6 @@ package walk
 import (
 	"flag"
 	"path"
-	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
@@ -31,56 +30,49 @@ type walkConfig struct {
 
 const walkName = "_walk"
 
-func getWalkConfig(c *config.Config) walkConfig {
-	return c.Exts[walkName].(walkConfig)
+func getWalkConfig(c *config.Config) *walkConfig {
+	return c.Exts[walkName].(*walkConfig)
 }
 
-func (wc *walkConfig) isExcluded(base string) bool {
+func (wc *walkConfig) isExcluded(rel, base string) bool {
+	f := path.Join(rel, base)
 	for _, x := range wc.excludes {
-		if base == x {
+		if f == x {
 			return true
 		}
 	}
 	return false
 }
 
-type walkConfigurer struct{}
+type Configurer struct{}
 
-func (_ *walkConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
+func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
+	wc := &walkConfig{}
+	c.Exts[walkName] = wc
+}
 
-func (_ *walkConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
+func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
 
-func (_ *walkConfigurer) KnownDirectives() []string {
+func (_ *Configurer) KnownDirectives() []string {
 	return []string{"exclude", "ignore"}
 }
 
-func (_ *walkConfigurer) Configure(c *config.Config, rel string, f *rule.File) {
-	var wc walkConfig
-	if raw, ok := c.Exts[walkName]; ok {
-		wc = raw.(walkConfig)
-		wc.ignore = false
-		if rel != "" {
-			prefix := path.Base(rel) + "/"
-			excludes := make([]string, 0, len(wc.excludes))
-			for _, x := range wc.excludes {
-				if strings.HasPrefix(x, prefix) {
-					excludes = append(excludes, x[len(prefix):])
-				}
-			}
-			wc.excludes = excludes
-		}
-	}
+func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
+	wc := getWalkConfig(c)
+	wcCopy := &walkConfig{}
+	*wcCopy = *wc
+	wcCopy.ignore = false
 
 	if f != nil {
 		for _, d := range f.Directives {
 			switch d.Key {
 			case "exclude":
-				wc.excludes = append(wc.excludes, d.Value)
+				wcCopy.excludes = append(wcCopy.excludes, path.Join(rel, d.Value))
 			case "ignore":
-				wc.ignore = true
+				wcCopy.ignore = true
 			}
 		}
 	}
 
-	c.Exts[walkName] = wc
+	c.Exts[walkName] = wcCopy
 }

--- a/internal/walk/walk_test.go
+++ b/internal/walk/walk_test.go
@@ -368,7 +368,7 @@ func createFiles(files []fileSpec) (string, error) {
 }
 
 func testConfig(t *testing.T, repoRoot string) (*config.Config, []config.Configurer) {
-	cexts := []config.Configurer{&config.CommonConfigurer{}}
+	cexts := []config.Configurer{&config.CommonConfigurer{}, &Configurer{}}
 	c := testtools.NewTestConfig(t, cexts, nil, []string{"-repo_root=" + repoRoot})
 	return c, cexts
 }


### PR DESCRIPTION
internal/walk.Configurer is now public. A walk.Configurer
implementation must be included in the cexts. This normalizes handling
of configuration within walk.

Also, a small change to the way walkConfig tracks excluded files: each
excluded file is a path relative to the repository root instead of a
path relative to the current directory.