### PR TITLE
language/go: experimental module mode

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -291,7 +291,8 @@ func runFixUpdate(cmd command, args []string) error {
 	ruleIndex.Finish()
 
 	// Resolve dependencies.
-	rc := repo.NewRemoteCache(uc.repos)
+	rc, cleanupRc := repo.NewRemoteCache(uc.repos)
+	defer cleanupRc()
 	for _, v := range visits {
 		for i, r := range v.rules {
 			from := label.New(c.RepoName, v.pkgRel, r.Name())

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -176,7 +176,8 @@ FLAGS:
 
 func updateImportPaths(c *updateReposConfig, f *rule.File, kinds map[string]rule.KindInfo) error {
 	rs := repo.ListRepositories(f)
-	rc := repo.NewRemoteCache(rs)
+	rc, cleanupRc := repo.NewRemoteCache(rs)
+	defer cleanupRc()
 
 	genRules := make([]*rule.Rule, len(c.importPaths))
 	errs := make([]error, len(c.importPaths))
@@ -210,7 +211,8 @@ func updateImportPaths(c *updateReposConfig, f *rule.File, kinds map[string]rule
 
 func importFromLockFile(c *updateReposConfig, f *rule.File, kinds map[string]rule.KindInfo) error {
 	rs := repo.ListRepositories(f)
-	rc := repo.NewRemoteCache(rs)
+	rc, cleanupRc := repo.NewRemoteCache(rs)
+	defer cleanupRc()
 	genRules, err := repo.ImportRepoRules(c.lockFilename, rc)
 	if err != nil {
 		return err

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -21,6 +21,7 @@ import (
 	"go/build"
 	"log"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -178,7 +179,7 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 	}
 
 	if gc.depMode == externalMode {
-		return resolveExternal(rc, imp)
+		return resolveExternal(gc.moduleMode, rc, imp)
 	} else {
 		return resolveVendored(rc, imp)
 	}
@@ -243,8 +244,28 @@ func resolveWithIndexGo(ix *resolve.RuleIndex, imp string, from label.Label) (la
 	return bestMatch.Label, nil
 }
 
-func resolveExternal(rc *repo.RemoteCache, imp string) (label.Label, error) {
-	prefix, repo, err := rc.Root(imp)
+var modMajorRex = regexp.MustCompile(`/v\d+(?:/|$)`)
+
+func resolveExternal(moduleMode bool, rc *repo.RemoteCache, imp string) (label.Label, error) {
+	// If we're in module mode, use "go list" to find the module path and
+	// repository name. Otherwise, use special cases (for github.com, golang.org)
+	// or send a GET with ?go-get=1 to find the root. If the path contains
+	// a major version suffix (e.g., /v2), treat it as a module anyway though.
+	//
+	// Eventually module mode will be the only mode. But for now, it's expensive
+	// and not the common case, especially when known repositories aren't
+	// listed in WORKSPACE (which is currently the case within go_repository).
+	if !moduleMode {
+		moduleMode = modMajorRex.FindStringIndex(imp) != nil
+	}
+
+	var prefix, repo string
+	var err error
+	if moduleMode {
+		prefix, repo, err = rc.Mod(imp)
+	} else {
+		prefix, repo, err = rc.Root(imp)
+	}
 	if err != nil {
 		return label.NoLabel, err
 	}


### PR DESCRIPTION
This change adds a new flag to the Go extension,
-go_experimental_module_mode. It is off by default, but is turned on
when go_repository runs in module mode or when a go.mod file is
found. In the future, this flag will be removed, and we'll always run
in module mode.

When enabled, this flag changes how remote dependency resolution
works. Instead of using golang.org/x/tools/go/vcs (which does not
know about modules), we'll use "GO111MODULE=on go list <path>" in a
temporary directory. No special cases are enabled, but known
repositories from WORKSPACE and -known_repo arguments will be
observed.

Fixes #473