### PR TITLE
internal/language/go: replace ${SRCDIR} with "." in project root

### DIFF
--- a/internal/language/go/fileinfo.go
+++ b/internal/language/go/fileinfo.go
@@ -462,6 +462,9 @@ func expandSrcDir(str string, srcdir string) (string, bool) {
 	// so convert native paths with a different delimiter
 	// to "/" before starting (eg: on windows).
 	srcdir = filepath.ToSlash(srcdir)
+	if srcdir == "" {
+		srcdir = "."
+	}
 
 	// Spaces are tolerated in ${SRCDIR}, but not anywhere else.
 	chunks := strings.Split(str, "${SRCDIR}")

--- a/internal/language/go/testdata/cgolib/BUILD.want
+++ b/internal/language/go/testdata/cgolib/BUILD.want
@@ -18,7 +18,7 @@ go_library(
     clinkopts = ["-lweird"],
     copts = [
         "-I cgolib/sub -iquote cgolib/sub",
-        "-I/weird/path -Icgolib/sub",
+        "-I/weird/path -Icgolib/sub -Icgolib/othersub",
     ],
     importpath = "example.com/repo/cgolib",
     visibility = ["//visibility:public"],

--- a/internal/language/go/testdata/cgolib/foo.go
+++ b/internal/language/go/testdata/cgolib/foo.go
@@ -16,7 +16,7 @@ limitations under the License.
 package cgolib
 
 /**
-#cgo CFLAGS: -I/weird/path -Isub/../sub
+#cgo CFLAGS: -I/weird/path -Isub/../sub -I${SRCDIR}/../othersub
 #cgo CFLAGS: -I sub/../sub -iquote sub/../sub
 #cgo LDFLAGS: -lweird
 **/


### PR DESCRIPTION
Previously, if a cgo file in the project root contained a directive
like `#cgo CPPFLAGS: -I${SRCDIR}/foo`, it would be expanded to
-I/foo. It will now be expanded to -I./foo, which gets simplified to
-Ifoo.

Fixes #348