### PR TITLE
internal/walk: add -exclude command line option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,16 @@ The following flags are accepted:
 | Bazel may still filter sources with these tags. Use                                              |
 | ``bazel build --features gotags=foo,bar`` to set tags at build time.                             |
 +--------------------------------------------------------------+-----------------------------------+
+| :flag:`-exclude path`                                        |                                   |
++--------------------------------------------------------------+-----------------------------------+
+| Prevents Gazelle from processing a file or directory. If the path refers to                      |
+| a source file, Gazelle won't include it in any rules. If the path refers to                      |
+| a directory, Gazelle won't recurse into it.                                                      |
+|                                                                                                  |
+| This option may be repeated. Paths must be slash-separated, relative to the                      |
+| repository root. This is equivalent to the ``# gazelle:exclude path``                            |
+| directive.                                                                                       |
++--------------------------------------------------------------+-----------------------------------+
 | :flag:`-external external|vendored`                          | :value:`external`                 |
 +--------------------------------------------------------------+-----------------------------------+
 | Determines how Gazelle resolves import paths that cannot be resolve in the                       |

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "import_test.go",
+        "modules_test.go",
         "remote_test.go",
         "repo_test.go",
     ],

--- a/internal/walk/BUILD.bazel
+++ b/internal/walk/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/config:go_default_library",
+        "//internal/flag:go_default_library",
         "//internal/pathtools:go_default_library",
         "//internal/rule:go_default_library",
     ],

--- a/internal/walk/config.go
+++ b/internal/walk/config.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/config"
+	gzflag "github.com/bazelbuild/bazel-gazelle/internal/flag"
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
 )
 
@@ -48,7 +49,9 @@ func (wc *walkConfig) isExcluded(rel, base string) bool {
 type Configurer struct{}
 
 func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
-	c.Exts[walkName] = &walkConfig{}
+	wc := &walkConfig{}
+	c.Exts[walkName] = wc
+	fs.Var(&gzflag.MultiFlag{Values: &wc.excludes}, "exclude", "Path to file or directory that should be ignored (may be repeated)")
 }
 
 func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }


### PR DESCRIPTION
-exclude=foo/bar is equivalent to "# gazelle:exclude foo/bar" in the
root build file.

The motivation for this is to provide a simple way to exclude the
vendor directory in go_repository rules, but in a language-neutral
way.

Fixes #300