### PR TITLE
Add flag -vendor_dir to control vendor directory when -external is set to vendored.

### DIFF
--- a/language/go/config.go
+++ b/language/go/config.go
@@ -59,6 +59,10 @@ type goConfig struct {
 	// depMode determines how imports that are not standard, indexed, or local
 	// (under the current prefix) should be resolved.
 	depMode dependencyMode
+
+	// vendorDir specifies the vendor directory relative to WORKSPACE. Set with
+	// -vendor_path. It defaults to "vendor".
+	vendorDir string
 }
 
 func newGoConfig() *goConfig {
@@ -192,6 +196,7 @@ func (_ *goLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 			&externalFlag{&gc.depMode},
 			"external",
 			"external: resolve external packages with go_repository\n\tvendored: resolve external packages as packages in vendor/")
+		fs.StringVar(&gc.vendorDir, "vendor_dir", "vendor", "the vendor directory (default: \"vendor\"); used when -external is set to vendored.")
 	}
 	c.Exts[goName] = gc
 }

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -174,9 +174,8 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 
 	if gc.depMode == externalMode {
 		return resolveExternal(rc, imp)
-	} else {
-		return resolveVendored(rc, imp)
 	}
+	return resolveVendored(rc, gc.vendorDir, imp)
 }
 
 // isStandard returns whether a package is in the standard library.
@@ -251,8 +250,11 @@ func resolveExternal(rc *repo.RemoteCache, imp string) (label.Label, error) {
 	return label.New(repo, pkg, defaultLibName), nil
 }
 
-func resolveVendored(rc *repo.RemoteCache, imp string) (label.Label, error) {
-	return label.New("", path.Join("vendor", imp), defaultLibName), nil
+func resolveVendored(rc *repo.RemoteCache, vendorDir, imp string) (label.Label, error) {
+	if vendorDir == "" {
+		vendorDir = "vendor"
+	}
+	return label.New("", path.Join(vendorDir, imp), defaultLibName), nil
 }
 
 func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {


### PR DESCRIPTION
See issue #376.