### PR TITLE
Do not check if go_prefix is a prefix of import path

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -166,16 +166,16 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 		return label.New("bazel_gazelle", pkg, "go_default_library"), nil
 	}
 
+	if gc.depMode == externalMode {
+		return resolveExternal(rc, imp)
+	}
+
+	// This is a last ditch effort in case the rule index was incomplete.
 	if pathtools.HasPrefix(imp, gc.prefix) {
 		pkg := path.Join(gc.prefixRel, pathtools.TrimPrefix(imp, gc.prefix))
 		return label.New("", pkg, defaultLibName), nil
 	}
-
-	if gc.depMode == externalMode {
-		return resolveExternal(rc, imp)
-	} else {
-		return resolveVendored(rc, imp)
-	}
+	return resolveVendored(rc, imp)
 }
 
 // isStandard returns whether a package is in the standard library.


### PR DESCRIPTION
There are legitimate cases when an import path can have the current
repository's go_prefix as a prefix and yet can belong to a different
repository.

For example, v.io is github.com/vanadium/core, and v.io/x/lib is
github.com/vanadium/go.lib.

When doing external dependency resolution, we should rely on the result
from vcs.RepoRootForImportPath if the import path is not in the
resolver's rule index. For vendored dependency resolution, we can keep
the existing behavior.