### PR TITLE
go_repository: read configuration from main WORKSPACE

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -15,8 +15,14 @@
 load(
     "@bazel_gazelle//internal:go_repository.bzl",
     _go_repository = "go_repository",
-    _go_repository_cache = "go_repository_cache",
-    _go_repository_tools = "go_repository_tools",
+)
+load(
+    "@bazel_gazelle//internal:go_repository_cache.bzl",
+    "go_repository_cache",
+)
+load(
+    "@bazel_gazelle//internal:go_repository_tools.bzl",
+    "go_repository_tools",
 )
 load(
     "@bazel_gazelle//internal:overlay_repository.bzl",
@@ -35,7 +41,7 @@ go_repository = _go_repository
 
 def gazelle_dependencies(go_sdk = ""):
     if go_sdk:
-        _go_repository_cache(
+        go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_name = go_sdk,
         )
@@ -52,12 +58,12 @@ def gazelle_dependencies(go_sdk = ""):
             else:
                 platform = "host"
             go_sdk_info[name] = platform
-        _go_repository_cache(
+        go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_info = go_sdk_info,
         )
 
-    _go_repository_tools(
+    go_repository_tools(
         name = "bazel_gazelle_go_repository_tools",
         go_cache = "@bazel_gazelle_go_repository_cache//:go.env",
     )
@@ -74,7 +80,7 @@ def gazelle_dependencies(go_sdk = ""):
         name = "com_github_bazelbuild_buildtools",
         importpath = "github.com/bazelbuild/buildtools",
         sum = "h1:KLCFP96KTydy03EMRwdGnngaD76gt34BBWK4g7TChgk=",
-        version = "v0.0.0-20190329162354-3f7be923c4b0",        
+        version = "v0.0.0-20190329162354-3f7be923c4b0",
     )
 
     _maybe(
@@ -82,7 +88,7 @@ def gazelle_dependencies(go_sdk = ""):
         name = "com_github_fsnotify_fsnotify",
         importpath = "github.com/fsnotify/fsnotify",
         sum = "h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=",
-        version = "v1.4.7",      
+        version = "v1.4.7",
     )
 
     _maybe(

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/bazelbuild/bazel-gazelle
 
+go 1.12
+
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20190329162354-3f7be923c4b0

--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -1,0 +1,131 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:common.bzl", "executable_extension")
+
+def _go_repository_cache_impl(ctx):
+    if ctx.attr.go_sdk_name:
+        go_sdk_name = ctx.attr.go_sdk_name
+    else:
+        host_platform = _detect_host_platform(ctx)
+        matches = [
+            name
+            for name, platform in ctx.attr.go_sdk_info.items()
+            if host_platform == platform or platform == "host"
+        ]
+        if len(matches) > 1:
+            fail('gazelle found more than one suitable Go SDK ({}). Specify which one to use with gazelle_dependencies(go_sdk = "go_sdk").'.format(", ".join(matches)))
+        if len(matches) == 0:
+            fail('gazelle could not find a Go SDK. Specify which one to use with gazelle_dependencies(go_sdk = "go_sdk").')
+        if len(matches) == 1:
+            go_sdk_name = matches[0]
+
+    go_sdk_label = Label("@" + go_sdk_name + "//:ROOT")
+
+    go_root = str(ctx.path(go_sdk_label).dirname)
+    go_path = str(ctx.path("."))
+    go_cache = str(ctx.path("gocache"))
+    if ctx.os.environ.get("GO_REPOSITORY_USE_HOST_CACHE", "") == "1":
+        extension = executable_extension(ctx)
+        go_tool = go_root + "/bin/go" + extension
+        res = ctx.execute([go_tool, "env", "GOPATH"])
+        if res.return_code:
+            fail("failed to read go environment: " + res.stderr)
+        if not res.stdout:
+            fail("GOPATH must be set when GO_REPOSITORY_USE_HOST_CACHE is enabled.")
+        go_path = res.stdout.strip()
+        res = ctx.execute([go_tool, "env", "GOCACHE"])
+        if res.return_code:
+            fail("failed to read go environment: " + res.stderr)
+        if not res.stdout:
+            fail("GOCACHE must be set when GO_REPOSITORY_USE_HOST_CACHE is enabled.")
+        go_cache = res.stdout.strip()
+
+    env_tpl = """
+GOROOT='{goroot}'
+GOPATH='{gopath}'
+GOCACHE='{gocache}'
+"""
+    env_content = env_tpl.format(
+        goroot = go_root,
+        gopath = go_path,
+        gocache = go_cache,
+    )
+    ctx.file("go.env", env_content)
+    ctx.file("BUILD.bazel", 'exports_files(["go.env"])')
+
+go_repository_cache = repository_rule(
+    _go_repository_cache_impl,
+    attrs = {
+        "go_sdk_name": attr.string(),
+        "go_sdk_info": attr.string_dict(),
+    },
+    # Don't put anything in environ. If we switch between the host cache
+    # and Bazel's cache, it shouldn't actually invalidate Bazel's cache.
+)
+
+def read_cache_env(ctx, path):
+    result = ctx.execute(["cat", path])
+    if result.return_code:
+        fail("failed to read cache environment: " + result.stderr)
+    env = {}
+    lines = result.stdout.split("\n")
+    for line in lines:
+        line = line.strip()
+        if line == "" or line.startswith("#"):
+            continue
+        k, sep, v = line.partition("=")
+        if sep == "":
+            fail("failed to parse cache environment")
+        env[k] = v.strip("'")
+    return env
+
+# copied from rules_go. Keep in sync.
+def _detect_host_platform(ctx):
+    if ctx.os.name == "linux":
+        host = "linux_amd64"
+        res = ctx.execute(["uname", "-p"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "s390x":
+                host = "linux_s390x"
+            elif uname == "i686":
+                host = "linux_386"
+
+        # uname -p is not working on Aarch64 boards
+        # or for ppc64le on some distros
+        res = ctx.execute(["uname", "-m"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "aarch64":
+                host = "linux_arm64"
+            elif uname == "armv6l":
+                host = "linux_arm"
+            elif uname == "armv7l":
+                host = "linux_arm"
+            elif uname == "ppc64le":
+                host = "linux_ppc64le"
+
+        # Default to amd64 when uname doesn't return a known value.
+
+    elif ctx.os.name == "mac os x":
+        host = "darwin_amd64"
+    elif ctx.os.name.startswith("windows"):
+        host = "windows_amd64"
+    elif ctx.os.name == "freebsd":
+        host = "freebsd_amd64"
+    else:
+        fail("Unsupported operating system: " + ctx.os.name)
+
+    return host

--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -1,0 +1,121 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go/private:common.bzl", "env_execute", "executable_extension")
+load("@bazel_gazelle//internal:go_repository_cache.bzl", "read_cache_env")
+
+_GO_REPOSITORY_TOOLS_BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "fetch_repo",
+    srcs = ["bin/fetch_repo{extension}"],
+)
+
+filegroup(
+    name = "gazelle",
+    srcs = ["bin/gazelle{extension}"],
+)
+
+exports_files(["ROOT"])
+"""
+
+def _go_repository_tools_impl(ctx):
+    # Create a link to the gazelle repo. This will be our GOPATH.
+    env = read_cache_env(ctx, str(ctx.path(ctx.attr.go_cache)))
+    extension = executable_extension(ctx)
+    go_tool = env["GOROOT"] + "/bin/go" + extension
+
+    ctx.symlink(
+        ctx.path(Label("@bazel_gazelle//:WORKSPACE")).dirname,
+        "src/github.com/bazelbuild/bazel-gazelle",
+    )
+
+    # Resolve a label for each source file so this rule will be re-executed
+    # when they change.
+    list_script = str(ctx.path(Label("@bazel_gazelle//internal:list_repository_tools_srcs.go")))
+    result = ctx.execute([go_tool, "run", list_script])
+    if result.return_code:
+        print("could not resolve gazelle sources: " + result.stderr)
+    else:
+        for line in result.stdout.split("\n"):
+            line = line.strip()
+            if line == "":
+                continue
+            ctx.path(Label(line))
+
+    # Build the tools.
+    env.update({
+        "GOPATH": str(ctx.path(".")),
+        "GO111MODULE": "off",
+        # workaround: to find gcc for go link tool on Arm platform
+        "PATH": ctx.os.environ["PATH"],
+        # workaround: avoid the Go SDK paths from leaking into the binary
+        "GOROOT_FINAL": "GOROOT",
+        # workaround: avoid cgo paths in /tmp leaking into binary
+        "CGO_ENABLED": "0",
+    })
+    if "GOPROXY" in ctx.os.environ:
+        env["GOPROXY"] = ctx.os.environ["GOPROXY"]
+
+    args = [
+        go_tool,
+        "install",
+        "-ldflags",
+        "-w -s",
+        "-gcflags",
+        "all=-trimpath=" + env["GOPATH"],
+        "-asmflags",
+        "all=-trimpath=" + env["GOPATH"],
+        "github.com/bazelbuild/bazel-gazelle/cmd/gazelle",
+        "github.com/bazelbuild/bazel-gazelle/cmd/fetch_repo",
+    ]
+    result = env_execute(ctx, args, environment = env)
+    if result.return_code:
+        fail("failed to build tools: " + result.stderr)
+
+    # add a build file to export the tools
+    ctx.file(
+        "BUILD.bazel",
+        _GO_REPOSITORY_TOOLS_BUILD_FILE.format(extension = executable_extension(ctx)),
+        False,
+    )
+    ctx.file(
+        "ROOT",
+        "",
+        False,
+    )
+
+go_repository_tools = repository_rule(
+    _go_repository_tools_impl,
+    attrs = {
+        "go_cache": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+    },
+    environ = [
+        "GOCACHE",
+        "GOPATH",
+        "GO_REPOSITORY_USE_HOST_CACHE",
+    ],
+)
+"""go_repository_tools is a synthetic repository used by go_repository.
+
+
+go_repository depends on two Go binaries: fetch_repo and gazelle. We can't
+build these with Bazel inside a repository rule, and we don't want to manage
+prebuilt binaries, so we build them in here with go build, using whichever
+SDK rules_go is using.
+"""


### PR DESCRIPTION
'gazelle fix' and 'gazelle update' now accept -repo_config, the path
to a file where information about repositories can be loaded. By
default, this is WORKSPACE in the repository root directory.
'gazelle fix' and 'gazelle update-repos' still update the WORKSPACE
file in the repository root directory when this flag is set.

go_repository passes the path to @//:WORKSPACE to -repo_config.

go_repository resolves @//:WORKSPACE and any files mentioned in
'# gazelle:repository_macro' directives. When these files, all
go_repository rules will be invalidated. It should not be necessary to
download cached repositories (except vcs repositories; see #549).
On a Macbook Pro, it takes about 22.5s to re-evaluate 70 cached,
invalidated go_repository rules for github.com/gohugoio/hugo. If this
becomes a project for large projects, we can provide a way to disable
or limit this behavior in the future.

go_repository_tools and go_repository_cache are moved to their own
.bzl files. Changes in go_repository.bzl should not invalidate these
in the future.

Fixes #529