### PR TITLE
Fix internal/walk.TestUpdateDirs on macOS

### DIFF
--- a/internal/walk/walk_test.go
+++ b/internal/walk/walk_test.go
@@ -388,6 +388,11 @@ func createFiles(files []fileSpec) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	dir, err = filepath.EvalSymlinks(dir) // macOS has symlinks in temp dir.
+	if err != nil {
+		return "", err
+	}
+
 	for _, f := range files {
 		path := filepath.Join(dir, f.path)
 		if strings.HasSuffix(f.path, "/") {


### PR DESCRIPTION
Walk was getting confused by a symlink in the temporary
directory. This only happened with go test, not with Bazel.