### PR TITLE
walk: allow "# gazelle:exclude ."

### DIFF
--- a/walk/config.go
+++ b/walk/config.go
@@ -24,6 +24,10 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
+// TODO(#472): store location information to validate each exclude. They
+// may be set in one directory and used in another. Excludes work on
+// declared generated files, so we can't just stat.
+
 type walkConfig struct {
 	excludes []string
 	ignore   bool

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -136,6 +136,10 @@ func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode,
 		c = configure(cexts, knownDirectives, c, rel, f)
 		wc := getWalkConfig(c)
 
+		if wc.isExcluded(rel, ".") {
+			return
+		}
+
 		var subdirs, regularFiles []string
 		for _, fi := range files {
 			base := fi.Name()

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -200,6 +200,30 @@ gen(
 	}
 }
 
+func TestExcludeSelf(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+		}, {
+			Path:    "sub/BUILD.bazel",
+			Content: "# gazelle:exclude .",
+		}, {
+			Path: "sub/below/BUILD.bazel",
+		},
+	})
+	defer cleanup()
+
+	c, cexts := testConfig(t, dir)
+	var buildRels []string
+	Walk(c, cexts, []string{dir}, VisitAllUpdateDirsMode, func(_ string, rel string, _ *config.Config, _ bool, f *rule.File, _, _, _ []string) {
+		buildRels = append(buildRels, rel)
+	})
+
+	if len(buildRels) != 1 || buildRels[0] != "" {
+		t.Errorf("Walk: got %#v; want %#v", buildRels, []string{""})
+	}
+}
+
 func TestGeneratedFiles(t *testing.T) {
 	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
 		{


### PR DESCRIPTION
As a special case, a build file may exclude its own directory. This is
similar to "# gazelle:ignore" but it also covers subdirectories.

Updates #472