### PR TITLE
language/go: break hard dependency on language/proto

### DIFF
--- a/language/go/config.go
+++ b/language/go/config.go
@@ -105,6 +105,14 @@ func (gc *goConfig) setBuildTags(tags string) error {
 	return nil
 }
 
+func getProtoMode(c *config.Config) proto.Mode {
+	if pc := proto.GetProtoConfig(c); pc != nil {
+		return pc.Mode
+	} else {
+		return proto.DisableGlobalMode
+	}
+}
+
 // dependencyMode determines how imports of packages outside of the prefix
 // are resolved.
 type dependencyMode int
@@ -194,8 +202,9 @@ func (_ *goLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 	// or when the package name can't be determined.
 	// TODO(jayconrod): deprecate and remove this behavior.
 	gc := getGoConfig(c)
-	pc := proto.GetProtoConfig(c)
-	pc.GoPrefix = gc.prefix
+	if pc := proto.GetProtoConfig(c); pc != nil {
+		pc.GoPrefix = gc.prefix
+	}
 	return nil
 }
 

--- a/language/go/fix.go
+++ b/language/go/fix.go
@@ -187,8 +187,7 @@ func flattenSrcs(c *config.Config, f *rule.File) {
 // are not migrated.
 func removeLegacyProto(c *config.Config, f *rule.File) {
 	// Don't fix if the proto mode was set to something other than the default.
-	pc := proto.GetProtoConfig(c)
-	if pc.Mode != proto.DefaultMode {
+	if pcMode := getProtoMode(c); pcMode != proto.DefaultMode {
 		return
 	}
 

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -92,7 +92,7 @@ func (pkg *goPackage) addFile(c *config.Config, info fileInfo, cgo bool) error {
 	case info.ext == unknownExt || !cgo && (info.ext == cExt || info.ext == csExt):
 		return nil
 	case info.ext == protoExt:
-		if proto.GetProtoConfig(c).Mode == proto.LegacyMode {
+		if pcMode := getProtoMode(c); pcMode == proto.LegacyMode {
 			// Only add files in legacy mode. This is used to generate a filegroup
 			// that contains all protos. In order modes, we get the .proto files
 			// from information emitted by the proto language extension.

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/repo"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
@@ -109,7 +108,7 @@ var (
 
 func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
 	gc := getGoConfig(c)
-	pc := proto.GetProtoConfig(c)
+	pcMode := getProtoMode(c)
 	if build.IsLocalImport(imp) {
 		cleanRel := path.Clean(path.Join(from.Pkg, imp))
 		if build.IsLocalImport(cleanRel) {
@@ -126,7 +125,7 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 		return l, nil
 	}
 
-	if pc.Mode.ShouldUseKnownImports() {
+	if pcMode.ShouldUseKnownImports() {
 		// These are commonly used libraries that depend on Well Known Types.
 		// They depend on the generated versions of these protos to avoid conflicts.
 		// However, since protoc-gen-go depends on these libraries, we generate
@@ -257,7 +256,7 @@ func resolveVendored(rc *repo.RemoteCache, imp string) (label.Label, error) {
 }
 
 func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
-	pc := proto.GetProtoConfig(c)
+	pcMode := getProtoMode(c)
 
 	if wellKnownProtos[imp] {
 		return label.NoLabel, skipImportError
@@ -267,7 +266,7 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache,
 		return l, nil
 	}
 
-	if l, ok := knownProtoImports[imp]; ok && pc.Mode.ShouldUseKnownImports() {
+	if l, ok := knownProtoImports[imp]; ok && pcMode.ShouldUseKnownImports() {
 		if l.Equal(from) {
 			return label.NoLabel, skipImportError
 		} else {

--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -48,8 +48,14 @@ type ProtoConfig struct {
 	groupOption string
 }
 
+// GetProtoConfig returns the proto language configuration. If the proto
+// extension was not run, it will return nil.
 func GetProtoConfig(c *config.Config) *ProtoConfig {
-	return c.Exts[protoName].(*ProtoConfig)
+	pc := c.Exts[protoName]
+	if pc == nil {
+		return nil
+	}
+	return pc.(*ProtoConfig)
 }
 
 // Mode determines how proto rules are generated.


### PR DESCRIPTION
The Go extension no longer requires the proto extension to be run
first. If the proto extension is not run, it should behave as if the
proto extension ran in "disable_global" mode.

Fixes #364