### PR TITLE
proto/generate: fix inclusion of generated files in proto_library targets

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -44,7 +44,7 @@ func (_ *protoLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 	var genProtoFiles []string
 	for _, name := range args.GenFiles {
 		if strings.HasSuffix(name, ".proto") {
-			genProtoFiles = append(args.GenFiles, name)
+			genProtoFiles = append(genProtoFiles, name)
 		}
 	}
 	pkgs := buildPackages(pc, args.Dir, args.Rel, regularProtoFiles, genProtoFiles)

--- a/language/proto/testdata/protos/BUILD.old
+++ b/language/proto/testdata/protos/BUILD.old
@@ -1,0 +1,11 @@
+genrule(
+    name = "gen_foo_proto",
+    outs = ["foo_generated.proto"],
+    cmd = """echo 'syntax = "proto2"' > foo_generated.proto""",
+)
+
+genrule(
+    name = "gen_bar_txt",
+    outs = ["bar_generated.txt"],
+    cmd = "echo 12345 > bar_generated.txt",
+)

--- a/language/proto/testdata/protos/BUILD.want
+++ b/language/proto/testdata/protos/BUILD.want
@@ -1,5 +1,8 @@
 proto_library(
     name = "protos_proto",
-    srcs = ["foo.proto"],
+    srcs = [
+        "foo.proto",
+        "foo_generated.proto",
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
In the course of developing #448 , I identified a bug that results in non-proto files
being included in the srcs of generated proto_library rules, if any generated
proto files were present in that directory.

This change updates the existing protos test case that identifies that bug and
makes the small fix.

This scenario seems unlikely to come up in practice, so it's possible that no one has actually run into it. 