### PR TITLE
Add "github.com/pkg/errors" to gazelle deps

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -40,6 +40,15 @@ def gazelle_dependencies(go_sdk = "@go_sdk//:ROOT"):
         commit = "f3dd8fd95a7d078cb10fd7fb475b22c3cdbcb307",  # 0.2.0 as of 2017-12-04
     )
 
+    _maybe(
+        go_repository,
+        name = "errors_go",
+        importpath = "github.com/pkg/errors",
+        commit = "30136e27e2ac8d167177e8a583aa4c3fea5be833",
+        patches = ["@bazel_gazelle//internal:repository_rules_test_errors.patch"],
+        patch_args = ["-p1"],
+    )
+
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -14,16 +14,6 @@ register_toolchains(
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
-
-load("@bazel_gazelle//:def.bzl", "go_repository", "git_repository", "http_archive")
-
-go_repository(
-    name = "errors_go",
-    importpath = "github.com/pkg/errors",
-    commit = "30136e27e2ac8d167177e8a583aa4c3fea5be833",
-    patches = ["@bazel_gazelle//internal:repository_rules_test_errors.patch"],
-    patch_args = ["-p1"],
-)
 """
 
 bazel_test(


### PR DESCRIPTION
This change is in preparation of bazelbuild/rules_go#1614, which starts
analyzing targets of bazel_test in the host workspace.