### PR TITLE
language/go: implement minimal module compatibility

### DIFF
--- a/cmd/gazelle/version.go
+++ b/cmd/gazelle/version.go
@@ -26,7 +26,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/repo"
 )
 
-var minimumRulesGoVersion = version.Version{0, 13, 0}
+var minimumRulesGoVersion = version.Version{0, 19, 0}
 
 // checkRulesGoVersion checks whether a compatible version of rules_go is
 // being used in the workspace. A message will be logged if an incompatible

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -132,6 +132,7 @@ def _go_repository_impl(ctx):
         gazelle = ctx.path(Label(_gazelle))
         cmd = [
             gazelle,
+            "-go_repository_mode",
             "-go_prefix",
             ctx.attr.importpath,
             "-mode",
@@ -142,7 +143,7 @@ def _go_repository_impl(ctx):
         if config_path:
             cmd.extend(["-repo_config", str(config_path)])
         if ctx.attr.version:
-            cmd.append("-go_experimental_module_mode")
+            cmd.append("-go_repository_module_mode")
         if ctx.attr.build_file_name:
             cmd.extend(["-build_file_name", ctx.attr.build_file_name])
         if ctx.attr.build_tags:

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -74,8 +74,14 @@ type goConfig struct {
 	// goGrpcCompilersSet indicates whether goGrpcCompiler was set explicitly.
 	goGrpcCompilersSet bool
 
-	// moduleMode is true if external dependencies should be resolved as modules.
-	// TODO(jayconrod): this should be the only mode in the future.
+	// goRepositoryMode is true if Gazelle was invoked by a go_repository rule.
+	// In this mode, we won't go out to the network to resolve external deps.
+	goRepositoryMode bool
+
+	// moduleMode is true if the current directory is intended to be built
+	// as part of a module. Minimal module compatibility won't be supported
+	// if this is true in the root directory. External dependencies may be
+	// resolved differently (also depending on goRepositoryMode).
 	moduleMode bool
 }
 
@@ -228,16 +234,16 @@ func (_ *goLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 			&gzflag.MultiFlag{Values: &gc.goGrpcCompilers, IsSet: &gc.goGrpcCompilersSet},
 			"go_grpc_compiler",
 			"go_proto_library compiler to use for gRPC (may be repeated)")
-		// TODO(jayconrod): remove this flag when gazelle within go_repository
-		// automatically has a list of repositories from the main WORKSPACE.
-		// Enabling module mode without this will make go_repository slower,
-		// since we'd be going out to the network much more often.
+		fs.BoolVar(
+			&gc.goRepositoryMode,
+			"go_repository_mode",
+			false,
+			"set when gazelle is invoked by go_repository")
 		fs.BoolVar(
 			&gc.moduleMode,
-			"go_experimental_module_mode",
+			"go_repository_module_mode",
 			false,
-			"when enabled, external Go imports will be resolved as modules",
-		)
+			"set when gazelle is invoked by go_repository in module mode")
 	}
 	c.Exts[goName] = gc
 }

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -485,4 +486,22 @@ func (si *platformStringInfo) convertToPlatforms() {
 		}
 		si.archs = nil
 	}
+}
+
+var semverRex = regexp.MustCompile(`^.*?(/v\d+)(?:/.*)?$`)
+
+// pathWithoutSemver removes a semantic version suffix from path.
+// For example, if path is "example.com/foo/v2/bar", pathWithoutSemver
+// will return "example.com/foo/bar". If there is no semantic version suffix,
+// "" will be returned.
+func pathWithoutSemver(path string) string {
+	m := semverRex.FindStringSubmatchIndex(path)
+	if m == nil {
+		return ""
+	}
+	v := path[m[2]+2 : m[3]]
+	if v[0] == '0' || v == "1" {
+		return ""
+	}
+	return path[:m[2]] + path[m[3]:]
 }

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -1117,6 +1117,29 @@ func TestResolveExternal(t *testing.T) {
 			}},
 			moduleMode: true,
 			want:       "@custom_repo//v2/foo:go_default_library",
+		}, {
+			desc:       "min_module_compat",
+			importpath: "example.com/foo",
+			repos: []repo.Repo{{
+				Name:     "com_example_foo_v2",
+				GoPrefix: "example.com/foo/v2",
+			}},
+			moduleMode: true,
+			want:       "@com_example_foo_v2//:go_default_library",
+		}, {
+			desc:       "min_module_compat_both",
+			importpath: "example.com/foo",
+			repos: []repo.Repo{
+				{
+					Name:     "com_example_foo",
+					GoPrefix: "example.com/foo",
+				}, {
+					Name:     "com_example_foo_v2",
+					GoPrefix: "example.com/foo/v2",
+				},
+			},
+			moduleMode: true,
+			want:       "@com_example_foo//:go_default_library",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
* The Go extension now accepts flags -go_repository_mode and
  -go_repository_module_mode.
* The Go extension will emit importpath_aliases attributes for
  libraries with importpath set if -go_repository_mode was set,
  Gazelle is in module mode, the prefix is actually a prefix of
  importpath, the prefix contains a semantic import
  version suffix, and the prefix was set in the root package.
  Such a library can be imported with more than one import path.
* The minimum version of rules_go is now 0.19.0, since support for
  importpath_aliases is needed.
* When initializing RemoteCache, which is used to resolve external
  import paths, if we have a known import path that contains a
  semantic import version suffix, but we don't have a known import
  path for the path without the suffix, we create an aliases.

Also:

* Avoided parsing WORKSPACE and related files multiple times when
  -repo_config is set.

Fixes #477