### PR TITLE
go_repository: Support GIT_SSH and GIT_SSH_COMMAND env vars

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -93,6 +93,8 @@ def _go_repository_impl(ctx):
             "https_proxy",
             "no_proxy",
             "GIT_SSL_CAINFO",
+            "GIT_SSH",
+            "GIT_SSH_COMMAND",
         ]
         env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 


### PR DESCRIPTION
These environment variables allow the `ssh` implementation to be overridden when cloning a Go repository with SSH.