### PR TITLE
Fix go_repository configuration

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -2,6 +2,7 @@ filegroup(
     name = "all_files",
     testonly = True,
     srcs = [
+        "BUILD.bazel",
         "//cmd/autogazelle:all_files",
         "//cmd/fetch_repo:all_files",
         "//cmd/gazelle:all_files",

--- a/deps.bzl
+++ b/deps.bzl
@@ -39,7 +39,9 @@ load(
 # Re-export go_repository . Users should get it from this file.
 go_repository = _go_repository
 
-def gazelle_dependencies(go_sdk = ""):
+def gazelle_dependencies(
+        go_sdk = "",
+        go_repository_default_config = "@//:WORKSPACE"):
     if go_sdk:
         go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -16,6 +16,7 @@ exports_files(
     [
         "gazelle.bash.in",
         "list_repository_tools_srcs.go",
+        "repository_rules_test_errors.patch",
     ],
     visibility = ["//visibility:public"],
 )
@@ -28,6 +29,8 @@ filegroup(
         "gazelle.bash.in",
         "gazelle_binary.bzl",
         "go_repository.bzl",
+        "go_repository_cache.bzl",
+        "go_repository_tools.bzl",
         "list_repository_tools_srcs.go",
         "overlay_repository.bzl",
         "repository_rules_test_errors.patch",

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -21,24 +21,11 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
 )
 
-const mainWorkspace = `
--- WORKSPACE --
-local_repository(
-    name = "io_bazel_rules_go",
-    path = "../io_bazel_rules_go",
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
-
-go_rules_dependencies()
-
-go_register_toolchains(go_version = "host")
-
-local_repository(
-    name = "bazel_gazelle",
-    path = "../bazel_gazelle",
-)
-
+var testArgs = bazel_testing.Args{
+	Main: `
+-- BUILD.bazel --
+`,
+	WorkspaceSuffix: `
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
@@ -57,12 +44,11 @@ go_repository(
     version = "v0.8.1",
     sum ="h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
 )
-
--- BUILD.bazel --
-`
+`,
+}
 
 func TestMain(m *testing.M) {
-	bazel_testing.TestMain(m, bazel_testing.Args{Main: mainWorkspace})
+	bazel_testing.TestMain(m, testArgs)
 }
 
 func TestBuild(t *testing.T) {

--- a/internal/language/BUILD.bazel
+++ b/internal/language/BUILD.bazel
@@ -1,6 +1,9 @@
 filegroup(
     name = "all_files",
     testonly = True,
-    srcs = ["//internal/language/test_filegroup:all_files"],
+    srcs = [
+        "BUILD.bazel",
+        "//internal/language/test_filegroup:all_files",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -73,7 +73,7 @@ func (*testFilegroupLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *r
 var kinds = map[string]rule.KindInfo{
 	"filegroup": {
 		NonEmptyAttrs:  map[string]bool{"srcs": true, "deps": true},
-		MergeableAttrs: map[string]bool{"deps": true},
+		MergeableAttrs: map[string]bool{"srcs": true},
 	},
 }
 

--- a/repository.rst
+++ b/repository.rst
@@ -214,6 +214,21 @@ returned by ``go env GOPATH``.
 | mode, Gazelle will run if there is no build file in the repository root                                 |
 | directory.                                                                                              |
 +--------------------------------+----------------------+-------------------------------------------------+
+| :param:`build_config`          | :type:`label`        | :value:`@//:WORKSPACE`                          |
++--------------------------------+----------------------+-------------------------------------------------+
+| A file that Gazelle should read to learn about external repositories before                             |
+| generating build files. This is useful for dependency resolution. For example,                          |
+| a ``go_repository`` rule in this file establishes a mapping between a                                   |
+| repository name like ``golang.org/x/tools`` and a workspace name like                                   |
+| ``org_golang_x_tools``. Workspace directives like                                                       |
+| ``# gazelle:repository_macro`` are recognized.                                                          |
+|                                                                                                         |
+| By default, Gazelle reads the WORKSPACE file in the main workspace. This                                |
+| means that ``go_repository`` rules are re-evaluated when WORKSPACE changes.                             |
+| Their content should still be fetched from a local cache, but build files                               |
+| will be regenerated. If this is not desirable, ``build_config`` may be set                              |
+| to a less frequently updated file or ``None`` to disable this functionality.                            |
++--------------------------------+----------------------+-------------------------------------------------+
 | :param:`build_file_name`       | :type:`string`       | :value:`BUILD.bazel,BUILD`                      |
 +--------------------------------+----------------------+-------------------------------------------------+
 | Comma-separated list of names Gazelle will consider to be build files.                                  |


### PR DESCRIPTION
* Updated to rules_go at master to get compatibility fixes, new features for
  minimal module compatibility, and `go_bazel_test`.
* Rewrote `//internal:repository_rules_test` to `//internal:go_repository_test`.
  The old test was broken by incompatible changes in new versions of Bazel.
  The new test uses a new integration testing framework. We should be able
  to improve `go_repository` test coverage in the future.
* Added `//internal/language/test_filegroup`, an extension that generates
  `all_files` `filegroup` targets in each package. This is needed for
  `go_bazel_test`, since it explicitly depends files in repositories under test.
* Generated filegroups with the new extension.
