### PR TITLE
GO_REPOSITORY_USE_HOST_CACHE enables a shared mod cache

### DIFF
--- a/repository.rst
+++ b/repository.rst
@@ -61,11 +61,11 @@ go_repository
 if they are not already present. This is the simplest way to depend on
 external Go projects.
 
-When ``go_repository`` is in module mode, a module cache is kept within 
-``@bazel_gazelle_go_repository_cache``. This cache is separate from the
-user's cache to avoid any dependence on system configuration. By setting
-``GO_REPOSITORY_USE_HOST_CACHE=1`` you can override this behaviour, and
-``go_repository`` will share the user's module cache.
+When ``go_repository`` is in module mode, it saves downloaded modules in a shared,
+internal cache within Bazel's cache. It may be cleared with ``bazel clean --expunge``.
+By setting the environment variable ``GO_REPOSITORY_USE_HOST_CACHE=1``, you can
+force ``go_repository`` to use the module cache on the host system in the location
+returned by ``go env GOPATH``.
 
 **Example**
 

--- a/repository.rst
+++ b/repository.rst
@@ -61,6 +61,12 @@ go_repository
 if they are not already present. This is the simplest way to depend on
 external Go projects.
 
+When ``go_repository`` is in module mode, a module cache is kept within 
+``@bazel_gazelle_go_repository_cache``. This cache is separate from the
+user's cache to avoid any dependence on system configuration. By setting
+``GO_REPOSITORY_USE_HOST_CACHE=1`` you can override this behaviour, and
+``go_repository`` will share the user's module cache.
+
 **Example**
 
 .. code:: bzl


### PR DESCRIPTION
#394 

Adds the `GO_REPOSITORY_USE_HOST_CACHE` environment variable, which when set will tell `go_repository` to share the user's module cache. This is achieved by having Bazel's go toolchain use the same `GOPATH` and `GOCACHE` as the local go toolchain.

