### PR TITLE
Include hidden directories during walking

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -140,7 +140,7 @@ func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode,
 		for _, fi := range files {
 			base := fi.Name()
 			switch {
-			case base == "" || base[0] == '.' || wc.isExcluded(rel, base):
+			case base == "" || wc.isExcluded(rel, base):
 				continue
 
 			case fi.IsDir() || fi.Mode()&os.ModeSymlink != 0 && symlinks.follow(c, dir, rel, base):

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -194,7 +194,7 @@ gen(
 			files = append(files, path.Join(rel, f))
 		}
 	})
-	want := []string{"BUILD.bazel", "_blank"}
+	want := []string{".dot", "BUILD.bazel", "_blank"}
 	if !reflect.DeepEqual(files, want) {
 		t.Errorf("got %#v; want %#v", files, want)
 	}


### PR DESCRIPTION
As discussed in #164, Go allows to import packages under hidden directories. If that happens, there is no way to generate build files for those packages. On the other hand, if there are unbuildable Go files in hidden directories, but Gazelle generates build files for them, it is easy to exclude them with `# gazelle: exclude` directives, the same strategy with "testdata"

Our scenario: in some of our projects, we check in the generated code under `.gen` directories. Those directories should be treated as regular Go package.

Fixed #164