### PR TITLE
language/go: add special cases for rules_go and gazelle imports

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -156,6 +156,18 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 		return label.NoLabel, err
 	}
 
+	// Special cases for rules_go and bazel_gazelle.
+	// These have names that don't following conventions and they're
+	// typeically declared with http_archive, not go_repository, so Gazelle
+	// won't recognize them.
+	if pathtools.HasPrefix(imp, "github.com/bazelbuild/rules_go") {
+		pkg := pathtools.TrimPrefix(imp, "github.com/bazelbuild/rules_go")
+		return label.New("io_bazel_rules_go", pkg, "go_default_library"), nil
+	} else if pathtools.HasPrefix(imp, "github.com/bazelbuild/bazel-gazelle") {
+		pkg := pathtools.TrimPrefix(imp, "github.com/bazelbuild/bazel-gazelle")
+		return label.New("bazel_gazelle", pkg, "go_default_library"), nil
+	}
+
 	if pathtools.HasPrefix(imp, gc.prefix) {
 		pkg := path.Join(gc.prefixRel, pathtools.TrimPrefix(imp, gc.prefix))
 		return label.New("", pkg, defaultLibName), nil

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -425,6 +425,26 @@ go_library(
 )
 `,
 		}, {
+			desc: "gazelle_special",
+			old: buildFile{content: `
+go_library(
+    name = "go_default_library",
+    _imports = [
+        "github.com/bazelbuild/bazel-gazelle/language",
+        "github.com/bazelbuild/rules_go/go/tools/bazel",
+    ],
+)        
+`},
+			want: `
+go_library(
+    name = "go_default_library",
+    deps = [
+        "@bazel_gazelle//language:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)
+`,
+		}, {
 			desc: "local_unknown",
 			old: buildFile{content: `
 go_binary(


### PR DESCRIPTION
rules_go and bazel-gazelle both have workspace names that don't follow
normal naming conventions. Both are typically declared with
http_archive instead of go_repository. When libraries from these
repositories are imported, Gazelle will fail to generate correct
labels.

This change adds special cases for these repositories in language/go.

Fixes #363