### PR TITLE
Clarifies "ambiguous import" message

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -227,7 +227,8 @@ func resolveWithIndexGo(ix *resolve.RuleIndex, imp string, from label.Label) (la
 			// Current match is worse
 		} else {
 			// Match is ambiguous
-			matchError = fmt.Errorf("multiple rules (%s and %s) may be imported with %q from %s", bestMatch.Label, m.Label, imp, from)
+			// TODO: consider listing all the ambiguous rules here.
+			matchError = fmt.Errorf("rule %s imports %q which matches multiple rules: %s and %s. # gazelle:resolve may be used to disambiguate", from, imp, bestMatch.Label, m.Label)
 		}
 	}
 	if matchError != nil {


### PR DESCRIPTION
The old error message is not very useful: it is difficult to scan
visually, once you scan it it is not clear what it means, it offers no
suggestions at all what to do to fix the issue, and is very difficult to
google a solution for.

The new error is somewhat more verbose, but uses clearer language
(where the issue is comes first, details later) and offers clear ways
to resolve the issue.

Handles #478 in part.