### PR TITLE
populating VCS field when go_repository's remote is not null

### DIFF
--- a/repo/dep.go
+++ b/repo/dep.go
@@ -45,7 +45,12 @@ func importRepoRulesDep(filename string) ([]Repo, error) {
 	var repos []Repo
 	for _, p := range file.Projects {
 		var vcs string
-		if len(p.Source) > 0 {
+		if p.Source != "" {
+			// TODO(#411): Handle source directives correctly. It may be an import
+			// path, or a URL. In the case of an import path, we should resolve it
+			// to the correct remote and vcs. In the case of a URL, we should
+			// correctly determine what VCS to use (the URL will usually start
+			// with "https://", which is used by multiple VCSs).
 			vcs = "git"
 		}
 		repos = append(repos, Repo{
@@ -53,7 +58,7 @@ func importRepoRulesDep(filename string) ([]Repo, error) {
 			GoPrefix: p.Name,
 			Commit:   p.Revision,
 			Remote:   p.Source,
-			VCS: vcs,
+			VCS:      vcs,
 		})
 	}
 	return repos, nil

--- a/repo/dep.go
+++ b/repo/dep.go
@@ -44,11 +44,16 @@ func importRepoRulesDep(filename string) ([]Repo, error) {
 
 	var repos []Repo
 	for _, p := range file.Projects {
+		var vcs string
+		if len(p.Source) > 0 {
+			vcs = "git"
+		}
 		repos = append(repos, Repo{
 			Name:     label.ImportPathToBazelRepoName(p.Name),
 			GoPrefix: p.Name,
 			Commit:   p.Revision,
 			Remote:   p.Source,
+			VCS: vcs,
 		})
 	}
 	return repos, nil

--- a/repo/import_test.go
+++ b/repo/import_test.go
@@ -84,6 +84,7 @@ go_repository(
     commit = "a93e51b5a57ef416dac8bb02d11407b6f55d8929",
     importpath = "github.com/Masterminds/semver",
     remote = "https://github.com/carolynvs/semver.git",
+    vcs = "git",
 )
 
 go_repository(


### PR DESCRIPTION
`bazel-gazelle/cmd/fetch_repo` command requires `--vcs` to be present when  `--remote` is present.  As a result, when there is `source` field in dep lock file, the `vcs` field should be populated for the resulting `go_repository` rules as well. Otherwise the subsequent bazel build will fail when it is calling gazelle to fetch external libraries.