### PR TITLE
map_kind directive: fix bug in handling of packages lacking a BUILD file

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -253,7 +253,7 @@ func runFixUpdate(cmd command, args []string) error {
 			if repl, ok := c.KindMap[r.Kind()]; ok {
 				mappedKindInfo[repl.KindName] = kinds[r.Kind()]
 				mappedKinds = append(mappedKinds, repl)
-				mrslv.MappedKind(f, repl)
+				mrslv.MappedKind(rel, repl)
 				r.SetKind(repl.KindName)
 			}
 		}
@@ -295,7 +295,7 @@ func runFixUpdate(cmd command, args []string) error {
 	for _, v := range visits {
 		for i, r := range v.rules {
 			from := label.New(c.RepoName, v.pkgRel, r.Name())
-			mrslv.Resolver(r, v.file).Resolve(v.c, ruleIndex, rc, r, v.imports[i], from)
+			mrslv.Resolver(r, v.pkgRel).Resolve(v.c, ruleIndex, rc, r, v.imports[i], from)
 		}
 		merger.MergeFile(v.file, v.empty, v.rules, merger.PostResolve,
 			unionKindInfoMaps(kinds, v.mappedKindInfo))

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1813,6 +1813,9 @@ go_library(
 			Path:    "enabled/existing_rules/unmapped/unmapped_lib.go",
 			Content: `package unmapped`,
 		}, {
+			Path:    "enabled/existing_rules/nobuild/nobuild_lib.go",
+			Content: `package nobuild`,
+		}, {
 			Path:    "enabled/overridden/BUILD.bazel",
 			Content: "# gazelle:map_kind go_library overridden_library //tools/overridden:def.bzl",
 		}, {
@@ -1931,6 +1934,19 @@ go_library(
     name = "go_default_library",
     srcs = ["unmapped_lib.go"],
     importpath = "example.com/mapkind/enabled/existing_rules",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+		{
+			Path: "enabled/existing_rules/nobuild/BUILD.bazel",
+			Content: `
+load("//tools/go:def.bzl", "my_library")
+
+my_library(
+    name = "go_default_library",
+    srcs = ["nobuild_lib.go"],
+    importpath = "example.com/mapkind/enabled/existing_rules/nobuild",
     visibility = ["//visibility:public"],
 )
 `,

--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -43,21 +43,18 @@ func (mr *metaResolver) AddBuiltin(kindName string, resolver resolve.Resolver) {
 }
 
 // MappedKind records the fact that the given mapping was applied while
-// processing the given file.
-func (mr *metaResolver) MappedKind(f *rule.File, kind config.MappedKind) {
-	mr.mappedKinds[f.Pkg] = append(mr.mappedKinds[f.Pkg], kind)
+// processing the given package.
+func (mr *metaResolver) MappedKind(pkgRel string, kind config.MappedKind) {
+	mr.mappedKinds[pkgRel] = append(mr.mappedKinds[pkgRel], kind)
 }
 
-// Resolver returns a resolver for the given rule and file, and a bool
-// indicating whether one was found.  If f is nil, mapped kinds are disregarded.
-func (mr metaResolver) Resolver(r *rule.Rule, f *rule.File) resolve.Resolver {
-	// If f is provided, check the replacements used while processing that package.
-	// If the rule is a kind that was mapped, return the resolver for the kind it was mapped from.
-	if f != nil {
-		for _, mappedKind := range mr.mappedKinds[f.Pkg] {
-			if mappedKind.KindName == r.Kind() {
-				return mr.builtins[mappedKind.FromKind]
-			}
+// Resolver returns a resolver for the given rule and package, and a bool
+// indicating whether one was found. Empty string may be passed for pkgRel,
+// which results in consulting the builtin kinds only.
+func (mr metaResolver) Resolver(r *rule.Rule, pkgRel string) resolve.Resolver {
+	for _, mappedKind := range mr.mappedKinds[pkgRel] {
+		if mappedKind.KindName == r.Kind() {
+			return mr.builtins[mappedKind.FromKind]
 		}
 	}
 	return mr.builtins[r.Kind()]

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -960,7 +960,7 @@ go_proto_library(
 			}
 			ix.Finish()
 			for i, r := range f.Rules {
-				mrslv.Resolver(r, nil).Resolve(c, ix, rc, r, imports[i], label.New("", tc.old.rel, r.Name()))
+				mrslv.Resolver(r, "").Resolve(c, ix, rc, r, imports[i], label.New("", tc.old.rel, r.Name()))
 			}
 			f.Sync()
 			got := strings.TrimSpace(string(bzl.Format(f.File)))
@@ -1170,6 +1170,6 @@ func convertImportsAttr(r *rule.Rule) interface{} {
 
 type mapResolver map[string]resolve.Resolver
 
-func (mr mapResolver) Resolver(r *rule.Rule, f *rule.File) resolve.Resolver {
+func (mr mapResolver) Resolver(r *rule.Rule, f string) resolve.Resolver {
 	return mr[r.Kind()]
 }

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -426,6 +426,6 @@ func convertImportsAttr(r *rule.Rule) interface{} {
 
 type mapResolver map[string]resolve.Resolver
 
-func (mr mapResolver) Resolver(r *rule.Rule, f *rule.File) resolve.Resolver {
+func (mr mapResolver) Resolver(r *rule.Rule, f string) resolve.Resolver {
 	return mr[r.Kind()]
 }


### PR DESCRIPTION
This previously assumed a *rule.File would be present for every kind mapping,
which is not the case for packages that lack a pre-existing BUILD file. This
change indexes the mapped kinds by the package relative path instead, with ""
denoting "ignore mapped kinds". This also adds a test to identify the problem
and verify the fix.

Fixes #469