### PR TITLE
Fix go_repository rule when using urls

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -84,6 +84,7 @@ def _go_repository_impl(ctx):
     else:
         fail("one of urls, commit, tag, or importpath must be specified")
 
+    generate = ctx.attr.build_file_generation == "on"
     if fetch_repo_args or generate:
         env = read_cache_env(ctx, str(ctx.path(Label("@bazel_gazelle_go_repository_cache//:go.env"))))
         env_keys = [
@@ -117,7 +118,6 @@ def _go_repository_impl(ctx):
             print("fetch_repo: " + result.stderr)
 
     # Generate build files if needed.
-    generate = ctx.attr.build_file_generation == "on"
     if ctx.attr.build_file_generation == "auto":
         generate = True
         for name in ["BUILD", "BUILD.bazel", ctx.attr.build_file_name]:

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -84,7 +84,16 @@ def _go_repository_impl(ctx):
     else:
         fail("one of urls, commit, tag, or importpath must be specified")
 
+    # Generate build files if needed.
     generate = ctx.attr.build_file_generation == "on"
+    if ctx.attr.build_file_generation == "auto":
+        generate = True
+        for name in ["BUILD", "BUILD.bazel", ctx.attr.build_file_name]:
+            path = ctx.path(name)
+            if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
+                generate = False
+                break
+
     if fetch_repo_args or generate:
         env = read_cache_env(ctx, str(ctx.path(Label("@bazel_gazelle_go_repository_cache//:go.env"))))
         env_keys = [
@@ -116,15 +125,6 @@ def _go_repository_impl(ctx):
             fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
         if result.stderr:
             print("fetch_repo: " + result.stderr)
-
-    # Generate build files if needed.
-    if ctx.attr.build_file_generation == "auto":
-        generate = True
-        for name in ["BUILD", "BUILD.bazel", ctx.attr.build_file_name]:
-            path = ctx.path(name)
-            if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
-                generate = False
-                break
 
     if generate:
         # Build file generation is needed


### PR DESCRIPTION
When urls attribute is set, go_repository rule currently throws this error:
```
ERROR: local variable 'generate' is referenced before assignment.
```

This change moves the definition of generate to just before its first use.