### PR TITLE
language/go: special case for protoc-gen-go/generator

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -140,6 +140,8 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 			return label.New("com_github_golang_protobuf", "descriptor", "go_default_library_gen"), nil
 		case "github.com/golang/protobuf/ptypes":
 			return label.New("com_github_golang_protobuf", "ptypes", "go_default_library_gen"), nil
+		case "github.com/golang/protobuf/protoc-gen-go/generator":
+			return label.New("com_github_golang_protobuf", "protoc-gen-go/generator", "go_default_library_gen"), nil
 		case "google.golang.org/grpc":
 			return label.New("org_golang_google_grpc", "", "go_default_library"), nil
 		}

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -760,6 +760,7 @@ go_library(
     _imports = [
         "github.com/golang/protobuf/jsonpb",
         "github.com/golang/protobuf/descriptor",
+        "github.com/golang/protobuf/protoc-gen-go/generator",
         "github.com/golang/protobuf/ptypes",
         "google.golang.org/grpc",
     ],
@@ -771,6 +772,7 @@ go_library(
     deps = [
         "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@org_golang_google_grpc//:go_default_library",
     ],


### PR DESCRIPTION
When proto rule generation is enabled, Gazelle now resolves
github.com/golang/protobuf/protoc-gen-go/generator to
@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen
instead of go_default_library.

Fixes #368