### PR TITLE
internal/resolve: add gazelle:resolve directive

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -158,7 +158,11 @@ var genericLoads = []rule.LoadInfo{
 
 func runFixUpdate(cmd command, args []string) error {
 	cexts := make([]config.Configurer, 0, len(languages)+3)
-	cexts = append(cexts, &config.CommonConfigurer{}, &updateConfigurer{}, &walk.Configurer{})
+	cexts = append(cexts,
+		&config.CommonConfigurer{},
+		&updateConfigurer{},
+		&walk.Configurer{},
+		&resolve.Configurer{})
 	kindToResolver := make(map[string]resolve.Resolver)
 	kinds := make(map[string]rule.KindInfo)
 	loads := genericLoads

--- a/internal/language/go/config_test.go
+++ b/internal/language/go/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
 	"github.com/bazelbuild/bazel-gazelle/internal/language"
 	"github.com/bazelbuild/bazel-gazelle/internal/language/proto"
+	"github.com/bazelbuild/bazel-gazelle/internal/resolve"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 	"github.com/bazelbuild/bazel-gazelle/internal/testtools"
 	"github.com/bazelbuild/bazel-gazelle/internal/walk"
@@ -44,7 +45,11 @@ func testConfig(t *testing.T, args ...string) (*config.Config, []language.Langua
 		args = append(args, "-repo_root=.")
 	}
 
-	cexts := []config.Configurer{&config.CommonConfigurer{}, &walk.Configurer{}}
+	cexts := []config.Configurer{
+		&config.CommonConfigurer{},
+		&walk.Configurer{},
+		&resolve.Configurer{},
+	}
 	langs := []language.Language{proto.New(), New()}
 	c := testtools.NewTestConfig(t, cexts, langs, args)
 	for _, lang := range langs {

--- a/internal/language/go/resolve.go
+++ b/internal/language/go/resolve.go
@@ -115,6 +115,10 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repos.RemoteCache, r
 		return label.NoLabel, skipImportError
 	}
 
+	if l, ok := resolve.FindRuleWithOverride(c, resolve.ImportSpec{Lang: "go", Imp: imp}, "go"); ok {
+		return l, nil
+	}
+
 	if pc.Mode.ShouldUseKnownImports() {
 		// These are commonly used libraries that depend on Well Known Types.
 		// They depend on the generated versions of these protos to avoid conflicts.
@@ -234,6 +238,10 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repos.RemoteCache
 
 	if wellKnownProtos[imp] {
 		return label.NoLabel, skipImportError
+	}
+
+	if l, ok := resolve.FindRuleWithOverride(c, resolve.ImportSpec{Lang: "proto", Imp: imp}, "go"); ok {
+		return l, nil
 	}
 
 	if l, ok := knownProtoImports[imp]; ok && pc.Mode.ShouldUseKnownImports() {

--- a/internal/language/proto/resolve.go
+++ b/internal/language/proto/resolve.go
@@ -44,7 +44,6 @@ func (_ *protoLang) Embeds(r *rule.Rule, from label.Label) []label.Label {
 }
 
 func (_ *protoLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repos.RemoteCache, r *rule.Rule, from label.Label) {
-	pc := GetProtoConfig(c)
 	importsRaw := r.PrivateAttr(config.GazelleImportsKey)
 	if importsRaw == nil {
 		// may not be set in tests.
@@ -54,7 +53,7 @@ func (_ *protoLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repos.R
 	r.DelAttr("deps")
 	deps := make([]string, 0, len(imports))
 	for _, imp := range imports {
-		l, err := resolveProto(pc, ix, r, imp, from)
+		l, err := resolveProto(c, ix, r, imp, from)
 		if err == skipImportError {
 			continue
 		} else if err != nil {
@@ -74,9 +73,14 @@ var (
 	notFoundError   = errors.New("not found")
 )
 
-func resolveProto(pc *ProtoConfig, ix *resolve.RuleIndex, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
+func resolveProto(c *config.Config, ix *resolve.RuleIndex, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
+	pc := GetProtoConfig(c)
 	if !strings.HasSuffix(imp, ".proto") {
 		return label.NoLabel, fmt.Errorf("can't import non-proto: %q", imp)
+	}
+
+	if l, ok := resolve.FindRuleWithOverride(c, resolve.ImportSpec{Imp: imp, Lang: "proto"}, "proto"); ok {
+		return l, nil
 	}
 
 	if l, ok := knownImports[imp]; ok && pc.Mode.ShouldUseKnownImports() {

--- a/internal/resolve/BUILD.bazel
+++ b/internal/resolve/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["index.go"],
+    srcs = [
+        "config.go",
+        "index.go",
+    ],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/resolve",
     visibility = ["//visibility:public"],
     deps = [

--- a/internal/resolve/config.go
+++ b/internal/resolve/config.go
@@ -1,0 +1,115 @@
+/* Copyright 2018 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolve
+
+import (
+	"flag"
+	"log"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	"github.com/bazelbuild/bazel-gazelle/internal/label"
+	"github.com/bazelbuild/bazel-gazelle/internal/rule"
+)
+
+// FindRuleWithOverride searches the current configuration for user-specified
+// dependency resolution overrides. Overrides specified later (in configuration
+// files in deeper directories, or closer to the end of the file) are
+// returned first. If no override is found, label.NoLabel is returned.
+func FindRuleWithOverride(c *config.Config, imp ImportSpec, lang string) (label.Label, bool) {
+	rc := getResolveConfig(c)
+	for i := len(rc.overrides) - 1; i >= 0; i-- {
+		o := rc.overrides[i]
+		if o.matches(imp, lang) {
+			return o.dep, true
+		}
+	}
+	return label.NoLabel, false
+}
+
+type overrideSpec struct {
+	imp  ImportSpec
+	lang string
+	dep  label.Label
+}
+
+func (o overrideSpec) matches(imp ImportSpec, lang string) bool {
+	return imp.Lang == o.imp.Lang &&
+		imp.Imp == o.imp.Imp &&
+		(o.lang == "" || o.lang == lang)
+}
+
+type resolveConfig struct {
+	overrides []overrideSpec
+}
+
+const resolveName = "_resolve"
+
+func getResolveConfig(c *config.Config) *resolveConfig {
+	return c.Exts[resolveName].(*resolveConfig)
+}
+
+type Configurer struct{}
+
+func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
+	c.Exts[resolveName] = &resolveConfig{}
+}
+
+func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
+
+func (_ *Configurer) KnownDirectives() []string {
+	return []string{"resolve"}
+}
+
+func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
+	rc := getResolveConfig(c)
+	rcCopy := &resolveConfig{
+		overrides: rc.overrides[:],
+	}
+
+	if f != nil {
+		for _, d := range f.Directives {
+			if d.Key == "resolve" {
+				parts := strings.Fields(d.Value)
+				o := overrideSpec{}
+				var lbl string
+				if len(parts) == 3 {
+					o.imp.Lang = parts[0]
+					o.imp.Imp = parts[1]
+					lbl = parts[2]
+				} else if len(parts) == 4 {
+					o.imp.Lang = parts[0]
+					o.lang = parts[1]
+					o.imp.Imp = parts[2]
+					lbl = parts[3]
+				} else {
+					log.Printf("could not parse directive: %s\n\texpected gazelle:resolve source-language [import-language] import-string label", d.Value)
+					continue
+				}
+				var err error
+				o.dep, err = label.Parse(lbl)
+				if err != nil {
+					log.Printf("gazelle:resolve %s: %v", d.Value, err)
+					continue
+				}
+				o.dep = o.dep.Abs("", rel)
+				rcCopy.overrides = append(rcCopy.overrides, o)
+			}
+		}
+	}
+
+	c.Exts[resolveName] = rcCopy
+}

--- a/internal/resolve/index.go
+++ b/internal/resolve/index.go
@@ -195,8 +195,6 @@ type FindResult struct {
 	// a matched rule.
 	Label label.Label
 
-	Rule *rule.Rule
-
 	// Embeds is the transitive closure of labels for rules that the matched
 	// rule embeds. It may contains duplicates and does not include the label
 	// for the rule itself.
@@ -222,7 +220,6 @@ func (ix *RuleIndex) FindRulesByImport(imp ImportSpec, lang string) []FindResult
 		}
 		results = append(results, FindResult{
 			Label:  m.label,
-			Rule:   m.rule,
 			Embeds: m.embeds,
 		})
 	}


### PR DESCRIPTION
Users can now write directives like:
"# gazelle:resolve source-lang [import-lang] import-string label"
to override normal dependency resolution rules. These overrides behave
like normal configuration directives: they are effective in the
directory of the build file that contains them as well as
subdirectories.

Fixes #217