### PR TITLE
Update to rules_go 0.19.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,14 @@
 workspace(name = "bazel_gazelle")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "8ea79bbd5e6ea09dc611c245d1dc09ef7ab7118a",  # master as of 2019-06-28
-    remote = "https://github.com/bazelbuild/rules_go",
-    shallow_since = "1561753935 -0400",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
+    ],
+    sha256 = "9fb16af4d4836c8222142e54c9efa0bb5fc562ffc893ce2abeac3e25daead144",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/deps.bzl
+++ b/deps.bzl
@@ -79,6 +79,14 @@ def gazelle_dependencies(
 
     _maybe(
         go_repository,
+        name = "org_golang_x_sys",
+        importpath = "golang.org/x/sys",
+        sum = "h1:Lk4tbZFnlyPgV+sLgTw5yGfzrlOn9kx4vSombi2FFlY=",
+        version = "v0.0.0-20190122071731-054c452bb702",
+    )
+
+    _maybe(
+        go_repository,
         name = "com_github_bazelbuild_buildtools",
         importpath = "github.com/bazelbuild/buildtools",
         sum = "h1:KLCFP96KTydy03EMRwdGnngaD76gt34BBWK4g7TChgk=",


### PR DESCRIPTION
Also add explicit dependency on org_golang_x_sys, since
go_rules_dependencies no longer provides it.