### PR TITLE
internal/language/go: special case for google.golang.org/grpc

### DIFF
--- a/internal/language/go/resolve.go
+++ b/internal/language/go/resolve.go
@@ -140,6 +140,8 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repos.RemoteCache, r
 			return label.New("com_github_golang_protobuf", "descriptor", "go_default_library_gen"), nil
 		case "github.com/golang/protobuf/ptypes":
 			return label.New("com_github_golang_protobuf", "ptypes", "go_default_library_gen"), nil
+		case "google.golang.org/grpc":
+			return label.New("org_golang_google_grpc", "", "go_default_library"), nil
 		}
 		if l, ok := knownGoProtoImports[imp]; ok {
 			return l, nil

--- a/internal/language/go/resolve_test.go
+++ b/internal/language/go/resolve_test.go
@@ -753,7 +753,7 @@ go_library(
 )
 `,
 		}, {
-			desc: "proto_ptypes",
+			desc: "proto_special",
 			old: buildFile{content: `
 go_library(
     name = "go_default_library",
@@ -761,6 +761,7 @@ go_library(
         "github.com/golang/protobuf/jsonpb",
         "github.com/golang/protobuf/descriptor",
         "github.com/golang/protobuf/ptypes",
+        "google.golang.org/grpc",
     ],
 )
 `},
@@ -771,6 +772,7 @@ go_library(
         "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 `,


### PR DESCRIPTION
The import "google.golang.org/grpc" now resolves to the label
"@org_golang_google_grpc//:go_default_library" when proto rule
generation is enabled.

go_proto_library adds this dependency implicitly when the go_grpc
compiler is used. If google.golang.org/grpc is vendored and gazelle
resolves the vendored version, that causes conflicts which are
difficult to resolve.

This can be bypassed by disabling proto rule generation or using the
new "# gazelle:resolve" directive.

Fixes #217