### PR TITLE
go_repository: support modules

### DIFF
--- a/cmd/fetch_repo/BUILD.bazel
+++ b/cmd/fetch_repo/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["fetch_repo.go"],
+    srcs = [
+        "fetch_repo.go",
+        "module.go",
+        "vcs.go",
+    ],
     importpath = "github.com/bazelbuild/bazel-gazelle/cmd/fetch_repo",
     visibility = ["//visibility:private"],
     deps = ["//vendor/golang.org/x/tools/go/vcs:go_default_library"],

--- a/cmd/fetch_repo/fetch_repo.go
+++ b/cmd/fetch_repo/fetch_repo.go
@@ -13,78 +13,88 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Command fetch_repo is similar to "go get -d" but it works even if the given
-// repository path is not a buildable Go package and it checks out a specific
-// revision rather than the latest revision.
+// Command fetch_repo downloads a Go module or repository at a specific
+// version or commit.
 //
-// The difference between fetch_repo and "git clone" or {new_,}git_repository is
-// that fetch_repo recognizes import redirection of Go and it supports other
-// version control systems than git.
+// In module mode, fetch_repo downloads a module using "go mod download",
+// verifies the contents against a sum, then copies the contents of the module
+// to a target directory. fetch_repo respects GOPATH and GOPROXY.
 //
-// These differences help us to manage external Go repositories in the manner of
-// Bazel.
+// In repository mode, fetch_repo clones a repository using a VCS tool.
+// fetch_repo performs import path redirection in this mode.
 package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 
 	"golang.org/x/tools/go/vcs"
 )
 
 var (
-	remote     = flag.String("remote", "", "The URI of the remote repository. Must be used with the --vcs flag.")
-	cmd        = flag.String("vcs", "", "Version control system to use to fetch the repository. Should be one of: git,hg,svn,bzr. Must be used with the --remote flag.")
-	rev        = flag.String("rev", "", "target revision")
-	dest       = flag.String("dest", "", "destination directory")
+	// Common flags
 	importpath = flag.String("importpath", "", "Go importpath to the repository fetch")
+	dest       = flag.String("dest", "", "destination directory")
 
-	// Used for overriding in tests to disable network calls.
-	repoRootForImportPath = vcs.RepoRootForImportPath
+	// Repository flags
+	remote = flag.String("remote", "", "The URI of the remote repository. Must be used with the --vcs flag.")
+	cmd    = flag.String("vcs", "", "Version control system to use to fetch the repository. Should be one of: git,hg,svn,bzr. Must be used with the --remote flag.")
+	rev    = flag.String("rev", "", "target revision")
+
+	// Module flags
+	version = flag.String("version", "", "module version. Must be semantic version or pseudo-version.")
+	sum     = flag.String("sum", "", "hash of module contents")
 )
 
-func getRepoRoot(remote, cmd, importpath string) (*vcs.RepoRoot, error) {
-	if (cmd == "") != (remote == "") {
-		return nil, fmt.Errorf("--remote should be used with the --vcs flag. If this is an import path, use --importpath instead.")
-	}
-
-	if cmd != "" && remote != "" {
-		v := vcs.ByCmd(cmd)
-		if v == nil {
-			return nil, fmt.Errorf("invalid VCS type: %s", cmd)
-		}
-		return &vcs.RepoRoot{
-			VCS:  v,
-			Repo: remote,
-			Root: importpath,
-		}, nil
-	}
-
-	// User did not give us complete information for VCS / Remote.
-	// Try to figure out the information from the import path.
-	r, err := repoRootForImportPath(importpath, true)
-	if err != nil {
-		return nil, err
-	}
-	if importpath != r.Root {
-		return nil, fmt.Errorf("not a root of a repository: %s", importpath)
-	}
-	return r, nil
-}
-
-func run() error {
-	r, err := getRepoRoot(*remote, *cmd, *importpath)
-	if err != nil {
-		return err
-	}
-	return r.VCS.CreateAtRev(*dest, r.Repo, *rev)
-}
+// Override in tests to disable network calls.
+var repoRootForImportPath = vcs.RepoRootForImportPath
 
 func main() {
-	flag.Parse()
+	log.SetFlags(0)
+	log.SetPrefix("fetch_repo: ")
 
-	if err := run(); err != nil {
-		log.Fatal(err)
+	flag.Parse()
+	if *importpath == "" {
+		log.Fatal("-importpath must be set")
+	}
+	if *dest == "" {
+		log.Fatal("-dest must be set")
+	}
+	if flag.NArg() != 0 {
+		log.Fatal("fetch_repo does not accept positional arguments")
+	}
+
+	if *version != "" {
+		if *remote != "" {
+			log.Fatal("-remote must not be set in module mode")
+		}
+		if *cmd != "" {
+			log.Fatal("-vcs must not be set in module mode")
+		}
+		if *rev != "" {
+			log.Fatal("-rev must not be set in module mode")
+		}
+		if *version == "" {
+			log.Fatal("-version must be set in module mode")
+		}
+		if *sum == "" {
+			log.Fatal("-sum must be set in module mode")
+		}
+		if err := fetchModule(*dest, *importpath, *version, *sum); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		if *version != "" {
+			log.Fatal("-version must not be set in repository mode")
+		}
+		if *sum != "" {
+			log.Fatal("-sum must not be set in repository mode")
+		}
+		if *rev == "" {
+			log.Fatal("-rev must be set in repository mode")
+		}
+		if err := fetchRepo(*dest, *remote, *cmd, *importpath, *rev); err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/cmd/fetch_repo/fetch_repo.go
+++ b/cmd/fetch_repo/fetch_repo.go
@@ -18,7 +18,7 @@ limitations under the License.
 //
 // In module mode, fetch_repo downloads a module using "go mod download",
 // verifies the contents against a sum, then copies the contents of the module
-// to a target directory. fetch_repo respects GOPATH and GOPROXY.
+// to a target directory. fetch_repo respects GOPATH, GOCACHE, and GOPROXY.
 //
 // In repository mode, fetch_repo clones a repository using a VCS tool.
 // fetch_repo performs import path redirection in this mode.

--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -1,0 +1,307 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+func fetchModule(dest, importpath, version, sum string) error {
+	// Check that version is a complete semantic version or pseudo-version.
+	if _, ok := parse(version); !ok {
+		return fmt.Errorf("%q is not a valid semantic version", version)
+	} else if isSemverPrefix(version) {
+		return fmt.Errorf("-version must be a complete semantic version. %q is a prefix.", version)
+	}
+
+	// Locate the go binary. If GOROOT is set, we'll use that one; otherwise,
+	// we'll use PATH.
+	goPath := "go"
+	if runtime.GOOS == "windows" {
+		goPath += ".exe"
+	}
+	if goroot, ok := os.LookupEnv("GOROOT"); ok {
+		goPath = filepath.Join(goroot, "bin", goPath)
+	}
+
+	// Download the module. In Go 1.11, this command must be run in a module,
+	// so we create a dummy module in the current directory (which should be
+	// empty).
+	w, err := os.OpenFile("go.mod", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return fmt.Errorf("error creating temporary go.mod: %v", err)
+	}
+	_, err = fmt.Fprintln(w, "module example.com/temporary/module/for/fetch_repo/download")
+	if err != nil {
+		w.Close()
+		return fmt.Errorf("error writing temporary go.mod: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("error closing temporary go.mod: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := exec.Command(goPath, "mod", "download", "-json", importpath+"@"+version)
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+	dlErr := cmd.Run()
+	os.Remove("go.mod")
+	if dlErr != nil {
+		if _, ok := dlErr.(*exec.ExitError); !ok {
+			return dlErr
+		}
+	}
+
+	// Parse the JSON output.
+	var dl struct{ Dir, Sum, Error string }
+	if err := json.Unmarshal(buf.Bytes(), &dl); err != nil {
+		return err
+	}
+	if dl.Error != "" {
+		return errors.New(dl.Error)
+	}
+	if dlErr != nil {
+		return dlErr
+	}
+	if dl.Sum != sum {
+		return fmt.Errorf("downloaded module with sum %s; expected sum %s", dl.Sum, sum)
+	}
+
+	// Copy the module to the destination.
+	return copyTree(dest, dl.Dir)
+}
+
+func copyTree(destRoot, srcRoot string) error {
+	return filepath.Walk(srcRoot, func(src string, info os.FileInfo, e error) (err error) {
+		if e != nil {
+			return e
+		}
+		rel, err := filepath.Rel(srcRoot, src)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		dest := filepath.Join(destRoot, rel)
+
+		if info.IsDir() {
+			return os.Mkdir(dest, 0777)
+		} else {
+			r, err := os.Open(src)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			w, err := os.Create(dest)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if cerr := w.Close(); err == nil && cerr != nil {
+					err = cerr
+				}
+			}()
+			_, err = io.Copy(w, r)
+			return err
+		}
+	})
+}
+
+// semantic version parsing functions below this point were copied from
+// cmd/go/internal/semver and cmd/go/internal/modload at go1.12beta2.
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+	err        string
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		p.err = "missing v prefix"
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad major version"
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad minor prefix"
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad minor version"
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad patch prefix"
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad patch version"
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			p.err = "bad prerelease"
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			p.err = "bad build"
+			return
+		}
+	}
+	if v != "" {
+		p.err = "junk on end"
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+// isSemverPrefix reports whether v is a semantic version prefix: v1 or  v1.2 (not v1.2.3).
+// The caller is assumed to have checked that semver.IsValid(v) is true.
+func isSemverPrefix(v string) bool {
+	dots := 0
+	for i := 0; i < len(v); i++ {
+		switch v[i] {
+		case '-', '+':
+			return false
+		case '.':
+			dots++
+			if dots >= 2 {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/cmd/fetch_repo/vcs.go
+++ b/cmd/fetch_repo/vcs.go
@@ -1,0 +1,59 @@
+/* Copyright 2019 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/vcs"
+)
+
+func fetchRepo(dest, remote, cmd, importpath, rev string) error {
+	root, err := getRepoRoot(remote, cmd, importpath)
+	if err != nil {
+		return err
+	}
+	return root.VCS.CreateAtRev(dest, root.Repo, rev)
+}
+
+func getRepoRoot(remote, cmd, importpath string) (*vcs.RepoRoot, error) {
+	if (cmd == "") != (remote == "") {
+		return nil, fmt.Errorf("--remote should be used with the --vcs flag. If this is an import path, use --importpath instead.")
+	}
+
+	if cmd != "" && remote != "" {
+		v := vcs.ByCmd(cmd)
+		if v == nil {
+			return nil, fmt.Errorf("invalid VCS type: %s", cmd)
+		}
+		return &vcs.RepoRoot{
+			VCS:  v,
+			Repo: remote,
+			Root: importpath,
+		}, nil
+	}
+
+	// User did not give us complete information for VCS / Remote.
+	// Try to figure out the information from the import path.
+	r, err := repoRootForImportPath(importpath, true)
+	if err != nil {
+		return nil, err
+	}
+	if importpath != r.Root {
+		return nil, fmt.Errorf("not a root of a repository: %s", importpath)
+	}
+	return r, nil
+}

--- a/deps.bzl
+++ b/deps.bzl
@@ -15,6 +15,7 @@
 load(
     "@bazel_gazelle//internal:go_repository.bzl",
     _go_repository = "go_repository",
+    _go_repository_cache = "go_repository_cache",
     _go_repository_tools = "go_repository_tools",
 )
 load(
@@ -33,9 +34,14 @@ load(
 go_repository = _go_repository
 
 def gazelle_dependencies(go_sdk = "@go_sdk//:ROOT"):
+    _go_repository_cache(
+        name = "bazel_gazelle_go_repository_cache",
+        go_sdk = go_sdk,
+    )
+
     _go_repository_tools(
         name = "bazel_gazelle_go_repository_tools",
-        go_sdk = go_sdk,
+        go_cache = "@bazel_gazelle_go_repository_cache//:go.env",
     )
 
     _maybe(

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -48,6 +48,9 @@ bazel_test(
 # TODO(jayconrod): test fetch_repo error cases.
 
 exports_files(
-    ["gazelle.bash.in"],
+    [
+        "gazelle.bash.in",
+        "list_repository_tools_srcs.go",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -18,11 +18,18 @@ gazelle_dependencies()
 load("@bazel_gazelle//:deps.bzl", "go_repository", "git_repository", "http_archive")
 
 go_repository(
-    name = "errors_go",
+    name = "errors_go_git",
     importpath = "github.com/pkg/errors",
     commit = "30136e27e2ac8d167177e8a583aa4c3fea5be833",
     patches = ["@bazel_gazelle//internal:repository_rules_test_errors.patch"],
     patch_args = ["-p1"],
+)
+
+go_repository(
+    name = "errors_go_mod",
+    importpath = "github.com/pkg/errors",
+    version = "v0.8.1",
+    sum ="h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
 )
 """
 
@@ -31,13 +38,14 @@ bazel_test(
     command = "build",
     externals = ["@bazel_gazelle//:WORKSPACE"],
     extra_files = ["repository_rules_test_errors.patch"],
-    targets = ["@errors_go//:errors"],
+    targets = [
+        "@errors_go_git//:errors",
+        "@errors_go_mod//:go_default_library",
+    ],
     workspace = _REPOSITORY_RULES_TEST_WORKSPACE,
 )
 
-# TODO(jayconrod): test git_repository and http_archive with overlays here.
-# We'll probably want to extend bazel_test to copy data files into the
-# workspace directory so we can have overlay build files.
+# TODO(jayconrod): test fetch_repo error cases.
 
 exports_files(
     ["gazelle.bash.in"],

--- a/internal/list_repository_tools_srcs.go
+++ b/internal/list_repository_tools_srcs.go
@@ -1,0 +1,62 @@
+// +build ignore
+
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// list_go_repository_tools prints Bazel labels for source files that
+// gazelle and fetch_repo depend on. go_repository_tools resolves these
+// labels so that when a source file changes, the gazelle and fetch_repo
+// binaries are rebuilt for go_repository.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	dir := filepath.FromSlash("src/github.com/bazelbuild/bazel-gazelle")
+	if err := os.Chdir(dir); err != nil {
+		log.Fatal(err)
+	}
+
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(path)
+		if base == "vendor" || base == "third_party" || base == "testdata" {
+			return filepath.SkipDir
+		}
+		if !info.IsDir() &&
+			(strings.HasSuffix(base, ".go") && !strings.HasSuffix(base, "_test.go") ||
+				base == "BUILD.bazel" || base == "BUILD") {
+			label := filepath.ToSlash(path)
+			if i := strings.LastIndexByte(label, '/'); i >= 0 {
+				label = "@bazel_gazelle//" + label[:i] + ":" + label[i+1:]
+			} else {
+				label = "@bazel_gazelle//:" + label
+			}
+			fmt.Println(label)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/repository.rst
+++ b/repository.rst
@@ -133,6 +133,9 @@ external Go projects.
 | A hash of the module contents. In module mode, ``go_repository`` will verify                            |
 | the downloaded module matches this sum. May only be set when ``version``                                |
 | is also set.                                                                                            |
+|                                                                                                         |
+| A value for ``sum`` may be found in the ``go.sum`` file or by running                                   |
+| ``go mod download -json <module>@<version>``.                                                           |
 +--------------------------------+----------------------+-------------------------------------------------+
 | :param:`commit`                | :type:`string`       | :value:`""`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+

--- a/repository.rst
+++ b/repository.rst
@@ -20,9 +20,10 @@ and transform them by applying patches or generating build files.
 
 The Gazelle repository provides three rules:
 
-* `go_repository`_ downloads a Go project over HTTP or using a version control
-  tool like git. It understands Go import path redirection. If build files are
-  not already present, it can generate them with Gazelle.
+* `go_repository`_ downloads a Go project using either ``go mod download``, a
+  version control tool like ``git``, or a direct HTTP download. It understands
+  Go import path redirection. If build files are not already present, it can
+  generate them with Gazelle.
 * `git_repository`_ downloads a project with git. Unlike the native
   ``git_repository``, this rule allows you to specify an "overlay": a set of
   files to be copied into the downloaded project. This may be used to add
@@ -66,6 +67,14 @@ external Go projects.
 
   load("@bazel_gazelle//:deps.bzl", "go_repository")
 
+  # Download using "go mod download"
+  go_repository(
+      name = "com_github_pkg_errors",
+      importpath = "github.com/pkg/errors",
+      sum = "h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
+      version = "v0.8.1",
+  )
+
   # Download automatically via git
   go_repository(
       name = "com_github_pkg_errors",
@@ -104,11 +113,26 @@ external Go projects.
 +--------------------------------+----------------------+-------------------------------------------------+
 | :param:`importpath`            | :type:`string`       | |mandatory|                                     |
 +--------------------------------+----------------------+-------------------------------------------------+
-| The Go import path that matches the root directory of this repository. If                               |
-| neither ``urls`` nor ``remote`` are specified, ``go_repository`` will download                          |
-| the repository from this location. This supports import path redirection.                               |
-| If build files are generated, libraries will have ``importpath`` prefixed                               |
-| with this string.                                                                                       |
+| The Go import path that matches the root directory of this repository. In                               |
+| module mode (when ``version`` is set), this must be the module path. If                                 |
+| neither ``urls`` nor ``remote`` is specified, ``go_repository`` will                                    |
+| automatically find the true path of the module, applying import path                                    |
+| redirection.                                                                                            |
+|                                                                                                         |
+| If build files are generated for this repository, libraries will have their                             |
+| ``importpath`` attributes prefixed with this ``importpath`` string.                                     |
++--------------------------------+----------------------+-------------------------------------------------+
+| :param:`version`               | :type:`string`       | :value:`""`                                     |
++--------------------------------+----------------------+-------------------------------------------------+
+| If specified, ``go_repository`` will download the module at this version                                |
+| using ``go mod download``. ``sum`` must also be set. ``commit``, ``tag``,                               |
+| and ``urls`` may not be set.                                                                            |
++--------------------------------+----------------------+-------------------------------------------------+
+| :param:`sum`                   | :type:`string`       | :value:`""`                                     |
++--------------------------------+----------------------+-------------------------------------------------+
+| A hash of the module contents. In module mode, ``go_repository`` will verify                            |
+| the downloaded module matches this sum. May only be set when ``version``                                |
+| is also set.                                                                                            |
 +--------------------------------+----------------------+-------------------------------------------------+
 | :param:`commit`                | :type:`string`       | :value:`""`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+


### PR DESCRIPTION
go_repository has two new attributes: version and sum. If version is
specified, go_repository will run in module mode (distinct from
repository mode and http mode). version and sum must be specified
together.

In module mode, go_repository invokes fetch_repo with -version and
-sum arguments. fetch_repo will run "go mod download" to retrieve the
module.

Fixes #400