### PR TITLE
Support lowercase version of *_proxy env vars

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -88,6 +88,9 @@ def _go_repository_impl(ctx):
             "HTTP_PROXY",
             "HTTPS_PROXY",
             "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
             "GIT_SSL_CAINFO",
         ]
         env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})


### PR DESCRIPTION
Many tools support or even prefer the lowercase version of the {http,https,no}_proxy environment variables. This PR adds support for passing the lowercase version through Gazelle.

For example:
* Golang supports both versions but the uppercase takes precedence (https://github.com/golang/net/blob/d196dffd7c2beec1957382065df08bcc353b9706/http/httpproxy/proxy.go#L91-L98)
* curl gives precedence to the lowercase version of all 3 variables but accepts the uppercase version for HTTPS_PROXY and NO_PROXY (https://github.com/curl/curl/blob/e3a53e3efb942a5446a22725340e36af63f1632e/lib/url.c#L2430-L2446)