### PR TITLE
repo: There are three go pseudoversion formats

### DIFF
--- a/repo/modules.go
+++ b/repo/modules.go
@@ -35,7 +35,23 @@ type module struct {
 	Main          bool
 }
 
-var regexMixedVersioning = regexp.MustCompile(`^(.*?)-([0-9]{14})-([a-fA-F0-9]{12})$`)
+// Per the `go help modules` documentation:
+//   There are three pseudo-version forms:
+//
+//   vX.0.0-yyyymmddhhmmss-abcdefabcdef is used when there is no earlier
+//   versioned commit with an appropriate major version before the target commit.
+//   (This was originally the only form, so some older go.mod files use this form
+//   even for commits that do follow tags.)
+//
+//   vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef is used when the most
+//   recent versioned commit before the target commit is vX.Y.Z-pre.
+//
+//   vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdefabcdef is used when the most
+//   recent versioned commit before the target commit is vX.Y.Z.
+//
+// We need to match all three of these with the following regexp.
+
+var regexMixedVersioning = regexp.MustCompile(`^(.*?)[-.]((?:0\.|)[0-9]{14})-([a-fA-F0-9]{12})$`)
 
 func toRepoRule(mod module) Repo {
 	var tag, commit string

--- a/repo/modules_test.go
+++ b/repo/modules_test.go
@@ -25,6 +25,8 @@ func TestGoModuleSpecialCases(t *testing.T) {
 		{in: "v0.0.0-20180718195005-e651d75abec6", wantCommit: "e651d75abec6"},
 		{in: "v2.0.0+incompatible", wantTag: "v2.0.0"},
 		{in: "v1.0.0-20170511165959-379148ca0225", wantCommit: "379148ca0225"},
+		{in: "v0.8.3-0.20180104185457-379148ca0225", wantCommit: "379148ca0225"},
+		{in: "v0.8.3-pre.0.20180104185457-379148ca0235", wantCommit: "379148ca0235"},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			repo := toRepoRule(module{Version: tc.in})


### PR DESCRIPTION
Go modules use three forms of pseudoversions (per go help modules).
Adjust the regexp used for extracting commit hashes to match the second
and third types. (also block-quote the relevant documentation)

fixes: #417 