### PR TITLE
Handle the "replace" directive in go.mod when running "update-repos"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,73 @@ load("//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@io_bazel_rules_go//tests:bazel_tests.bzl", "test_environment")
 
 test_environment()
+
+go_repository(
+    name = "com_github_bazelbuild_buildtools",
+    commit = "80c7f0d45d7e",
+    importpath = "github.com/bazelbuild/buildtools",
+)
+
+go_repository(
+    name = "com_github_burntsushi_toml",
+    importpath = "github.com/BurntSushi/toml",
+    tag = "v0.3.0",
+)
+
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    importpath = "github.com/davecgh/go-spew",
+    tag = "v1.1.0",
+)
+
+go_repository(
+    name = "com_github_fsnotify_fsnotify",
+    importpath = "github.com/fsnotify/fsnotify",
+    tag = "v1.4.7",
+)
+
+go_repository(
+    name = "com_github_pelletier_go_toml",
+    importpath = "github.com/pelletier/go-toml",
+    tag = "v1.0.1",
+)
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    importpath = "github.com/pmezard/go-difflib",
+    tag = "v1.0.0",
+)
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    importpath = "github.com/stretchr/testify",
+    tag = "v1.2.2",
+)
+
+go_repository(
+    name = "in_gopkg_check_v1",
+    commit = "20d25e280405",
+    importpath = "gopkg.in/check.v1",
+)
+
+go_repository(
+    name = "in_gopkg_yaml_v2",
+    importpath = "gopkg.in/yaml.v2",
+    tag = "v2.2.1",
+)
+
+go_repository(
+    name = "org_golang_x_sys",
+    commit = "8469e314837c",
+    importpath = "golang.org/x/sys",
+)
+
+go_repository(
+    name = "org_golang_x_tools",
+    commit = "5d2fd3ccab98",
+    importpath = "golang.org/x/tools",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,6 @@ go_repository(
 
 go_repository(
     name = "org_golang_x_tools",
-    commit = "5d2fd3ccab98",
+    commit = "3e7aa9e59977",
     importpath = "golang.org/x/tools",
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20181004145325-8469e314837c // indirect
-	golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98
+	golang.org/x/tools v0.0.0-20181019201213-3e7aa9e59977
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/pelletier/go-toml v1.0.1
 	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20181004145325-8469e314837c // indirect
 	golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98
 	gopkg.in/yaml.v2 v2.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20181004145325-8469e314837c h1:SJ7JoQNVl3mC7EWkkONgBWgCno8LcABIJwFMkWBC+EY=
 golang.org/x/sys v0.0.0-20181004145325-8469e314837c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98 h1:KhEttxC0n20M9dfd9WD/Dwy190M8IPOGITNI2csSXg0=
-golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181019201213-3e7aa9e59977 h1:gyGiDZZwunzILdKyr2iu0bvDC9KvK4wItjj+aV+sBro=
+golang.org/x/tools v0.0.0-20181019201213-3e7aa9e59977/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pelletier/go-toml v1.0.1 h1:0nx4vKBl23+hEaCOV1mFhKS9vhhBtFYWC7rQY0vJA
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20181004145325-8469e314837c h1:SJ7JoQNVl3mC7EWkkONgBWgCno8LcABIJwFMkWBC+EY=
 golang.org/x/sys v0.0.0-20181004145325-8469e314837c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98 h1:KhEttxC0n20M9dfd9WD/Dwy190M8IPOGITNI2csSXg0=

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "import_test.go",
+        "modules_test.go",
         "remote_test.go",
         "repo_test.go",
     ],
@@ -30,5 +31,6 @@ go_test(
     deps = [
         "//internal/rule:go_default_library",
         "//vendor/golang.org/x/tools/go/vcs:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/internal/repos/import_test.go
+++ b/internal/repos/import_test.go
@@ -28,6 +28,7 @@ import (
 
 func init() {
 	goListModulesFn = goListModulesStub
+	findRemoteFn = findRemoteStub
 }
 
 func TestImports(t *testing.T) {
@@ -257,4 +258,11 @@ func goListModulesStub(dir string) ([]byte, error) {
 	"GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.1.mod"
 }
 `), nil
+}
+
+func findRemoteStub(importpath string) (remote, vcsName string, err error) {
+	if importpath == "github.com/joe-mann/go-toml" {
+		return "https://github.com/joe-mann/go-toml", "git", nil
+	}
+	return "", "", nil
 }

--- a/internal/repos/import_test.go
+++ b/internal/repos/import_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/internal/rule"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -112,6 +113,8 @@ require (
 	golang.org/x/tools v0.0.0-20170824195420-5d2fd3ccab98
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+replace github.com/pelletier/go-toml => github.com/joe-mann/go-toml v1.0.1
 `,
 			want: `
 go_repository(
@@ -135,7 +138,9 @@ go_repository(
 go_repository(
     name = "com_github_pelletier_go_toml",
     importpath = "github.com/pelletier/go-toml",
+    remote = "https://github.com/joe-mann/go-toml",
     tag = "v1.0.1",
+    vcs = "git",
 )
 
 go_repository(
@@ -179,9 +184,7 @@ go_repository(
 			}
 			got := strings.TrimSpace(string(f.Format()))
 			want := strings.TrimSpace(tc.want)
-			if got != want {
-				t.Errorf("got:\n%s\n\nwant:\n%s\n", got, want)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 }
@@ -219,9 +222,16 @@ func goListModulesStub(dir string) ([]byte, error) {
 {
 	"Path": "github.com/pelletier/go-toml",
 	"Version": "v1.0.1",
+	"Replace": {
+		"Path": "github.com/joe-mann/go-toml",
+		"Version": "v1.0.1",
+		"Time": "2017-09-24T18:42:18Z",
+		"Dir": "/usr/local/google/home/jayconrod/go/pkg/mod/github.com/joe-mann/go-toml@v1.0.1",
+		"GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/github.com/joe-mann/go-toml/@v/v1.0.1.mod"
+	},
 	"Time": "2017-09-24T18:42:18Z",
-	"Dir": "/usr/local/google/home/jayconrod/go/pkg/mod/github.com/pelletier/go-toml@v1.0.1",
-	"GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/github.com/pelletier/go-toml/@v/v1.0.1.mod"
+	"Dir": "/usr/local/google/home/jayconrod/go/pkg/mod/github.com/joe-mann/go-toml@v1.0.1",
+	"GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/github.com/joe-mann/go-toml/@v/v1.0.1.mod"
 }
 {
 	"Path": "golang.org/x/tools",

--- a/internal/repos/modules.go
+++ b/internal/repos/modules.go
@@ -44,6 +44,8 @@ type replace struct {
 
 var regexMixedVersioning = regexp.MustCompile(`^(.*?)-([0-9]{14})-([a-fA-F0-9]{12})$`)
 
+var findRemoteFn = findRemote
+
 func toRepoRule(mod module) (*Repo, error) {
 	var version string
 	if mod.Replace != nil {
@@ -62,7 +64,7 @@ func toRepoRule(mod module) (*Repo, error) {
 	var remote, vcs string
 	if mod.Replace != nil {
 		var err error
-		if remote, vcs, err = findRemote(mod.Replace.Path); err != nil {
+		if remote, vcs, err = findRemoteFn(mod.Replace.Path); err != nil {
 			return nil, fmt.Errorf("unable to determine remote for %s (replacement for %s): %s",
 				mod.Replace.Path, mod.Path, err.Error())
 		}


### PR DESCRIPTION
This PR adds handling of "replace" directives found in go.mod when running "update-repos --from_file=go.mod". This allows Gazelle to handle situations where a repository has been forked, or where a repository has been "mirrored" to an internally-hosted location, for example.

Edit: I've just realised that I forgot a small piece of refactoring to remove the tests' reliance being able to talk to the remote "replaced" repositories (when vcs.RepoRootForImportPath is called). I'll fix this issue ASAP.