### PR TITLE
language/go: Add option to disable go_proto_library rule generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -619,6 +619,19 @@ The following directives are recognized:
 | ``@io_bazel_rules_go//proto:go_proto_library.bzl`` is loaded, Gazelle                      |
 | will run in ``legacy`` mode.                                                               |
 +---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:go_proto mode`                  | :value:`default`                       |
++---------------------------------------------------+----------------------------------------+
+| Tells Gazelle how to generate ``go_proto_library`` rules for .proto files.                 |
+| Valid values are:                                                                          |
+|                                                                                            |
+| * ``default``: .proto file rules are generated using the mode specified by the             |
+|   ``proto`` gazelle directive. This is the default mode.                                   |
+| * ``disable``: ``go_proto_library`` rules are not generated. ``go_proto_library`` rules    |
+|   should be handwritten or generated via a custom gazelle plugin. Pregenerated .pb.go      |
+|   files are also ignored.                                                                  |
+|                                                                                            |
+| This directive applies to the current directory and subdirectories.                        |
++---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:proto_group option`             | :value:`""`                            |
 +---------------------------------------------------+----------------------------------------+
 | *This directive is only effective in* ``package`` *mode (see above).*                      |

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -74,6 +74,10 @@ type goConfig struct {
 	// goGrpcCompilersSet indicates whether goGrpcCompiler was set explicitly.
 	goGrpcCompilersSet bool
 
+	// noGoProtoLibrary indicates whether go_proto_library rules should be
+	// generated.
+	noGoProtoLibrary bool
+
 	// moduleMode is true if external dependencies should be resolved as modules.
 	// TODO(jayconrod): this should be the only mode in the future.
 	moduleMode bool
@@ -199,6 +203,7 @@ func (_ *goLang) KnownDirectives() []string {
 		"build_tags",
 		"go_grpc_compilers",
 		"go_proto_compilers",
+		"go_proto",
 		"importmap_prefix",
 		"prefix",
 	}
@@ -313,6 +318,10 @@ func (_ *goLang) Configure(c *config.Config, rel string, f *rule.File) {
 				} else {
 					gc.goProtoCompilersSet = true
 					gc.goProtoCompilers = splitValue(d.Value)
+				}
+			case "go_proto":
+				if d.Value == "disable" {
+					gc.noGoProtoLibrary = true
 				}
 			case "importmap_prefix":
 				gc.importMapPrefix = d.Value

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -145,6 +145,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	g := &generator{
 		c:                   c,
 		rel:                 args.Rel,
+		noGoProtoLibrary:    gc.noGoProtoLibrary,
 		shouldSetVisibility: args.File == nil || !args.File.HasDefaultVisibility(),
 	}
 	var res language.GenerateResult
@@ -348,6 +349,7 @@ func defaultPackageName(c *config.Config, rel string) string {
 type generator struct {
 	c                   *config.Config
 	rel                 string
+	noGoProtoLibrary    bool
 	shouldSetVisibility bool
 }
 
@@ -355,6 +357,12 @@ func (g *generator) generateProto(mode proto.Mode, target protoTarget, importPat
 	if !mode.ShouldGenerateRules() && mode != proto.LegacyMode {
 		// Don't create or delete proto rules in this mode. Any existing rules
 		// are likely hand-written.
+		return "", nil
+	}
+
+	if g.noGoProtoLibrary {
+		// Don't create or delete proto rules in this mode, because the user
+		// specified that nothing should be done with the proto_library rule.
 		return "", nil
 	}
 

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -125,7 +125,7 @@ func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r 
 		return l, nil
 	}
 
-	if pcMode.ShouldUseKnownImports() {
+	if gc.ShouldUseKnownImports(pcMode) {
 		// These are commonly used libraries that depend on Well Known Types.
 		// They depend on the generated versions of these protos to avoid conflicts.
 		// However, since protoc-gen-go depends on these libraries, we generate
@@ -283,6 +283,7 @@ func resolveVendored(rc *repo.RemoteCache, imp string) (label.Label, error) {
 }
 
 func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
+	gc := getGoConfig(c)
 	pcMode := getProtoMode(c)
 
 	if wellKnownProtos[imp] {
@@ -293,7 +294,7 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache,
 		return l, nil
 	}
 
-	if l, ok := knownProtoImports[imp]; ok && pcMode.ShouldUseKnownImports() {
+	if l, ok := knownProtoImports[imp]; ok && gc.ShouldUseKnownImports(pcMode) {
 		if l.Equal(from) {
 			return label.NoLabel, skipImportError
 		} else {

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -918,6 +918,43 @@ go_proto_library(
     deps = ["//sub:embed"],
 )
 `,
+		}, {
+			desc: "go_proto_disable_resolve_well_known_types",
+			index: []buildFile{{
+				rel: "",
+				content: `
+# gazelle:go_proto disable
+`,
+			},
+			},
+			old: buildFile{content: `
+go_library(
+    name = "go_default_library",
+    _imports = [
+        "github.com/golang/protobuf/proto",
+        "github.com/golang/protobuf/jsonpb",
+        "github.com/golang/protobuf/descriptor",
+        "github.com/golang/protobuf/protoc-gen-go/generator",
+        "github.com/golang/protobuf/ptypes",
+        "google.golang.org/genproto/protobuf/ptype",
+        "google.golang.org/grpc",
+    ],
+)
+`},
+			want: `
+go_library(
+    name = "go_default_library",
+    deps = [
+        "@com_github_golang_protobuf//descriptor:go_default_library_gen",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@io_bazel_rules_go//proto/wkt:type_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/language/go/testdata/go_proto_disable/BUILD.old
+++ b/language/go/testdata/go_proto_disable/BUILD.old
@@ -1,0 +1,1 @@
+# gazelle:go_proto disable

--- a/language/go/testdata/go_proto_disable/BUILD.want
+++ b/language/go/testdata/go_proto_disable/BUILD.want
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+proto_library(
+    name = "go_proto_disable_proto",
+    srcs = ["foo.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "protos/sub/sub.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["extra.go"],
+    _gazelle_imports = [],
+    importpath = "example.com/repo/go_proto_disable",
+    visibility = ["//visibility:public"],
+)

--- a/language/go/testdata/go_proto_disable/extra.go
+++ b/language/go/testdata/go_proto_disable/extra.go
@@ -1,0 +1,1 @@
+package go_proto_disable

--- a/language/go/testdata/go_proto_disable/foo.pb.go
+++ b/language/go/testdata/go_proto_disable/foo.pb.go
@@ -1,0 +1,1 @@
+package go_proto_disable

--- a/language/go/testdata/go_proto_disable/foo.proto
+++ b/language/go/testdata/go_proto_disable/foo.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+option go_package = "example.com/repo/go_proto_disable";
+
+import "google/protobuf/any.proto";
+import "protos/sub/sub.proto";

--- a/language/go/testdata/go_proto_disable/sub/sub.proto
+++ b/language/go/testdata/go_proto_disable/sub/sub.proto
@@ -1,0 +1,1 @@
+syntax = "proto2";

--- a/language/go/testdata/go_proto_disable_no_go/BUILD.old
+++ b/language/go/testdata/go_proto_disable_no_go/BUILD.old
@@ -1,0 +1,1 @@
+# gazelle:go_proto disable

--- a/language/go/testdata/go_proto_disable_no_go/BUILD.want
+++ b/language/go/testdata/go_proto_disable_no_go/BUILD.want
@@ -1,0 +1,9 @@
+proto_library(
+    name = "go_proto_disable_proto",
+    srcs = ["foo.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "protos/sub/sub.proto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/language/go/testdata/go_proto_disable_no_go/foo.proto
+++ b/language/go/testdata/go_proto_disable_no_go/foo.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+option go_package = "example.com/repo/go_proto_disable";
+
+import "google/protobuf/any.proto";
+import "protos/sub/sub.proto";

--- a/language/go/testdata/go_proto_disable_no_go/sub/sub.proto
+++ b/language/go/testdata/go_proto_disable_no_go/sub/sub.proto
@@ -1,0 +1,1 @@
+syntax = "proto2";


### PR DESCRIPTION
This commit adds a gazelle directive to disable go_proto_library rule
generation.

Resolves #497.