### PR TITLE
go_repository: print stderr, even on success

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -108,6 +108,8 @@ def _go_repository_impl(ctx):
         )
         if result.return_code:
             fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
+        if result.stderr:
+            print("fetch_repo: " + result.stderr)
 
     if generate:
         # Build file generation is needed
@@ -140,6 +142,8 @@ def _go_repository_impl(ctx):
                 ctx.attr.importpath,
                 result.stderr,
             ))
+        if result.stderr:
+            print("gazelle: " + result.stderr)
 
     # Apply patches if necessary.
     patch(ctx)


### PR DESCRIPTION
Gazelle considers most errors non-fatal. It prints warnings and exits 0.
go_repository should at least print these.

Updates #498, but this is by no means a complete solution.