### PR TITLE
fixed error message

### DIFF
--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -278,7 +278,7 @@ outer:
 
 func checkStripImportPrefix(prefix, rel string) error {
 	if !strings.HasPrefix(prefix, "/") || !strings.HasPrefix(rel, prefix[1:]) {
-		return fmt.Errorf("invalid strip_import_prefix: %q", rel)
+		return fmt.Errorf("invalid proto_strip_import_prefix %q at %s", prefix, rel)
 	}
 	return nil
 }

--- a/language/proto/config_test.go
+++ b/language/proto/config_test.go
@@ -1,0 +1,11 @@
+package proto
+
+import "testing"
+
+func TestCheckStripImportPrefix(t *testing.T) {
+	e := checkStripImportPrefix("/example.com/idl", "example.com")
+	wantErr := "invalid proto_strip_import_prefix \"/example.com/idl\" at example.com"
+	if e == nil || e.Error() != wantErr {
+		t.Errorf("got:\n%v\n\nwant:\n%s\n", e, wantErr)
+	}
+}

--- a/language/proto/config_test.go
+++ b/language/proto/config_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proto
 
 import "testing"


### PR DESCRIPTION
Gazelle was printing the build file path instead of `proto_strip_import_prefix` when prefix is invalid. This PR fixes that.