### PR TITLE
[WIP] Add support for cgo pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     packages:
       - wget
       - pkg-config
+      - libjpeg-dev
+      - libpng-dev
 
 before_install:
   - |


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/bazel-gazelle/issues/203

The tests for pkg-config require libpng and libjpeg to be installed, and skips without failing if one of them isn't installed. 

Signed-off-by: Odin Ugedal <odin@ugedal.com>