### PR TITLE
cmd/move_labels: remove workaround for LoadStmt

### DIFF
--- a/cmd/move_labels/move_labels.go
+++ b/cmd/move_labels/move_labels.go
@@ -114,11 +114,6 @@ func moveLabelsInDir(c *configuration) ([]*build.File, error) {
 
 func moveLabelsInFile(file *build.File, from, to string) {
 	build.Edit(file, func(x build.Expr, _ []build.Expr) build.Expr {
-		// TODO: Remove special case handling for LoadStmt when build.Edit starts
-		// walking inside it to consider the Module field.
-		if loadStmt, ok := x.(*build.LoadStmt); ok {
-			return moveLabelsInLoadStmt(loadStmt, from, to)
-		}
 		str, ok := x.(*build.StringExpr)
 		if !ok {
 			return nil
@@ -135,12 +130,6 @@ func moveLabelsInFile(file *build.File, from, to string) {
 		}
 		return &build.StringExpr{Value: moved}
 	})
-}
-
-func moveLabelsInLoadStmt(loadStmt *build.LoadStmt, from, to string) *build.LoadStmt {
-	newModule := moveLabel(from, to, loadStmt.Module.Value)
-	loadStmt.Module = &build.StringExpr{Value: newModule}
-	return loadStmt
 }
 
 func moveLabel(from, to, str string) string {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/bazelbuild/bazel-gazelle
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/bazelbuild/buildtools v0.0.0-20190122172533-1f3678932acd
+	github.com/bazelbuild/buildtools v0.0.0-20190202002759-027686e28d67
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bazelbuild/buildtools v0.0.0-20190117133251-56771622edee h1:wLdQK8zHN
 github.com/bazelbuild/buildtools v0.0.0-20190117133251-56771622edee/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/buildtools v0.0.0-20190122172533-1f3678932acd h1:hxq17QUlhzPu8geJGcEmfufk9aB/BRLyi9v2I6OHmI0=
 github.com/bazelbuild/buildtools v0.0.0-20190122172533-1f3678932acd/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
+github.com/bazelbuild/buildtools v0.0.0-20190202002759-027686e28d67 h1:zS8p6ZRbNVa7QfK3tpoIRDqGzCA2J0uJffaMTWoneac=
+github.com/bazelbuild/buildtools v0.0.0-20190202002759-027686e28d67/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/vendor/github.com/bazelbuild/buildtools/build/lex.go
+++ b/vendor/github.com/bazelbuild/buildtools/build/lex.go
@@ -560,6 +560,14 @@ func (in *input) Lex(val *yySymType) int {
 	if k := keywordToken[val.tok]; k != 0 {
 		return k
 	}
+	switch val.tok {
+	case "pass":
+		return _PASS
+	case "break":
+		return _BREAK
+	case "continue":
+		return _CONTINUE
+	}
 	for _, c := range val.tok {
 		if c > '9' || c < '0' {
 			return _IDENT
@@ -641,6 +649,8 @@ func (in *input) order(v Expr) {
 	case *StringExpr:
 		// nothing
 	case *Ident:
+		// nothing
+	case *BranchStmt:
 		// nothing
 	case *DotExpr:
 		in.order(v.X)

--- a/vendor/github.com/bazelbuild/buildtools/build/parse.y
+++ b/vendor/github.com/bazelbuild/buildtools/build/parse.y
@@ -93,6 +93,9 @@ package build
 %token	<pos>	_STRING  // quoted string
 %token	<pos>	_DEF     // keyword def
 %token	<pos>	_RETURN  // keyword return
+%token	<pos>	_PASS    // keyword pass
+%token	<pos>	_BREAK   // keyword break
+%token	<pos>	_CONTINUE // keyword continue
 %token	<pos>	_INDENT  // indentation
 %token	<pos>	_UNINDENT // unindentation
 
@@ -423,6 +426,27 @@ small_stmt:
 	}
 |	expr '=' expr      { $$ = binary($1, $2, $<tok>2, $3) }
 |	expr _AUGM expr    { $$ = binary($1, $2, $<tok>2, $3) }
+|	_PASS
+	{
+		$$ = &BranchStmt{
+			Token: $<tok>1,
+			TokenPos: $1,
+		}
+	}
+|	_BREAK
+	{
+		$$ = &BranchStmt{
+			Token: $<tok>1,
+			TokenPos: $1,
+		}
+	}
+|	_CONTINUE
+	{
+		$$ = &BranchStmt{
+			Token: $<tok>1,
+			TokenPos: $1,
+		}
+	}
 
 semi_opt:
 |	';'

--- a/vendor/github.com/bazelbuild/buildtools/build/parse.y.go
+++ b/vendor/github.com/bazelbuild/buildtools/build/parse.y.go
@@ -58,11 +58,14 @@ const _OR = 57366
 const _STRING = 57367
 const _DEF = 57368
 const _RETURN = 57369
-const _INDENT = 57370
-const _UNINDENT = 57371
-const ShiftInstead = 57372
-const _ASSERT = 57373
-const _UNARY = 57374
+const _PASS = 57370
+const _BREAK = 57371
+const _CONTINUE = 57372
+const _INDENT = 57373
+const _UNINDENT = 57374
+const ShiftInstead = 57375
+const _ASSERT = 57376
+const _UNARY = 57377
 
 var yyToknames = [...]string{
 	"$end",
@@ -110,6 +113,9 @@ var yyToknames = [...]string{
 	"_STRING",
 	"_DEF",
 	"_RETURN",
+	"_PASS",
+	"_BREAK",
+	"_CONTINUE",
 	"_INDENT",
 	"_UNINDENT",
 	"ShiftInstead",
@@ -124,7 +130,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line build/parse.y:932
+//line build/parse.y:956
 
 // Go helper code.
 
@@ -363,201 +369,207 @@ var yyExca = [...]int{
 
 const yyPrivate = 57344
 
-const yyLast = 633
+const yyLast = 693
 
 var yyAct = [...]int{
 
-	16, 195, 22, 154, 31, 192, 7, 2, 145, 117,
-	126, 130, 77, 18, 9, 36, 85, 152, 205, 129,
-	216, 70, 71, 207, 141, 37, 33, 75, 80, 83,
-	73, 29, 32, 107, 171, 29, 147, 43, 44, 88,
-	204, 91, 88, 206, 114, 32, 95, 96, 97, 98,
-	99, 100, 101, 102, 103, 104, 105, 106, 29, 108,
-	109, 110, 111, 112, 199, 93, 118, 87, 119, 148,
-	35, 174, 74, 169, 28, 76, 13, 127, 132, 21,
-	132, 60, 132, 94, 175, 136, 26, 134, 27, 146,
-	137, 41, 222, 128, 63, 212, 69, 135, 29, 30,
-	142, 82, 150, 79, 209, 19, 24, 182, 155, 208,
-	20, 161, 32, 40, 14, 89, 90, 185, 153, 92,
-	46, 162, 163, 45, 48, 200, 49, 159, 47, 40,
-	165, 157, 65, 211, 173, 38, 124, 60, 64, 176,
-	178, 170, 39, 122, 66, 40, 37, 170, 172, 181,
-	183, 184, 177, 28, 164, 180, 40, 189, 168, 160,
-	151, 118, 191, 119, 149, 26, 193, 27, 40, 186,
-	190, 197, 198, 196, 139, 133, 40, 29, 30, 46,
-	113, 125, 45, 202, 146, 24, 218, 47, 179, 158,
-	201, 32, 140, 86, 72, 84, 60, 188, 1, 194,
-	213, 166, 167, 203, 187, 210, 25, 81, 78, 34,
-	193, 42, 215, 219, 197, 217, 196, 220, 214, 7,
-	28, 15, 12, 8, 4, 21, 23, 131, 67, 68,
-	123, 143, 26, 144, 27, 115, 116, 0, 0, 6,
-	0, 0, 11, 0, 29, 30, 17, 0, 0, 28,
-	0, 19, 24, 0, 21, 0, 20, 0, 32, 10,
-	14, 26, 221, 27, 5, 0, 0, 0, 6, 3,
-	0, 11, 0, 29, 30, 17, 0, 0, 0, 0,
-	19, 24, 0, 0, 0, 20, 0, 32, 10, 14,
-	0, 46, 0, 5, 45, 48, 0, 49, 0, 47,
-	138, 50, 0, 51, 0, 0, 0, 0, 60, 0,
-	59, 0, 0, 52, 0, 55, 0, 0, 62, 0,
-	0, 56, 61, 0, 0, 53, 54, 46, 57, 58,
-	45, 48, 0, 49, 0, 47, 0, 50, 0, 51,
-	0, 0, 0, 0, 60, 0, 59, 0, 0, 52,
-	0, 55, 0, 0, 62, 156, 0, 56, 61, 0,
-	0, 53, 54, 46, 57, 58, 45, 48, 0, 49,
-	0, 47, 0, 50, 0, 51, 0, 0, 0, 0,
-	60, 0, 59, 0, 0, 52, 132, 55, 0, 0,
-	62, 0, 0, 56, 61, 0, 0, 53, 54, 46,
-	57, 58, 45, 48, 0, 49, 0, 47, 0, 50,
-	0, 51, 0, 0, 0, 0, 60, 0, 59, 0,
-	0, 52, 0, 55, 0, 0, 62, 0, 0, 56,
-	61, 0, 0, 53, 54, 46, 57, 58, 45, 48,
-	0, 49, 0, 47, 0, 50, 0, 51, 0, 0,
-	0, 0, 60, 0, 59, 0, 0, 52, 0, 55,
-	0, 0, 0, 0, 0, 56, 61, 0, 0, 53,
-	54, 46, 57, 58, 45, 48, 0, 49, 0, 47,
-	0, 50, 0, 51, 0, 0, 0, 0, 60, 0,
-	59, 0, 0, 52, 0, 55, 0, 0, 0, 0,
-	0, 56, 0, 0, 0, 53, 54, 46, 57, 58,
-	45, 48, 0, 49, 0, 47, 0, 50, 0, 51,
-	0, 0, 28, 0, 60, 0, 59, 21, 0, 52,
-	0, 55, 0, 0, 26, 0, 27, 56, 0, 0,
-	0, 53, 54, 28, 57, 120, 29, 30, 21, 0,
-	0, 0, 0, 19, 24, 26, 0, 27, 20, 0,
-	32, 0, 14, 0, 0, 0, 0, 29, 30, 0,
-	0, 0, 0, 0, 19, 24, 0, 0, 121, 20,
-	46, 32, 0, 45, 48, 0, 49, 0, 47, 0,
-	50, 0, 51, 0, 28, 0, 0, 60, 0, 21,
-	0, 0, 52, 0, 55, 0, 26, 0, 27, 0,
-	56, 0, 0, 0, 53, 54, 0, 57, 29, 30,
-	0, 0, 0, 0, 0, 19, 24, 0, 0, 0,
-	20, 0, 32,
+	19, 198, 25, 157, 34, 195, 7, 2, 148, 120,
+	129, 133, 80, 39, 132, 88, 9, 155, 208, 219,
+	210, 144, 36, 21, 73, 74, 32, 35, 32, 110,
+	78, 83, 86, 76, 174, 40, 46, 47, 77, 117,
+	35, 38, 135, 207, 94, 150, 209, 63, 91, 98,
+	99, 100, 101, 102, 103, 104, 105, 106, 107, 108,
+	109, 13, 111, 112, 113, 114, 115, 32, 177, 121,
+	85, 122, 91, 202, 31, 135, 44, 79, 151, 178,
+	130, 139, 66, 96, 72, 172, 29, 215, 30, 225,
+	137, 43, 149, 140, 135, 138, 43, 90, 32, 33,
+	167, 97, 41, 92, 93, 145, 27, 95, 82, 42,
+	49, 158, 35, 48, 51, 153, 52, 212, 50, 131,
+	68, 214, 211, 185, 165, 166, 67, 63, 164, 43,
+	162, 125, 69, 188, 160, 43, 43, 176, 203, 154,
+	116, 168, 179, 181, 173, 127, 184, 171, 163, 175,
+	173, 43, 152, 186, 187, 180, 142, 136, 183, 40,
+	192, 128, 221, 182, 121, 194, 122, 161, 143, 196,
+	89, 75, 189, 193, 200, 201, 199, 49, 87, 191,
+	48, 1, 197, 190, 28, 50, 205, 149, 84, 169,
+	170, 81, 37, 204, 63, 45, 18, 12, 8, 4,
+	31, 26, 134, 216, 70, 24, 206, 71, 213, 126,
+	146, 147, 29, 196, 30, 218, 222, 200, 220, 199,
+	223, 217, 7, 31, 32, 33, 118, 119, 24, 0,
+	0, 22, 27, 0, 0, 29, 23, 30, 35, 0,
+	0, 0, 6, 0, 0, 11, 0, 32, 33, 20,
+	0, 0, 0, 0, 22, 27, 0, 0, 0, 23,
+	0, 35, 10, 14, 15, 16, 17, 31, 224, 0,
+	5, 0, 24, 0, 0, 0, 0, 0, 0, 29,
+	0, 30, 0, 0, 0, 0, 6, 3, 0, 11,
+	0, 32, 33, 20, 0, 0, 0, 0, 22, 27,
+	0, 0, 0, 23, 0, 35, 10, 14, 15, 16,
+	17, 31, 0, 0, 5, 0, 24, 0, 0, 0,
+	0, 0, 0, 29, 0, 30, 0, 0, 0, 0,
+	0, 0, 31, 0, 0, 32, 33, 24, 0, 0,
+	0, 0, 22, 27, 29, 0, 30, 23, 0, 35,
+	0, 14, 15, 16, 17, 0, 32, 33, 156, 0,
+	0, 0, 0, 22, 27, 0, 0, 0, 23, 0,
+	35, 0, 14, 15, 16, 17, 49, 0, 0, 48,
+	51, 0, 52, 0, 50, 141, 53, 0, 54, 0,
+	0, 0, 0, 63, 0, 62, 0, 0, 55, 0,
+	58, 0, 0, 65, 0, 0, 59, 64, 0, 0,
+	56, 57, 49, 60, 61, 48, 51, 0, 52, 0,
+	50, 0, 53, 0, 54, 0, 0, 0, 0, 63,
+	0, 62, 0, 0, 55, 0, 58, 0, 0, 65,
+	159, 0, 59, 64, 0, 0, 56, 57, 49, 60,
+	61, 48, 51, 0, 52, 0, 50, 0, 53, 0,
+	54, 0, 0, 0, 0, 63, 0, 62, 0, 0,
+	55, 135, 58, 0, 0, 65, 0, 0, 59, 64,
+	0, 0, 56, 57, 49, 60, 61, 48, 51, 0,
+	52, 0, 50, 0, 53, 0, 54, 0, 0, 0,
+	0, 63, 0, 62, 0, 0, 55, 0, 58, 0,
+	0, 65, 0, 0, 59, 64, 0, 0, 56, 57,
+	49, 60, 61, 48, 51, 0, 52, 0, 50, 0,
+	53, 0, 54, 0, 0, 0, 0, 63, 0, 62,
+	0, 0, 55, 0, 58, 0, 0, 0, 0, 0,
+	59, 64, 0, 0, 56, 57, 49, 60, 61, 48,
+	51, 0, 52, 0, 50, 0, 53, 0, 54, 0,
+	0, 0, 0, 63, 0, 62, 0, 0, 55, 0,
+	58, 0, 0, 0, 0, 0, 59, 0, 0, 0,
+	56, 57, 49, 60, 61, 48, 51, 0, 52, 0,
+	50, 0, 53, 0, 54, 0, 0, 0, 0, 63,
+	0, 62, 0, 0, 55, 0, 58, 0, 31, 0,
+	123, 0, 59, 24, 0, 0, 56, 57, 0, 60,
+	29, 0, 30, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 32, 33, 0, 0, 0, 0, 0, 22,
+	27, 0, 0, 124, 23, 49, 35, 0, 48, 51,
+	0, 52, 0, 50, 0, 53, 0, 54, 0, 0,
+	0, 0, 63, 0, 0, 0, 0, 55, 0, 58,
+	0, 0, 0, 0, 0, 59, 0, 0, 0, 56,
+	57, 0, 60,
 }
 var yyPact = [...]int{
 
-	-1000, -1000, 244, -1000, -1000, -1000, -23, -1000, -1000, -1000,
-	41, 148, -1000, 120, 589, 5, 395, 589, 127, 589,
-	589, 589, -1000, -1000, 189, -11, 589, 589, 589, -1000,
-	-1000, -1000, -1000, -1000, -36, 188, 33, 127, 589, 589,
-	589, 159, 589, 52, -1000, 589, 589, 589, 589, 589,
-	589, 589, 589, 589, 589, 589, 589, -1, 589, 589,
-	589, 589, 589, 167, 15, 538, 589, 123, 172, 159,
-	-1000, -1000, -11, -1000, 75, 359, 166, 53, 65, 166,
-	287, 165, 186, 395, -25, 517, 29, 589, 148, 159,
-	159, 431, 147, 69, -1000, 60, 60, 60, 175, 175,
-	116, 116, 116, 116, 116, 116, 116, 589, 503, 576,
-	-1000, 467, 323, 69, -1000, 183, 150, -1000, 395, 96,
-	589, 589, 136, 117, 589, 589, -1000, 149, -1000, 55,
-	3, -1000, 148, 589, -1000, 51, -1000, 64, 589, 589,
-	-1000, -1000, -1000, 182, 140, -1000, 92, 6, 6, 104,
-	127, 69, -1000, -1000, -1000, 116, 589, -1000, -1000, -1000,
-	538, 589, 395, 395, -1000, 589, -1000, -1000, 2, -1000,
-	3, 589, 30, 395, -1000, -1000, 395, -1000, 287, 112,
-	-1000, 29, 589, -1000, -1000, 69, -1000, -6, -26, 431,
-	-1000, 395, 91, 395, 124, -1000, -1000, 80, 431, 589,
-	69, -1000, 395, -1000, -1000, -29, -1000, -1000, -1000, 589,
-	180, 2, -11, 431, -1000, 215, -1000, 74, -1000, -1000,
-	-1000, -1000, -1000,
+	-1000, -1000, 262, -1000, -1000, -1000, -30, -1000, -1000, -1000,
+	12, 69, -1000, 87, 195, -1000, -1000, -1000, 4, 480,
+	195, 115, 195, 195, 195, -1000, -1000, 166, -16, 195,
+	195, 195, -1000, -1000, -1000, -1000, -1000, -40, 165, 63,
+	115, 195, 195, 195, 142, 195, 70, -1000, 195, 195,
+	195, 195, 195, 195, 195, 195, 195, 195, 195, 195,
+	-5, 195, 195, 195, 195, 195, 127, 10, 613, 195,
+	132, 152, 142, -1000, -1000, -16, -1000, 101, 444, 148,
+	15, 61, 148, 372, 147, 162, 480, -31, 327, 38,
+	195, 69, 142, 142, 516, 126, 306, -1000, 26, 26,
+	26, 173, 173, 106, 106, 106, 106, 106, 106, 106,
+	195, 588, 651, -1000, 552, 408, 306, -1000, 161, 139,
+	-1000, 480, 113, 195, 195, 82, 128, 195, 195, -1000,
+	138, -1000, 67, 3, -1000, 69, 195, -1000, 48, -1000,
+	59, 195, 195, -1000, -1000, -1000, 157, 137, -1000, 108,
+	-1, -1, 120, 115, 306, -1000, -1000, -1000, 106, 195,
+	-1000, -1000, -1000, 613, 195, 480, 480, -1000, 195, -1000,
+	-1000, -3, -1000, 3, 195, 39, 480, -1000, -1000, 480,
+	-1000, 372, 125, -1000, 38, 195, -1000, -1000, 306, -1000,
+	-6, -32, 516, -1000, 480, 104, 480, 112, -1000, -1000,
+	72, 516, 195, 306, -1000, 480, -1000, -1000, -33, -1000,
+	-1000, -1000, 195, 156, -3, -16, 516, -1000, 218, -1000,
+	71, -1000, -1000, -1000, -1000, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 10, 9, 236, 235, 8, 233, 231, 0, 5,
-	72, 13, 76, 230, 75, 229, 228, 15, 227, 11,
-	19, 2, 226, 7, 224, 223, 222, 221, 211, 3,
-	14, 209, 12, 208, 207, 4, 206, 17, 204, 1,
-	199, 198, 197, 195,
+	0, 10, 9, 227, 226, 8, 211, 210, 0, 5,
+	38, 23, 61, 209, 77, 207, 204, 13, 202, 11,
+	14, 2, 201, 7, 199, 198, 197, 196, 195, 3,
+	16, 192, 12, 191, 188, 4, 184, 17, 183, 1,
+	182, 181, 179, 178,
 }
 var yyR1 = [...]int{
 
 	0, 41, 37, 37, 42, 42, 38, 38, 38, 23,
 	23, 23, 23, 24, 24, 25, 25, 25, 27, 27,
 	26, 26, 28, 28, 29, 31, 31, 30, 30, 30,
-	30, 30, 43, 43, 11, 11, 11, 11, 11, 11,
-	11, 11, 11, 11, 11, 11, 11, 11, 11, 4,
-	4, 3, 3, 2, 2, 2, 2, 40, 40, 39,
-	39, 7, 7, 6, 6, 5, 5, 5, 5, 12,
-	12, 13, 13, 15, 15, 16, 16, 8, 8, 8,
+	30, 30, 30, 30, 30, 43, 43, 11, 11, 11,
+	11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+	11, 11, 4, 4, 3, 3, 2, 2, 2, 2,
+	40, 40, 39, 39, 7, 7, 6, 6, 5, 5,
+	5, 5, 12, 12, 13, 13, 15, 15, 16, 16,
 	8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-	8, 8, 8, 8, 8, 8, 8, 8, 8, 14,
-	14, 9, 9, 10, 10, 1, 1, 32, 34, 34,
-	33, 33, 33, 17, 17, 35, 36, 36, 21, 22,
-	18, 19, 19, 20, 20,
+	8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+	8, 8, 14, 14, 9, 9, 10, 10, 1, 1,
+	32, 34, 34, 33, 33, 33, 17, 17, 35, 36,
+	36, 21, 22, 18, 19, 19, 20, 20,
 }
 var yyR2 = [...]int{
 
 	0, 2, 5, 2, 0, 2, 0, 3, 2, 0,
 	2, 2, 3, 1, 1, 7, 6, 1, 4, 5,
 	1, 4, 2, 1, 4, 0, 3, 1, 2, 1,
-	3, 3, 0, 1, 1, 1, 3, 7, 4, 4,
-	6, 8, 1, 3, 4, 4, 3, 4, 3, 0,
-	2, 1, 3, 1, 3, 2, 2, 1, 3, 1,
-	3, 0, 2, 1, 3, 1, 3, 2, 2, 1,
-	3, 0, 1, 1, 3, 0, 2, 1, 4, 2,
-	2, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 3, 4, 3, 3, 3, 3, 5, 1,
-	3, 0, 1, 0, 2, 0, 1, 3, 1, 3,
-	0, 1, 2, 1, 3, 1, 1, 2, 1, 1,
-	4, 1, 3, 1, 2,
+	3, 3, 1, 1, 1, 0, 1, 1, 1, 3,
+	7, 4, 4, 6, 8, 1, 3, 4, 4, 3,
+	4, 3, 0, 2, 1, 3, 1, 3, 2, 2,
+	1, 3, 1, 3, 0, 2, 1, 3, 1, 3,
+	2, 2, 1, 3, 0, 1, 1, 3, 0, 2,
+	1, 4, 2, 2, 3, 3, 3, 3, 3, 3,
+	3, 3, 3, 3, 3, 3, 4, 3, 3, 3,
+	3, 5, 1, 3, 0, 1, 0, 2, 0, 1,
+	3, 1, 3, 0, 1, 2, 1, 3, 1, 1,
+	2, 1, 1, 4, 1, 3, 1, 2,
 }
 var yyChk = [...]int{
 
-	-1000, -41, -23, 25, -24, 49, 24, -29, -25, -30,
-	44, 27, -26, -12, 45, -27, -8, 31, -11, 36,
-	41, 10, -21, -22, 37, -36, 17, 19, 5, 29,
-	30, -35, 43, 49, -31, 29, -17, -11, 15, 22,
-	9, -12, -28, 32, 33, 7, 4, 12, 8, 10,
-	14, 16, 26, 38, 39, 28, 34, 41, 42, 23,
-	21, 35, 31, -12, 11, 5, 17, -16, -15, -12,
-	-8, -8, 5, -35, -10, -8, -14, -32, -33, -14,
-	-8, -34, -10, -8, -43, 52, 5, 34, 9, -12,
-	-12, -8, -12, 13, 31, -8, -8, -8, -8, -8,
-	-8, -8, -8, -8, -8, -8, -8, 34, -8, -8,
-	-8, -8, -8, 13, 29, -4, -3, -2, -8, -21,
-	7, 40, -12, -13, 13, 9, -1, -35, 18, -20,
-	-19, -18, 27, 9, -1, -20, 20, -1, 13, 9,
-	6, 49, -30, -7, -6, -5, -21, 7, 40, -12,
-	-11, 13, -37, 49, -29, -8, 32, -37, 6, -1,
-	9, 15, -8, -8, 18, 13, -12, -12, 9, 18,
-	-19, 31, -17, -8, 20, 20, -8, -32, -8, 6,
-	-1, 9, 15, -21, -21, 13, -37, -38, -42, -8,
-	-2, -8, -9, -8, -40, -39, -35, -21, -8, 34,
-	13, -5, -8, -37, 46, 24, 49, 49, 18, 13,
-	-1, 9, 15, -8, -37, -23, 49, -9, 6, -39,
-	-35, 47, 18,
+	-1000, -41, -23, 25, -24, 52, 24, -29, -25, -30,
+	44, 27, -26, -12, 45, 46, 47, 48, -27, -8,
+	31, -11, 36, 41, 10, -21, -22, 37, -36, 17,
+	19, 5, 29, 30, -35, 43, 52, -31, 29, -17,
+	-11, 15, 22, 9, -12, -28, 32, 33, 7, 4,
+	12, 8, 10, 14, 16, 26, 38, 39, 28, 34,
+	41, 42, 23, 21, 35, 31, -12, 11, 5, 17,
+	-16, -15, -12, -8, -8, 5, -35, -10, -8, -14,
+	-32, -33, -14, -8, -34, -10, -8, -43, 55, 5,
+	34, 9, -12, -12, -8, -12, 13, 31, -8, -8,
+	-8, -8, -8, -8, -8, -8, -8, -8, -8, -8,
+	34, -8, -8, -8, -8, -8, 13, 29, -4, -3,
+	-2, -8, -21, 7, 40, -12, -13, 13, 9, -1,
+	-35, 18, -20, -19, -18, 27, 9, -1, -20, 20,
+	-1, 13, 9, 6, 52, -30, -7, -6, -5, -21,
+	7, 40, -12, -11, 13, -37, 52, -29, -8, 32,
+	-37, 6, -1, 9, 15, -8, -8, 18, 13, -12,
+	-12, 9, 18, -19, 31, -17, -8, 20, 20, -8,
+	-32, -8, 6, -1, 9, 15, -21, -21, 13, -37,
+	-38, -42, -8, -2, -8, -9, -8, -40, -39, -35,
+	-21, -8, 34, 13, -5, -8, -37, 49, 24, 52,
+	52, 18, 13, -1, 9, 15, -8, -37, -23, 52,
+	-9, 6, -39, -35, 50, 18,
 }
 var yyDef = [...]int{
 
 	9, -2, 0, 1, 10, 11, 0, 13, 14, 25,
-	0, 0, 17, 27, 29, 20, 69, 0, 77, 75,
-	0, 0, 34, 35, 0, 42, 103, 110, 103, 118,
-	119, 116, 115, 12, 32, 0, 0, 113, 0, 0,
-	0, 28, 0, 0, 23, 0, 0, 0, 0, 0,
+	0, 0, 17, 27, 29, 32, 33, 34, 20, 72,
+	0, 80, 78, 0, 0, 37, 38, 0, 45, 106,
+	113, 106, 121, 122, 119, 118, 12, 35, 0, 0,
+	116, 0, 0, 0, 28, 0, 0, 23, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 49, 71, 0, 105, 73,
-	79, 80, 0, 117, 0, 99, 105, 108, 0, 105,
-	99, 111, 0, 99, 0, 33, 61, 0, 0, 30,
-	31, 70, 0, 0, 22, 81, 82, 83, 84, 85,
-	86, 87, 88, 89, 90, 91, 92, 0, 94, 95,
-	96, 97, 0, 0, 36, 0, 105, 51, 53, 34,
-	0, 0, 72, 0, 0, 106, 76, 0, 43, 0,
-	123, 121, 0, 106, 104, 0, 46, 0, 0, 112,
-	48, 24, 26, 0, 105, 63, 65, 0, 0, 0,
-	114, 0, 21, 6, 4, 93, 0, 18, 38, 50,
-	106, 0, 55, 56, 39, 101, 78, 74, 0, 44,
-	124, 0, 0, 100, 45, 47, 107, 109, 0, 0,
-	62, 106, 0, 67, 68, 0, 19, 0, 3, 98,
-	52, 54, 0, 102, 105, 57, 59, 0, 122, 0,
-	0, 64, 66, 16, 9, 0, 8, 5, 40, 101,
-	0, 106, 0, 120, 15, 0, 7, 0, 37, 58,
-	60, 2, 41,
+	0, 0, 0, 0, 0, 0, 0, 0, 52, 74,
+	0, 108, 76, 82, 83, 0, 120, 0, 102, 108,
+	111, 0, 108, 102, 114, 0, 102, 0, 36, 64,
+	0, 0, 30, 31, 73, 0, 0, 22, 84, 85,
+	86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+	0, 97, 98, 99, 100, 0, 0, 39, 0, 108,
+	54, 56, 37, 0, 0, 75, 0, 0, 109, 79,
+	0, 46, 0, 126, 124, 0, 109, 107, 0, 49,
+	0, 0, 115, 51, 24, 26, 0, 108, 66, 68,
+	0, 0, 0, 117, 0, 21, 6, 4, 96, 0,
+	18, 41, 53, 109, 0, 58, 59, 42, 104, 81,
+	77, 0, 47, 127, 0, 0, 103, 48, 50, 110,
+	112, 0, 0, 65, 109, 0, 70, 71, 0, 19,
+	0, 3, 101, 55, 57, 0, 105, 108, 60, 62,
+	0, 125, 0, 0, 67, 69, 16, 9, 0, 8,
+	5, 43, 104, 0, 109, 0, 123, 15, 0, 7,
+	0, 40, 61, 63, 2, 44,
 }
 var yyTok1 = [...]int{
 
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	49, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+	52, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
 	5, 6, 7, 8, 9, 10, 11, 12, 3, 3,
-	3, 3, 3, 3, 3, 3, 3, 3, 13, 52,
+	3, 3, 3, 3, 3, 3, 3, 3, 13, 55,
 	14, 15, 16, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -570,8 +582,8 @@ var yyTok2 = [...]int{
 
 	2, 3, 22, 23, 24, 25, 26, 27, 28, 29,
 	30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-	40, 41, 42, 43, 44, 45, 46, 47, 48, 50,
-	51,
+	40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+	50, 51, 53, 54,
 }
 var yyTok3 = [...]int{
 	0,
@@ -916,14 +928,14 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:183
+//line build/parse.y:186
 		{
 			yylex.(*input).file = &File{Stmt: yyDollar[1].exprs}
 			return 0
 		}
 	case 2:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line build/parse.y:190
+//line build/parse.y:193
 		{
 			statements := yyDollar[4].exprs
 			if yyDollar[2].exprs != nil {
@@ -945,20 +957,20 @@ yydefault:
 		}
 	case 3:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:210
+//line build/parse.y:213
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
 	case 6:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:218
+//line build/parse.y:221
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastStmt = nil
 		}
 	case 7:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:223
+//line build/parse.y:226
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastStmt = yyDollar[1].lastStmt
@@ -972,21 +984,21 @@ yydefault:
 		}
 	case 8:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:235
+//line build/parse.y:238
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastStmt = nil
 		}
 	case 9:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:241
+//line build/parse.y:244
 		{
 			yyVAL.exprs = nil
 			yyVAL.lastStmt = nil
 		}
 	case 10:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:246
+//line build/parse.y:249
 		{
 			// If this statement follows a comment block,
 			// attach the comments to the statement.
@@ -1019,7 +1031,7 @@ yydefault:
 		}
 	case 11:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:277
+//line build/parse.y:280
 		{
 			// Blank line; sever last rule from future comments.
 			yyVAL.exprs = yyDollar[1].exprs
@@ -1027,7 +1039,7 @@ yydefault:
 		}
 	case 12:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:283
+//line build/parse.y:286
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastStmt = yyDollar[1].lastStmt
@@ -1041,14 +1053,14 @@ yydefault:
 		}
 	case 13:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:297
+//line build/parse.y:300
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 			yyVAL.lastStmt = yyDollar[1].exprs[len(yyDollar[1].exprs)-1]
 		}
 	case 14:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:302
+//line build/parse.y:305
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 			yyVAL.lastStmt = yyDollar[1].expr
@@ -1062,7 +1074,7 @@ yydefault:
 		}
 	case 15:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line build/parse.y:316
+//line build/parse.y:319
 		{
 			yyVAL.expr = &DefStmt{
 				Function: Function{
@@ -1078,7 +1090,7 @@ yydefault:
 		}
 	case 16:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line build/parse.y:330
+//line build/parse.y:333
 		{
 			yyVAL.expr = &ForStmt{
 				For:  yyDollar[1].pos,
@@ -1090,14 +1102,14 @@ yydefault:
 		}
 	case 17:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:340
+//line build/parse.y:343
 		{
 			yyVAL.expr = yyDollar[1].ifstmt
 			yyVAL.lastStmt = yyDollar[1].lastStmt
 		}
 	case 18:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:348
+//line build/parse.y:351
 		{
 			yyVAL.ifstmt = &IfStmt{
 				If:   yyDollar[1].pos,
@@ -1108,7 +1120,7 @@ yydefault:
 		}
 	case 19:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line build/parse.y:357
+//line build/parse.y:360
 		{
 			yyVAL.ifstmt = yyDollar[1].ifstmt
 			inner := yyDollar[1].ifstmt
@@ -1127,7 +1139,7 @@ yydefault:
 		}
 	case 21:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:378
+//line build/parse.y:381
 		{
 			yyVAL.ifstmt = yyDollar[1].ifstmt
 			inner := yyDollar[1].ifstmt
@@ -1140,26 +1152,26 @@ yydefault:
 		}
 	case 24:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:395
+//line build/parse.y:398
 		{
 			yyVAL.exprs = append([]Expr{yyDollar[1].expr}, yyDollar[2].exprs...)
 			yyVAL.lastStmt = yyVAL.exprs[len(yyVAL.exprs)-1]
 		}
 	case 25:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:401
+//line build/parse.y:404
 		{
 			yyVAL.exprs = []Expr{}
 		}
 	case 26:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:405
+//line build/parse.y:408
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 28:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:412
+//line build/parse.y:415
 		{
 			yyVAL.expr = &ReturnStmt{
 				Return: yyDollar[1].pos,
@@ -1168,7 +1180,7 @@ yydefault:
 		}
 	case 29:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:419
+//line build/parse.y:422
 		{
 			yyVAL.expr = &ReturnStmt{
 				Return: yyDollar[1].pos,
@@ -1176,19 +1188,46 @@ yydefault:
 		}
 	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:424
+//line build/parse.y:427
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:425
+//line build/parse.y:428
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 36:
+	case 32:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line build/parse.y:430
+		{
+			yyVAL.expr = &BranchStmt{
+				Token:    yyDollar[1].tok,
+				TokenPos: yyDollar[1].pos,
+			}
+		}
+	case 33:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line build/parse.y:437
+		{
+			yyVAL.expr = &BranchStmt{
+				Token:    yyDollar[1].tok,
+				TokenPos: yyDollar[1].pos,
+			}
+		}
+	case 34:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line build/parse.y:444
+		{
+			yyVAL.expr = &BranchStmt{
+				Token:    yyDollar[1].tok,
+				TokenPos: yyDollar[1].pos,
+			}
+		}
+	case 39:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:434
+//line build/parse.y:458
 		{
 			yyVAL.expr = &DotExpr{
 				X:       yyDollar[1].expr,
@@ -1197,9 +1236,9 @@ yydefault:
 				Name:    yyDollar[3].tok,
 			}
 		}
-	case 37:
+	case 40:
 		yyDollar = yyS[yypt-7 : yypt+1]
-//line build/parse.y:443
+//line build/parse.y:467
 		{
 			load := &LoadStmt{
 				Load:         yyDollar[1].pos,
@@ -1213,9 +1252,9 @@ yydefault:
 			}
 			yyVAL.expr = load
 		}
-	case 38:
+	case 41:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:457
+//line build/parse.y:481
 		{
 			yyVAL.expr = &CallExpr{
 				X:              yyDollar[1].expr,
@@ -1226,9 +1265,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[2].pos, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 39:
+	case 42:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:468
+//line build/parse.y:492
 		{
 			yyVAL.expr = &IndexExpr{
 				X:          yyDollar[1].expr,
@@ -1237,9 +1276,9 @@ yydefault:
 				End:        yyDollar[4].pos,
 			}
 		}
-	case 40:
+	case 43:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line build/parse.y:477
+//line build/parse.y:501
 		{
 			yyVAL.expr = &SliceExpr{
 				X:          yyDollar[1].expr,
@@ -1250,9 +1289,9 @@ yydefault:
 				End:        yyDollar[6].pos,
 			}
 		}
-	case 41:
+	case 44:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line build/parse.y:488
+//line build/parse.y:512
 		{
 			yyVAL.expr = &SliceExpr{
 				X:           yyDollar[1].expr,
@@ -1265,9 +1304,9 @@ yydefault:
 				End:         yyDollar[8].pos,
 			}
 		}
-	case 42:
+	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:501
+//line build/parse.y:525
 		{
 			if len(yyDollar[1].strings) == 1 {
 				yyVAL.expr = yyDollar[1].strings[0]
@@ -1279,9 +1318,9 @@ yydefault:
 				yyVAL.expr = binary(yyVAL.expr, end, "+", x)
 			}
 		}
-	case 43:
+	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:513
+//line build/parse.y:537
 		{
 			yyVAL.expr = &ListExpr{
 				Start:          yyDollar[1].pos,
@@ -1290,9 +1329,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 44:
+	case 47:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:522
+//line build/parse.y:546
 		{
 			yyVAL.expr = &Comprehension{
 				Curly:          false,
@@ -1303,9 +1342,9 @@ yydefault:
 				ForceMultiLine: forceMultiLineComprehension(yyDollar[1].pos, yyDollar[2].expr, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 45:
+	case 48:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:533
+//line build/parse.y:557
 		{
 			yyVAL.expr = &Comprehension{
 				Curly:          true,
@@ -1316,9 +1355,9 @@ yydefault:
 				ForceMultiLine: forceMultiLineComprehension(yyDollar[1].pos, yyDollar[2].expr, yyDollar[3].exprs, yyDollar[4].pos),
 			}
 		}
-	case 46:
+	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:544
+//line build/parse.y:568
 		{
 			yyVAL.expr = &DictExpr{
 				Start:          yyDollar[1].pos,
@@ -1327,9 +1366,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[3].pos),
 			}
 		}
-	case 47:
+	case 50:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:553
+//line build/parse.y:577
 		{
 			yyVAL.expr = &SetExpr{
 				Start:          yyDollar[1].pos,
@@ -1338,9 +1377,9 @@ yydefault:
 				ForceMultiLine: forceMultiLine(yyDollar[1].pos, yyDollar[2].exprs, yyDollar[4].pos),
 			}
 		}
-	case 48:
+	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:562
+//line build/parse.y:586
 		{
 			if len(yyDollar[2].exprs) == 1 && yyDollar[2].comma.Line == 0 {
 				// Just a parenthesized expression, not a tuple.
@@ -1360,67 +1399,67 @@ yydefault:
 				}
 			}
 		}
-	case 49:
+	case 52:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:583
+//line build/parse.y:607
 		{
 			yyVAL.exprs = nil
 		}
-	case 50:
+	case 53:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:587
+//line build/parse.y:611
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 51:
+	case 54:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:593
+//line build/parse.y:617
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 52:
+	case 55:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:597
+//line build/parse.y:621
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 54:
+	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:604
+//line build/parse.y:628
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 55:
+	case 58:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:608
+//line build/parse.y:632
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 56:
+	case 59:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:612
+//line build/parse.y:636
 		{
 			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
-	case 57:
+	case 60:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:617
+//line build/parse.y:641
 		{
 			yyVAL.loadargs = []*struct {
 				from Ident
 				to   Ident
 			}{yyDollar[1].loadarg}
 		}
-	case 58:
+	case 61:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:621
+//line build/parse.y:645
 		{
 			yyDollar[1].loadargs = append(yyDollar[1].loadargs, yyDollar[3].loadarg)
 			yyVAL.loadargs = yyDollar[1].loadargs
 		}
-	case 59:
+	case 62:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:627
+//line build/parse.y:651
 		{
 			start := yyDollar[1].string.Start.add("'")
 			if yyDollar[1].string.TripleQuote {
@@ -1440,9 +1479,9 @@ yydefault:
 				},
 			}
 		}
-	case 60:
+	case 63:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:644
+//line build/parse.y:668
 		{
 			start := yyDollar[3].string.Start.add("'")
 			if yyDollar[3].string.TripleQuote {
@@ -1459,51 +1498,51 @@ yydefault:
 				to: *yyDollar[1].expr.(*Ident),
 			}
 		}
-	case 61:
+	case 64:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:659
+//line build/parse.y:683
 		{
 			yyVAL.exprs = nil
 		}
-	case 62:
+	case 65:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:663
+//line build/parse.y:687
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 63:
+	case 66:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:669
+//line build/parse.y:693
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 64:
+	case 67:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:673
+//line build/parse.y:697
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 66:
+	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:680
+//line build/parse.y:704
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
-	case 67:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:684
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 68:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:688
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
 	case 70:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line build/parse.y:708
+		{
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
+	case 71:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line build/parse.y:712
+		{
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
+		}
+	case 73:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:695
+//line build/parse.y:719
 		{
 			tuple, ok := yyDollar[1].expr.(*TupleExpr)
 			if !ok || !tuple.NoBrackets {
@@ -1517,39 +1556,39 @@ yydefault:
 			tuple.List = append(tuple.List, yyDollar[3].expr)
 			yyVAL.expr = tuple
 		}
-	case 71:
+	case 74:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:710
+//line build/parse.y:734
 		{
 			yyVAL.expr = nil
 		}
-	case 73:
+	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:717
+//line build/parse.y:741
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 74:
+	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:721
+//line build/parse.y:745
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 75:
+	case 78:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:726
+//line build/parse.y:750
 		{
 			yyVAL.exprs = nil
 		}
-	case 76:
+	case 79:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:730
+//line build/parse.y:754
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 78:
+	case 81:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:737
+//line build/parse.y:761
 		{
 			yyVAL.expr = &LambdaExpr{
 				Function: Function{
@@ -1559,117 +1598,117 @@ yydefault:
 				},
 			}
 		}
-	case 79:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:746
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 80:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:747
-		{
-			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
-		}
-	case 81:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:748
-		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
-		}
 	case 82:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:749
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line build/parse.y:770
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 83:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:750
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line build/parse.y:771
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = unary(yyDollar[1].pos, yyDollar[1].tok, yyDollar[2].expr)
 		}
 	case 84:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:751
+//line build/parse.y:772
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 85:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:752
+//line build/parse.y:773
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:753
+//line build/parse.y:774
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:754
+//line build/parse.y:775
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:755
+//line build/parse.y:776
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 89:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:756
+//line build/parse.y:777
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:757
+//line build/parse.y:778
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:758
+//line build/parse.y:779
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:759
+//line build/parse.y:780
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 93:
-		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:760
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line build/parse.y:781
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 94:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:761
+//line build/parse.y:782
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 95:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:762
+//line build/parse.y:783
 		{
 			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 		}
 	case 96:
-		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:763
+		yyDollar = yyS[yypt-4 : yypt+1]
+//line build/parse.y:784
 		{
-			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "not in", yyDollar[4].expr)
 		}
 	case 97:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:765
+//line build/parse.y:785
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 98:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line build/parse.y:786
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 99:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line build/parse.y:787
+		{
+			yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
+		}
+	case 100:
+		yyDollar = yyS[yypt-3 : yypt+1]
+//line build/parse.y:789
 		{
 			if b, ok := yyDollar[3].expr.(*UnaryExpr); ok && b.Op == "not" {
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, "is not", b.X)
@@ -1677,9 +1716,9 @@ yydefault:
 				yyVAL.expr = binary(yyDollar[1].expr, yyDollar[2].pos, yyDollar[2].tok, yyDollar[3].expr)
 			}
 		}
-	case 98:
+	case 101:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line build/parse.y:773
+//line build/parse.y:797
 		{
 			yyVAL.expr = &ConditionalExpr{
 				Then:      yyDollar[1].expr,
@@ -1689,45 +1728,45 @@ yydefault:
 				Else:      yyDollar[5].expr,
 			}
 		}
-	case 99:
+	case 102:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:785
+//line build/parse.y:809
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 100:
+	case 103:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:789
+//line build/parse.y:813
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 101:
+	case 104:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:794
+//line build/parse.y:818
 		{
 			yyVAL.expr = nil
 		}
-	case 103:
+	case 106:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:800
+//line build/parse.y:824
 		{
 			yyVAL.exprs, yyVAL.comma = nil, Position{}
 		}
-	case 104:
+	case 107:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:804
+//line build/parse.y:828
 		{
 			yyVAL.exprs, yyVAL.comma = yyDollar[1].exprs, yyDollar[2].pos
 		}
-	case 105:
+	case 108:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:813
+//line build/parse.y:837
 		{
 			yyVAL.pos = Position{}
 		}
-	case 107:
+	case 110:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:819
+//line build/parse.y:843
 		{
 			yyVAL.expr = &KeyValueExpr{
 				Key:   yyDollar[1].expr,
@@ -1735,39 +1774,39 @@ yydefault:
 				Value: yyDollar[3].expr,
 			}
 		}
-	case 108:
+	case 111:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:829
+//line build/parse.y:853
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 109:
+	case 112:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:833
+//line build/parse.y:857
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
-	case 110:
+	case 113:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line build/parse.y:838
+//line build/parse.y:862
 		{
 			yyVAL.exprs = nil
 		}
-	case 111:
-		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:842
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
-	case 112:
-		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:846
-		{
-			yyVAL.exprs = yyDollar[1].exprs
-		}
 	case 114:
+		yyDollar = yyS[yypt-1 : yypt+1]
+//line build/parse.y:866
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 115:
+		yyDollar = yyS[yypt-2 : yypt+1]
+//line build/parse.y:870
+		{
+			yyVAL.exprs = yyDollar[1].exprs
+		}
+	case 117:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:853
+//line build/parse.y:877
 		{
 			tuple, ok := yyDollar[1].expr.(*TupleExpr)
 			if !ok || !tuple.NoBrackets {
@@ -1781,9 +1820,9 @@ yydefault:
 			tuple.List = append(tuple.List, yyDollar[3].expr)
 			yyVAL.expr = tuple
 		}
-	case 115:
+	case 118:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:869
+//line build/parse.y:893
 		{
 			yyVAL.string = &StringExpr{
 				Start:       yyDollar[1].pos,
@@ -1793,33 +1832,33 @@ yydefault:
 				Token:       yyDollar[1].tok,
 			}
 		}
-	case 116:
+	case 119:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:881
+//line build/parse.y:905
 		{
 			yyVAL.strings = []*StringExpr{yyDollar[1].string}
 		}
-	case 117:
+	case 120:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:885
+//line build/parse.y:909
 		{
 			yyVAL.strings = append(yyDollar[1].strings, yyDollar[2].string)
 		}
-	case 118:
+	case 121:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:891
+//line build/parse.y:915
 		{
 			yyVAL.expr = &Ident{NamePos: yyDollar[1].pos, Name: yyDollar[1].tok}
 		}
-	case 119:
+	case 122:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:897
+//line build/parse.y:921
 		{
 			yyVAL.expr = &LiteralExpr{Start: yyDollar[1].pos, Token: yyDollar[1].tok}
 		}
-	case 120:
+	case 123:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line build/parse.y:903
+//line build/parse.y:927
 		{
 			yyVAL.expr = &ForClause{
 				For:  yyDollar[1].pos,
@@ -1828,30 +1867,30 @@ yydefault:
 				X:    yyDollar[4].expr,
 			}
 		}
-	case 121:
+	case 124:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:913
+//line build/parse.y:937
 		{
 			yyVAL.exprs = []Expr{yyDollar[1].expr}
 		}
-	case 122:
+	case 125:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line build/parse.y:916
+//line build/parse.y:940
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, &IfClause{
 				If:   yyDollar[2].pos,
 				Cond: yyDollar[3].expr,
 			})
 		}
-	case 123:
+	case 126:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line build/parse.y:925
+//line build/parse.y:949
 		{
 			yyVAL.exprs = yyDollar[1].exprs
 		}
-	case 124:
+	case 127:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line build/parse.y:928
+//line build/parse.y:952
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[2].exprs...)
 		}

--- a/vendor/github.com/bazelbuild/buildtools/build/print.go
+++ b/vendor/github.com/bazelbuild/buildtools/build/print.go
@@ -394,6 +394,9 @@ func (p *printer) expr(v Expr, outerPrec int) {
 	case *Ident:
 		p.printf("%s", v.Name)
 
+	case *BranchStmt:
+		p.printf("%s", v.Token)
+
 	case *StringExpr:
 		// If the Token is a correct quoting of Value and has double quotes, use it,
 		// also use it if it has single quotes and the value itself contains a double quote symbol.

--- a/vendor/github.com/bazelbuild/buildtools/build/syntax.go
+++ b/vendor/github.com/bazelbuild/buildtools/build/syntax.go
@@ -126,6 +126,17 @@ func (x *Ident) Span() (start, end Position) {
 	return x.NamePos, x.NamePos.add(x.Name)
 }
 
+// BranchStmt represents a `pass` statement.
+type BranchStmt struct {
+	Comments
+	Token    string // pass, break, continue
+	TokenPos Position
+}
+
+func (x *BranchStmt) Span() (start, end Position) {
+	return x.TokenPos, x.TokenPos.add(x.Token)
+}
+
 func (x *Ident) asString() *StringExpr {
 	_, end := x.Span()
 	return &StringExpr{

--- a/vendor/github.com/bazelbuild/buildtools/build/walk.go
+++ b/vendor/github.com/bazelbuild/buildtools/build/walk.go
@@ -145,6 +145,18 @@ func WalkOnce(v Expr, f func(x *Expr)) {
 		f(&v.Then)
 		f(&v.Test)
 		f(&v.Else)
+	case *LoadStmt:
+		module := (Expr)(v.Module)
+		f(&module)
+		v.Module = module.(*StringExpr)
+		for i := range v.From {
+			from := (Expr)(v.From[i])
+			f(&from)
+			v.From[i] = from.(*Ident)
+			to := (Expr)(v.To[i])
+			f(&to)
+			v.To[i] = to.(*Ident)
+		}
 	case *DefStmt:
 		for i := range v.Params {
 			f(&v.Params[i])

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bazelbuild/buildtools v0.0.0-20190122172533-1f3678932acd
+# github.com/bazelbuild/buildtools v0.0.0-20190202002759-027686e28d67
 github.com/bazelbuild/buildtools/build
 github.com/bazelbuild/buildtools/tables
 # github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
* Update github.com/bazelbuild/buildtools. In the latest version,
  build.WalkOnce recurses into children of LoadStmt.
* Remove workaround in cmd/move_labels that recursed into children of
  LoadStmt.