### PR TITLE
Explicitly export symbols that need it, reformat files with Buildifier

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -19,9 +19,15 @@ load(
 )
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//internal:go_repository.bzl", _go_repository = "go_repository")
-load("//internal:overlay_repository.bzl", "git_repository", "http_archive")
+load(
+    "//internal:overlay_repository.bzl",
+    _git_repository = "git_repository",
+    _http_archive = "http_archive",
+)
 
 go_repository = _go_repository
+git_repository = _git_repository
+http_archive = _http_archive
 
 def _gazelle_runner_impl(ctx):
     go = _go_context(ctx)

--- a/def.bzl
+++ b/def.bzl
@@ -18,8 +18,10 @@ load(
     _go_rule = "go_rule",
 )
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("//internal:go_repository.bzl", "go_repository")
+load("//internal:go_repository.bzl", _go_repository = "go_repository")
 load("//internal:overlay_repository.bzl", "git_repository", "http_archive")
+
+go_repository = _go_repository
 
 def _gazelle_runner_impl(ctx):
     go = _go_context(ctx)

--- a/deps.bzl
+++ b/deps.bzl
@@ -14,9 +14,7 @@
 
 load(
     "@bazel_gazelle//internal:go_repository.bzl",
-    # Load go_repository in order to re-export. Users should get it
-    # from this file.
-    "go_repository",
+    _go_repository = "go_repository",
     _go_repository_tools = "go_repository_tools",
 )
 load(
@@ -30,6 +28,9 @@ load(
     "@bazel_tools//tools/build_defs/repo:git.bzl",
     _tools_git_repository = "git_repository",
 )
+
+# Re-export go_repository . Users should get it from this file.
+go_repository = _go_repository
 
 def gazelle_dependencies(go_sdk = "@go_sdk//:ROOT"):
     _go_repository_tools(


### PR DESCRIPTION
Progress towards https://github.com/bazelbuild/rules_go/issues/1829