### PR TITLE
internal/walk: add follow directives to follow symlinks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,6 +424,16 @@ The following directives are recognized:
 | vendor tree. This directive may be repeated to exclude multiple paths, one   |
 | per line.                                                                    |
 +------------------------------------------+-----------------------------------+
+| :direc:`# gazelle:follow path`           | n/a                               |
++------------------------------------------+-----------------------------------+
+| Instructs Gazelle to follow a symbolic link to a directory within the        |
+| repository. Normally, Gazelle does not follow symbolic links unless they     |
+| point outside of the repository root.                                        |
+|                                                                              |
+| Care must be taken to avoid visiting a directory more than once.             |
+| The ``# gazelle:exclude`` directive may be used to prevent Gazelle from      |
+| recursing into a directory.                                                  |
++------------------------------------------+-----------------------------------+
 | :direc:`# gazelle:ignore`                | n/a                               |
 +------------------------------------------+-----------------------------------+
 | Prevents Gazelle from modifying the build file. Gazelle will still read      |

--- a/internal/walk/config.go
+++ b/internal/walk/config.go
@@ -26,6 +26,7 @@ import (
 type walkConfig struct {
 	excludes []string
 	ignore   bool
+	follow   []string
 }
 
 const walkName = "_walk"
@@ -53,7 +54,7 @@ func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Confi
 func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
 
 func (_ *Configurer) KnownDirectives() []string {
-	return []string{"exclude", "ignore"}
+	return []string{"exclude", "follow", "ignore"}
 }
 
 func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
@@ -67,6 +68,8 @@ func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 			switch d.Key {
 			case "exclude":
 				wcCopy.excludes = append(wcCopy.excludes, path.Join(rel, d.Value))
+			case "follow":
+				wcCopy.follow = append(wcCopy.follow, path.Join(rel, d.Value))
 			case "ignore":
 				wcCopy.ignore = true
 			}


### PR DESCRIPTION
'# gazelle:follow link' directives can now be written in build
files. Gazelle will symbolic links to directories named in these
directives. Gazelle normally doesn't follow symbolic links within a
repository.

Care must be taken to avoid visiting a directory more than once. The
'# gazelle:exclude' directive may be used for this.