### PR TITLE
add NO_PROXY in env_keys while fetching repos for respecting system's NO_PROXY

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -55,6 +55,7 @@ def _go_repository_impl(ctx):
             "SSH_AUTH_SOCK",
             "HTTP_PROXY",
             "HTTPS_PROXY",
+            "NO_PROXY",
             "GIT_SSL_CAINFO",
         ]
         fetch_repo_env = {k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ}


### PR DESCRIPTION
while bazel will respect NO_PROXY but bazel-gazelle doesn't respect. So NO_PROXY should be add into env_list