### PR TITLE
walk: don't exclude file names starting with "_"

### DIFF
--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -215,6 +215,9 @@ func fileNameInfo(path_ string) fileInfo {
 	default:
 		ext = unknownExt
 	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		ext = unknownExt
+	}
 
 	// Determine test, goos, and goarch. This is intended to match the logic
 	// in goodOSArchFile in go/build.

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -94,8 +94,7 @@ func TestFileNameInfo(t *testing.T) {
 			"_test source",
 			"_test.go",
 			fileInfo{
-				ext:    goExt,
-				isTest: true,
+				ext: unknownExt,
 			},
 		},
 		{
@@ -238,6 +237,12 @@ func TestFileNameInfo(t *testing.T) {
 		{
 			"ignored file",
 			"foo.txt",
+			fileInfo{
+				ext: unknownExt,
+			},
+		}, {
+			"hidden file",
+			".foo.go",
 			fileInfo{
 				ext: unknownExt,
 			},

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -62,6 +62,8 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) (empty, gen []*rule.
 
 	// If proto rule generation is enabled, exclude .pb.go files that correspond
 	// to any .proto files present.
+	regularFiles := append([]string{}, args.RegularFiles...)
+	genFiles := append([]string{}, args.GenFiles...)
 	if !pcMode.ShouldIncludePregeneratedFiles() {
 		keep := func(f string) bool {
 			if strings.HasSuffix(f, ".pb.go") {
@@ -70,14 +72,14 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) (empty, gen []*rule.
 			}
 			return true
 		}
-		filterFiles(&args.RegularFiles, keep)
-		filterFiles(&args.GenFiles, keep)
+		filterFiles(&regularFiles, keep)
+		filterFiles(&genFiles, keep)
 	}
 
 	// Split regular files into files which can determine the package name and
 	// import path and other files.
 	var goFiles, otherFiles []string
-	for _, f := range args.RegularFiles {
+	for _, f := range regularFiles {
 		if strings.HasSuffix(f, ".go") {
 			goFiles = append(goFiles, f)
 		} else {
@@ -190,10 +192,10 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) (empty, gen []*rule.
 		// as static files. Bazel will use the generated files, but we will look at
 		// the content of static files, assuming they will be the same.
 		regularFileSet := make(map[string]bool)
-		for _, f := range args.RegularFiles {
+		for _, f := range regularFiles {
 			regularFileSet[f] = true
 		}
-		for _, f := range args.GenFiles {
+		for _, f := range genFiles {
 			if regularFileSet[f] {
 				continue
 			}

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -140,7 +140,7 @@ func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode,
 		for _, fi := range files {
 			base := fi.Name()
 			switch {
-			case base == "" || base[0] == '.' || base[0] == '_' || wc.isExcluded(rel, base):
+			case base == "" || base[0] == '.' || wc.isExcluded(rel, base):
 				continue
 
 			case fi.IsDir() || fi.Mode()&os.ModeSymlink != 0 && symlinks.follow(c, dir, rel, base):

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -194,7 +194,7 @@ gen(
 			files = append(files, path.Join(rel, f))
 		}
 	})
-	want := []string{"BUILD.bazel"}
+	want := []string{"BUILD.bazel", "_blank"}
 	if !reflect.DeepEqual(files, want) {
 		t.Errorf("got %#v; want %#v", files, want)
 	}


### PR DESCRIPTION
Go considers these hidden files and does not build them. The logic for
filtering these should be in the Go extension instead of walk, since
other languages don't have the same rule.

Fixes #395