### PR TITLE
Load rules_go workspace definitions from deps.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,14 +1,14 @@
 workspace(name = "bazel_gazelle")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_go",
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
+    commit = "68b747f721459407e56391737c975c0d8a12a4f8",
+    remote = "https://github.com/bazelbuild/rules_go",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 


### PR DESCRIPTION
Instead of def.bzl. This needs to be done before rules_go can fully
migrate to deps.bzl, since rules_go's tests depend on Gazelle
WORKSPACE.

Updates bazelbuild/rules_go#1924