### PR TITLE
Pass args to Configure with config.ConfigureArgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bazel-bin
 bazel-genfiles
 bazel-out
 bazel-testlogs
+.idea

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -155,7 +155,7 @@ func (ucr *updateConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) erro
 
 func (ucr *updateConfigurer) KnownDirectives() []string { return nil }
 
-func (ucr *updateConfigurer) Configure(c *config.Config, rel string, f *rule.File) {}
+func (ucr *updateConfigurer) Configure(args config.ConfigureArgs) {}
 
 // visitRecord stores information about about a directory visited with
 // packages.Walk.

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -120,7 +120,7 @@ func (_ *updateReposConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) e
 
 func (_ *updateReposConfigurer) KnownDirectives() []string { return nil }
 
-func (_ *updateReposConfigurer) Configure(c *config.Config, rel string, f *rule.File) {}
+func (_ *updateReposConfigurer) Configure(args config.ConfigureArgs) {}
 
 func updateRepos(args []string) error {
 	cexts := make([]config.Configurer, 0, 2)

--- a/config/config.go
+++ b/config/config.go
@@ -87,29 +87,28 @@ type Config struct {
 	Exts map[string]interface{}
 }
 
+// ConfigureArgs contains arguments for config.Configure. Arguments are
+// passed in a struct value so that new fields may be added in the future
+// without breaking existing implementations.
 type ConfigureArgs struct {
-	// Config is the configuration for the directory where rules are being
-	// generated.
+	// Config is the configuration for the current directory. It starts out as a copy
+	// of the configuration for the parent directory.
 	Config *Config
 
-	// Rel is the slash-separated path to the directory, relative to the
-	// repository root ("" for the root directory itself). This may be used
-	// as the package name in labels.
+	// Rel is the slash-separated relative path from the repository root to
+	// the current directory. It is "" for the root directory itself.
 	Rel string
 
-	// File is the build file for the directory. File is nil if there is
-	// no existing build file.
+	// File is the build file for the current directory or nil if there is no
+	// existing build file.
 	File *rule.File
 
 	// Subdirs is a list of subdirectories in the directory, including
-	// symbolic links to directories that Gazelle will follow.
+	// symbolic links to directories.
 	// RegularFiles is a list of regular files including other symbolic
 	// links.
-	// GeneratedFiles is a list of generated files in the directory
-	// (usually these are mentioned as "out" or "outs" attributes in rules).
 	Subdirs, RegularFiles []string
 }
-
 
 // MappedKind describes a replacement to use for a built-in kind.
 type MappedKind struct {
@@ -180,14 +179,9 @@ type Configurer interface {
 	// Configure modifies the configuration using directives and other information
 	// extracted from a build file. Configure is called in each directory.
 	//
-	// c is the configuration for the current directory. It starts out as a copy
-	// of the configuration for the parent directory.
-	//
-	// rel is the slash-separated relative path from the repository root to
-	// the current directory. It is "" for the root directory itself.
-	//
-	// f is the build file for the current directory or nil if there is no
-	// existing build file.
+	// args contains the arguments for Configure. This is passed as a
+	// struct to avoid breaking implementations in the future when new
+	// fields are added.
 	Configure(args ConfigureArgs)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,12 @@ func TestCommonConfigurerDirectives(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cc.Configure(c, "", f)
+	cc.Configure(ConfigureArgs{
+		Config: c,
+		Rel: "",
+		File: f,
+	})
+
 	want := []string{"x", "y"}
 	if !reflect.DeepEqual(c.ValidBuildFileNames, want) {
 		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, want)

--- a/internal/gazellebinarytest/xlang.go
+++ b/internal/gazellebinarytest/xlang.go
@@ -60,7 +60,7 @@ func (x *xlang) KnownDirectives() []string {
 	return nil
 }
 
-func (x *xlang) Configure(c *config.Config, rel string, f *rule.File) {
+func (x *xlang) Configure(args config.ConfigureArgs) {
 }
 
 func (x *xlang) GenerateRules(args language.GenerateArgs) language.GenerateResult {

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -51,7 +51,7 @@ func (*testFilegroupLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 
 func (*testFilegroupLang) KnownDirectives() []string { return nil }
 
-func (*testFilegroupLang) Configure(c *config.Config, rel string, f *rule.File) {}
+func (*testFilegroupLang) Configure(args config.ConfigureArgs) {}
 
 func (*testFilegroupLang) Kinds() map[string]rule.KindInfo {
 	return kinds

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -94,7 +94,11 @@ func TestDirectives(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cext := range cexts {
-		cext.Configure(c, "test", f)
+		cext.Configure(config.ConfigureArgs{
+			Config: c,
+			Rel: "test",
+			File: f,
+		})
 	}
 	gc := getGoConfig(c)
 	for _, tag := range []string{"foo", "bar", "gc"} {
@@ -136,7 +140,11 @@ func TestDirectives(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, cext := range cexts {
-		cext.Configure(c, "test/sub", f)
+		cext.Configure(config.ConfigureArgs{
+			Config: c,
+			Rel: "test/sub",
+			File: f,
+		})
 	}
 	gc = getGoConfig(c)
 	if gc.goGrpcCompilersSet {
@@ -161,7 +169,11 @@ func TestVendorConfig(t *testing.T) {
 	gc.importMapPrefix = "bad-importmap-prefix"
 	gc.importMapPrefixRel = ""
 	for _, cext := range cexts {
-		cext.Configure(c, "x/vendor", nil)
+		cext.Configure(config.ConfigureArgs{
+			Config: c,
+			Rel: "x/vendor",
+			File: nil,
+		})
 	}
 	gc = getGoConfig(c)
 	if gc.prefix != "" {
@@ -251,7 +263,11 @@ load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 				}
 			}
 			for _, cext := range cexts {
-				cext.Configure(c, tc.rel, f)
+				cext.Configure(config.ConfigureArgs{
+					Config: c,
+					Rel: tc.rel,
+					File: f,
+				})
 			}
 			pc = proto.GetProtoConfig(c)
 			if pc.Mode != tc.want {
@@ -305,7 +321,11 @@ gazelle(
 				t.Fatal(err)
 			}
 			for _, cext := range cexts {
-				cext.Configure(c, "x", f)
+				cext.Configure(config.ConfigureArgs{
+					Config: c,
+					Rel: "x",
+					File: f,
+				})
 			}
 			gc := getGoConfig(c)
 			if !gc.prefixSet {

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -17,6 +17,7 @@ package golang
 
 import (
 	"fmt"
+	"github.com/bazelbuild/bazel-gazelle/config"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -942,7 +943,11 @@ go_proto_library(
 				}
 				if bf.rel == "" {
 					for _, cext := range cexts {
-						cext.Configure(c, "", f)
+						cext.Configure(config.ConfigureArgs{
+							Config: c,
+							File: f,
+							Rel: "",
+						})
 					}
 				}
 				for _, r := range f.Rules {

--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -196,12 +196,12 @@ func (_ *protoLang) KnownDirectives() []string {
 	return []string{"proto", "proto_group", "proto_strip_import_prefix", "proto_import_prefix"}
 }
 
-func (_ *protoLang) Configure(c *config.Config, rel string, f *rule.File) {
+func (_ *protoLang) Configure(args config.ConfigureArgs) {
 	pc := &ProtoConfig{}
-	*pc = *GetProtoConfig(c)
-	c.Exts[protoName] = pc
-	if f != nil {
-		for _, d := range f.Directives {
+	*pc = *GetProtoConfig(args.Config)
+	args.Config.Exts[protoName] = pc
+	if args.File != nil {
+		for _, d := range args.File.Directives {
 			switch d.Key {
 			case "proto":
 				mode, err := ModeFromString(d.Value)
@@ -215,8 +215,8 @@ func (_ *protoLang) Configure(c *config.Config, rel string, f *rule.File) {
 				pc.groupOption = d.Value
 			case "proto_strip_import_prefix":
 				pc.stripImportPrefix = d.Value
-				if rel != "" {
-					if err := checkStripImportPrefix(pc.stripImportPrefix, rel); err != nil {
+				if args.Rel != "" {
+					if err := checkStripImportPrefix(pc.stripImportPrefix, args.Rel); err != nil {
 						log.Print(err)
 					}
 				}
@@ -225,7 +225,7 @@ func (_ *protoLang) Configure(c *config.Config, rel string, f *rule.File) {
 			}
 		}
 	}
-	inferProtoMode(c, rel, f)
+	inferProtoMode(args.Config, args.Rel, args.File)
 }
 
 // inferProtoMode sets ProtoConfig.Mode based on the directory name and the

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package proto
 
 import (
+	"github.com/bazelbuild/bazel-gazelle/config"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -385,7 +386,11 @@ proto_library(
 				}
 				if bf.rel == "" {
 					for _, cext := range cexts {
-						cext.Configure(c, "", f)
+						cext.Configure(config.ConfigureArgs{
+							Config: c,
+							File: f,
+							Rel: "",
+						})
 					}
 				}
 				for _, r := range f.Rules {

--- a/resolve/config.go
+++ b/resolve/config.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 // FindRuleWithOverride searches the current configuration for user-specified
@@ -74,14 +73,14 @@ func (_ *Configurer) KnownDirectives() []string {
 	return []string{"resolve"}
 }
 
-func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
-	rc := getResolveConfig(c)
+func (_ *Configurer) Configure(args config.ConfigureArgs) {
+	rc := getResolveConfig(args.Config)
 	rcCopy := &resolveConfig{
 		overrides: rc.overrides[:],
 	}
 
-	if f != nil {
-		for _, d := range f.Directives {
+	if args.File != nil {
+		for _, d := range args.File.Directives {
 			if d.Key == "resolve" {
 				parts := strings.Fields(d.Value)
 				o := overrideSpec{}
@@ -105,11 +104,11 @@ func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 					log.Printf("gazelle:resolve %s: %v", d.Value, err)
 					continue
 				}
-				o.dep = o.dep.Abs("", rel)
+				o.dep = o.dep.Abs("", args.Rel)
 				rcCopy.overrides = append(rcCopy.overrides, o)
 			}
 		}
 	}
 
-	c.Exts[resolveName] = rcCopy
+	args.Config.Exts[resolveName] = rcCopy
 }

--- a/walk/config.go
+++ b/walk/config.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	gzflag "github.com/bazelbuild/bazel-gazelle/flag"
-	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 // TODO(#472): store location information to validate each exclude. They
@@ -67,24 +66,24 @@ func (_ *Configurer) KnownDirectives() []string {
 	return []string{"exclude", "follow", "ignore"}
 }
 
-func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
-	wc := getWalkConfig(c)
+func (_ *Configurer) Configure(args config.ConfigureArgs) {
+	wc := getWalkConfig(args.Config)
 	wcCopy := &walkConfig{}
 	*wcCopy = *wc
 	wcCopy.ignore = false
 
-	if f != nil {
-		for _, d := range f.Directives {
+	if args.File != nil {
+		for _, d := range args.File.Directives {
 			switch d.Key {
 			case "exclude":
-				wcCopy.excludes = append(wcCopy.excludes, path.Join(rel, d.Value))
+				wcCopy.excludes = append(wcCopy.excludes, path.Join(args.Rel, d.Value))
 			case "follow":
-				wcCopy.follow = append(wcCopy.follow, path.Join(rel, d.Value))
+				wcCopy.follow = append(wcCopy.follow, path.Join(args.Rel, d.Value))
 			case "ignore":
 				wcCopy.ignore = true
 			}
 		}
 	}
 
-	c.Exts[walkName] = wcCopy
+	args.Config.Exts[walkName] = wcCopy
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -430,6 +430,6 @@ func (_ *testConfigurer) CheckFlags(_ *flag.FlagSet, _ *config.Config) error { r
 
 func (_ *testConfigurer) KnownDirectives() []string { return nil }
 
-func (tc *testConfigurer) Configure(c *config.Config, rel string, f *rule.File) {
-	tc.configure(c, rel, f)
+func (tc *testConfigurer) Configure(args config.ConfigureArgs) {
+	tc.configure(args.Config, args.Rel, args.File)
 }


### PR DESCRIPTION
In my extension I need list of files and directories for current `rel` in `Configure` func. I found out that `Walk` already has this data and I just need to pass it to `Configure`. Because it is braking change I also decided to convert all arguments to `ConfigureArgs` (same way as `GenerateRule` already has) and at least make it extensible for future.

I also modified `go/config.go` to use the `RegularFiles` slice instead of `os.Stat`.