### PR TITLE
Add support for the replace directive in go.mod 

### DIFF
--- a/language/go/kinds.go
+++ b/language/go/kinds.go
@@ -89,6 +89,7 @@ var goKinds = map[string]rule.KindInfo{
 			"commit":       true,
 			"importpath":   true,
 			"remote":       true,
+			"replace":      true,
 			"sha256":       true,
 			"strip_prefix": true,
 			"sum":          true,

--- a/repo/import_test.go
+++ b/repo/import_test.go
@@ -116,12 +116,16 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pelletier/go-toml v1.2.0
+	github.com/pelletier/go-toml v1.0.1
 	github.com/pmezard/go-difflib v1.0.0
 	golang.org/x/sys v0.0.0-20190122071731-054c452bb702 // indirect
 	golang.org/x/tools v0.0.0-20190122202912-9c309ee22fab
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
+)
+
+replace (
+	github.com/pelletier/go-toml => github.com/fork/go-toml v0.0.0-20190425002759-70bc0436ed16
 )
 `,
 				}, {
@@ -142,8 +146,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
-github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/fork/go-toml v0.0.0-20190425002759-70bc0436ed16 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
+github.com/fork/go-toml v0.0.0-20190425002759-70bc0436ed16/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 golang.org/x/sys v0.0.0-20190122071731-054c452bb702 h1:Lk4tbZFnlyPgV+sLgTw5yGfzrlOn9kx4vSombi2FFlY=
@@ -182,8 +186,9 @@ go_repository(
 go_repository(
     name = "com_github_pelletier_go_toml",
     importpath = "github.com/pelletier/go-toml",
+    replace = "github.com/fork/go-toml",
     sum = "h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=",
-    version = "v1.0.1",
+    version = "v0.0.0-20190425002759-70bc0436ed16",
 )
 
 go_repository(

--- a/repo/modules.go
+++ b/repo/modules.go
@@ -51,7 +51,6 @@ func importRepoRulesModules(filename string, _ *RemoteCache) (repos []Repo, err 
 		}
 	}
 	pathToModule := map[string]*module{}
-	replacePathToModule := map[string]*module{}
 	data, err := goListModules(tempDir)
 	if err != nil {
 		return nil, err
@@ -65,9 +64,10 @@ func importRepoRulesModules(filename string, _ *RemoteCache) (repos []Repo, err 
 		if mod.Main {
 			continue
 		}
-		pathToModule[mod.Path] = mod
 		if mod.Replace != nil {
-			replacePathToModule[mod.Replace.Path] = mod
+			pathToModule[mod.Replace.Path] = mod
+		} else {
+			pathToModule[mod.Path] = mod
 		}
 	}
 
@@ -86,9 +86,6 @@ func importRepoRulesModules(filename string, _ *RemoteCache) (repos []Repo, err 
 			continue
 		}
 		if mod, ok := pathToModule[path]; ok {
-			mod.Sum = sum
-		}
-		if mod, ok := replacePathToModule[path]; ok {
 			mod.Sum = sum
 		}
 	}

--- a/repo/modules.go
+++ b/repo/modules.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"log"
@@ -65,6 +66,11 @@ func importRepoRulesModules(filename string, _ *RemoteCache) (repos []Repo, err 
 			continue
 		}
 		if mod.Replace != nil {
+			if filepath.IsAbs(mod.Replace.Path) || build.IsLocalImport(mod.Replace.Path) {
+				log.Printf("go_repository does not support file path replacements for %s -> %s", mod.Path,
+					mod.Replace.Path)
+				continue
+			}
 			pathToModule[mod.Replace.Path] = mod
 		} else {
 			pathToModule[mod.Path] = mod

--- a/repo/modules.go
+++ b/repo/modules.go
@@ -94,7 +94,11 @@ func importRepoRulesModules(filename string, _ *RemoteCache) (repos []Repo, err 
 	var missingSumArgs []string
 	for _, mod := range pathToModule {
 		if mod.Sum == "" {
-			missingSumArgs = append(missingSumArgs, fmt.Sprintf("%s@%s", mod.Path, mod.Version))
+			if mod.Replace != nil {
+				missingSumArgs = append(missingSumArgs, fmt.Sprintf("%s@%s", mod.Replace.Path, mod.Replace.Version))
+			} else {
+				missingSumArgs = append(missingSumArgs, fmt.Sprintf("%s@%s", mod.Path, mod.Version))
+			}
 		}
 	}
 	if len(missingSumArgs) > 0 {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -56,6 +56,10 @@ type Repo struct {
 
 	// Sum is the hash of the module to be verified after download.
 	Sum string
+
+	// Replace is the Go import path of the module configured by the replace
+	// directive in go.mod.
+	Replace string
 }
 
 type byName []Repo
@@ -185,6 +189,9 @@ func GenerateRule(repo Repo) *rule.Rule {
 	}
 	if repo.Sum != "" {
 		r.SetAttr("sum", repo.Sum)
+	}
+	if repo.Replace != "" {
+		r.SetAttr("replace", repo.Replace)
 	}
 	return r
 }

--- a/repo/stubs_test.go
+++ b/repo/stubs_test.go
@@ -66,6 +66,13 @@ func goListModulesStub(dir string) ([]byte, error) {
 	"Version": "v1.0.1",
 	"Time": "2017-09-24T18:42:18Z",
 	"Dir": "/usr/local/google/home/jayconrod/go/pkg/mod/github.com/pelletier/go-toml@v1.0.1",
+	"Replace": {
+		"Path": "github.com/fork/go-toml",
+		"Version": "v0.0.0-20190425002759-70bc0436ed16",
+		"Time": "2017-04-06T11:16:28Z",
+		"Dir": "/usr/local/google/home/jayconrod/go/pkg/mod/github.com/fork/!go-toml@v1.0.1",
+        "GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/github.com/fork/go-toml@v/v1.0.1.mod"
+	},
 	"GoMod": "/usr/local/google/home/jayconrod/go/pkg/mod/cache/download/github.com/pelletier/go-toml/@v/v1.0.1.mod"
 }
 {


### PR DESCRIPTION
I think this may also partially address the issue raised in #407, that the replace directive in go.mod is not handled properly.

I noticed this at first when trying to add [Pulumi](https://github.com/pulumi/pulumi/) as a third_party dependency.

```
gazelle: error parsing "go.mod": exit status 1
```

With this patch I am able to directly run an `update-reps` and generate a proper `go_repository`.

For a given `go.mod`:
```
require (
        github.com/Nvveen/Gotty v0.0.0-20170406111628-a8b993ba6abd
)

replace (
        github.com/Nvveen/Gotty => github.com/ijc25/Gotty v0.0.0-20170406111628-a8b993ba6abd
)
```

Gazelle will produce:
```
    go_repository(
        name = "com_github_nvveen_gotty",
        importpath = "github.com/Nvveen/Gotty",
        replace = "github.com/ijc25/Gotty",
        sum = "h1:a0nQYN5aGC2AiAbRXGtbhFXVFEYhI8m0qm0rS4BZrlo=",
        version = "v0.0.0-20170406111628-a8b993ba6abd",
    )
```