### PR TITLE
fix-update: add -index, -r flags to control indexing and recursion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,10 +36,6 @@ import (
 // information is language-specific and is stored in Exts. This information
 // is modified by extensions that implement Configurer.
 type Config struct {
-	// Dirs is a list of absolute, canonical paths to directories where Gazelle
-	// should run.
-	Dirs []string
-
 	// RepoRoot is the absolute, canonical path to the root directory of the
 	// repository with all symlinks resolved.
 	RepoRoot string

--- a/internal/language/go/generate_test.go
+++ b/internal/language/go/generate_test.go
@@ -39,7 +39,7 @@ func TestGenerateRules(t *testing.T) {
 	for _, lang := range langs {
 		loads = append(loads, lang.Loads()...)
 	}
-	walk.Walk(c, cexts, func(dir, rel string, c *config.Config, update bool, oldFile *rule.File, subdirs, regularFiles, genFiles []string) {
+	walk.Walk(c, cexts, []string{"testdata"}, walk.VisitAllUpdateSubdirsMode, func(dir, rel string, c *config.Config, update bool, oldFile *rule.File, subdirs, regularFiles, genFiles []string) {
 		t.Run(rel, func(t *testing.T) {
 			var empty, gen []*rule.Rule
 			for _, lang := range langs {

--- a/internal/language/proto/generate_test.go
+++ b/internal/language/proto/generate_test.go
@@ -36,7 +36,7 @@ func TestGenerateRules(t *testing.T) {
 	lang := New()
 	c := testConfig(t, "testdata")
 
-	walk.Walk(c, []config.Configurer{lang}, func(dir, rel string, c *config.Config, update bool, oldFile *rule.File, subdirs, regularFiles, genFiles []string) {
+	walk.Walk(c, []config.Configurer{lang}, []string{"testdata"}, walk.VisitAllUpdateSubdirsMode, func(dir, rel string, c *config.Config, update bool, oldFile *rule.File, subdirs, regularFiles, genFiles []string) {
 		isTest := false
 		for _, name := range regularFiles {
 			if name == "BUILD.want" {

--- a/internal/walk/config.go
+++ b/internal/walk/config.go
@@ -47,8 +47,7 @@ func (wc *walkConfig) isExcluded(rel, base string) bool {
 type Configurer struct{}
 
 func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
-	wc := &walkConfig{}
-	c.Exts[walkName] = wc
+	c.Exts[walkName] = &walkConfig{}
 }
 
 func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }


### PR DESCRIPTION
When the -r flag is true (it is by default), Gazelle will update
directories listed in positional arguments and subdirectories.

When the -index flag is true (it is by default), Gazelle will build an
index of libraries for dependency resolution.

When both -r and -index are false, Gazelle may visit only the
directories listed in positional arguments.