### PR TITLE
language/go: special case for github.com/golang/protobuf/proto

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -132,6 +132,8 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 		// "go_default_library" versions of these libraries depend on the
 		// pre-generated versions of the proto libraries.
 		switch imp {
+		case "github.com/golang/protobuf/proto":
+			return label.New("com_github_golang_protobuf", "proto", "go_default_library"), nil
 		case "github.com/golang/protobuf/jsonpb":
 			return label.New("com_github_golang_protobuf", "jsonpb", "go_default_library_gen"), nil
 		case "github.com/golang/protobuf/descriptor":

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -808,6 +808,7 @@ go_library(
 go_library(
     name = "go_default_library",
     _imports = [
+        "github.com/golang/protobuf/proto",
         "github.com/golang/protobuf/jsonpb",
         "github.com/golang/protobuf/descriptor",
         "github.com/golang/protobuf/protoc-gen-go/generator",
@@ -822,6 +823,7 @@ go_library(
     deps = [
         "@com_github_golang_protobuf//descriptor:go_default_library_gen",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@org_golang_google_grpc//:go_default_library",


### PR DESCRIPTION
This should be resolved to the canonical external location in modes
where go_proto_library is in use.