### PR TITLE
Improve error logging for go_repository

### DIFF
--- a/repo/remote.go
+++ b/repo/remote.go
@@ -319,7 +319,11 @@ func defaultHeadCmd(remote, vcs string) (string, error) {
 		cmd := exec.Command("git", "ls-remote", remote, "HEAD")
 		out, err := cmd.Output()
 		if err != nil {
-			return "", fmt.Errorf("git ls-remote for %s : %v : %s", remote, err, err.(*exec.ExitError).Stderr)
+			var stdErr []byte
+			if e, ok := err.(*exec.ExitError); ok {
+				stdErr = e.Stderr
+			}
+			return "", fmt.Errorf("git ls-remote for %s : %v : %s", remote, err, stdErr)
 		}
 		ix := bytes.IndexByte(out, '\t')
 		if ix < 0 {
@@ -405,7 +409,11 @@ func defaultModInfo(rc *RemoteCache, importPath string) (modPath string, err err
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("finding module path for import %s: %v: %s", importPath, err, err.(*exec.ExitError).Stderr)
+		var stdErr []byte
+		if e, ok := err.(*exec.ExitError); ok {
+			stdErr = e.Stderr
+		}
+		return "", fmt.Errorf("finding module path for import %s: %v: %s", importPath, err, stdErr)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -319,7 +319,7 @@ func defaultHeadCmd(remote, vcs string) (string, error) {
 		cmd := exec.Command("git", "ls-remote", remote, "HEAD")
 		out, err := cmd.Output()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("git ls-remote for %s : %v : %s", remote, err, err.(*exec.ExitError).Stderr)
 		}
 		ix := bytes.IndexByte(out, '\t')
 		if ix < 0 {
@@ -405,7 +405,7 @@ func defaultModInfo(rc *RemoteCache, importPath string) (modPath string, err err
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("finding module path for import %s: %v", importPath, err)
+		return "", fmt.Errorf("finding module path for import %s: %v: %s", importPath, err, err.(*exec.ExitError).Stderr)
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-gazelle/pull/522 updated go_repository to print Gazelle warnings.

For `ls-remote` and `go list` failures the error is always printed as something like `exit status 1`.

This change updates the error messages to be something like 
`exit status 1 : failure printed to stderr`