### PR TITLE
go_repository: don't require a repository named "go_sdk"

### DIFF
--- a/cmd/fetch_repo/vcs.go
+++ b/cmd/fetch_repo/vcs.go
@@ -48,7 +48,7 @@ func getRepoRoot(remote, cmd, importpath string) (*vcs.RepoRoot, error) {
 
 	// User did not give us complete information for VCS / Remote.
 	// Try to figure out the information from the import path.
-	r, err := repoRootForImportPath(importpath, true)
+	r, err := repoRootForImportPath(importpath, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/fetch_repo/vcs.go
+++ b/cmd/fetch_repo/vcs.go
@@ -48,7 +48,8 @@ func getRepoRoot(remote, cmd, importpath string) (*vcs.RepoRoot, error) {
 
 	// User did not give us complete information for VCS / Remote.
 	// Try to figure out the information from the import path.
-	r, err := repoRootForImportPath(importpath, false)
+	verbose := false
+	r, err := repoRootForImportPath(importpath, verbose)
 	if err != nil {
 		return nil, err
 	}

--- a/deps.bzl
+++ b/deps.bzl
@@ -33,10 +33,26 @@ load(
 # Re-export go_repository . Users should get it from this file.
 go_repository = _go_repository
 
-def gazelle_dependencies(go_sdk = "@go_sdk//:ROOT"):
+def gazelle_dependencies(go_sdk = ""):
+    go_sdk_info = {}
+    if not go_sdk:
+        for name, r in native.existing_rules().items():
+            # avoid referencing _go_download_sdk in case the internal rules
+            # are renamed (removing leading "_") or more rules are added.
+            if "go_" not in r["kind"] or "_sdk" not in r["kind"]:
+                continue
+            if "goos" in r and "goarch" in r:
+                platform = r["goos"] + "_" + r["goarch"]
+            elif "go_host_sdk" in r["kind"]:
+                platform = "host"
+            else:
+                platform = "unknown"
+            go_sdk_info[name] = platform
+
     _go_repository_cache(
         name = "bazel_gazelle_go_repository_cache",
-        go_sdk = go_sdk,
+        go_sdk_name = go_sdk,
+        go_sdk_info = go_sdk_info,
     )
 
     _go_repository_tools(

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -13,7 +13,7 @@ register_toolchains(
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-gazelle_dependencies()
+gazelle_dependencies(go_sdk = "go_sdk")
 
 go_repository(
     name = "errors_go_git",


### PR DESCRIPTION
gazelle_dependencies will now detect any declared Go SDK
repository. It may use a go_download_sdk with goos and goarch set to
the host platform, or a go_host_sdk, or an SDK named "go_sdk".

If an appropriate repository can't be discovered, gazelle_dependencies
accepts a go_sdk parameter, which can be used to set the name.

Updates bazelbuild/rules_go#1507