### PR TITLE
language/go: fix typo s|compiler_plugin|compiler/plugin| in wkt map

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -328,7 +328,7 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache,
 var wellKnownProtos = map[string]bool{
 	"google/protobuf/any.proto":             true,
 	"google/protobuf/api.proto":             true,
-	"google/protobuf/compiler_plugin.proto": true,
+	"google/protobuf/compiler/plugin.proto": true,
 	"google/protobuf/descriptor.proto":      true,
 	"google/protobuf/duration.proto":        true,
 	"google/protobuf/empty.proto":           true,

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -735,7 +735,7 @@ go_proto_library(
     _imports = [
         "google/protobuf/any.proto",
         "google/protobuf/api.proto",
-        "google/protobuf/compiler_plugin.proto",
+        "google/protobuf/compiler/plugin.proto",
         "google/protobuf/descriptor.proto",
         "google/protobuf/duration.proto",
         "google/protobuf/empty.proto",


### PR DESCRIPTION
`google/protobuf/compiler/plugin.proto` was incorrectly written as `google/protobuf/compiler_plugin.proto` which doesn't exist in https://github.com/protocolbuffers/protobuf/tree/master/src/google/protobuf.
