### PR TITLE
build_extra_args should be a list

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -69,6 +69,8 @@ go_test(
     deps = [
         "//config:go_default_library",
         "//internal/wspace:go_default_library",
+        "//rule:go_default_library",
         "//testtools:go_default_library",
+        "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
     ],
 )

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -239,6 +240,7 @@ func applyBuildAttributes(c *updateReposConfig, r *rule.Rule) {
 		r.SetAttr("build_file_proto_mode", c.buildFileProtoModeAttr)
 	}
 	if c.buildExtraArgsAttr != "" {
-		r.SetAttr("build_extra_args", c.buildExtraArgsAttr)
+		extraArgs := strings.Split(c.buildExtraArgsAttr, ",")
+		r.SetAttr("build_extra_args", extraArgs)
 	}
 }

--- a/cmd/gazelle/update_repos_test.go
+++ b/cmd/gazelle/update_repos_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package main
 
 import (
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/buildtools/build"
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -65,4 +67,15 @@ func TestCommandLine(t *testing.T) {
 	if uc.buildExtraArgsAttr != "-exclude=vendor" {
 		t.Errorf(`got build_file_proto_mode %q; want "-exclude=vendor"`, uc.buildExtraArgsAttr)
 	}
+}
+
+func TestApplyBuildAttributes(t *testing.T)  {
+	config := updateReposConfig{buildExtraArgsAttr: "-exclude=vendor"}
+	r := rule.NewRule("go_repository", "uber_repo")
+	applyBuildAttributes(&config, r)
+	extraArgs := r.Attr("build_extra_args")
+	if _, ok := extraArgs.(*build.ListExpr); !ok {
+		t.Errorf("build_extra_args should be a list, got %q", extraArgs)
+	}
+
 }


### PR DESCRIPTION
`build_extra_args` of `go_repository` rules is a list. However, Gazelle passed it as a string, causing build failures in the resulting `go_repository` rules. This PR fixed that.