### PR TITLE
update-repos: add or update repositories in module mode

### DIFF
--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -43,7 +43,6 @@ def _go_repository_tools_impl(ctx):
         "src/github.com/bazelbuild/bazel-gazelle",
     )
 
-    # Build the tools.
     env.update({
         "GOPATH": str(ctx.path(".")),
         "GO111MODULE": "off",
@@ -75,6 +74,7 @@ def _go_repository_tools_impl(ctx):
     if result.return_code:
         fail("list_repository_tools_srcs: " + result.stderr)
 
+    # Build the tools.
     args = [
         go_tool,
         "install",

--- a/repo/remote_test.go
+++ b/repo/remote_test.go
@@ -219,3 +219,48 @@ func TestMod(t *testing.T) {
 		})
 	}
 }
+
+func TestModVersion(t *testing.T) {
+	for _, tc := range []struct {
+		desc, modPath, query           string
+		repos                          []Repo
+		wantName, wantVersion, wantSum string
+	}{
+		{
+			desc:    "known",
+			modPath: "example.com/known",
+			query:   "latest",
+			repos: []Repo{{
+				Name:     "known",
+				GoPrefix: "example.com/known",
+			}},
+			wantName:    "known",
+			wantVersion: "v1.2.3",
+			wantSum:     "h1:abcdef",
+		}, {
+			desc:        "unknown",
+			modPath:     "example.com/unknown",
+			query:       "latest",
+			wantName:    "com_example_unknown",
+			wantVersion: "v1.2.3",
+			wantSum:     "h1:abcdef",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			rc := NewStubRemoteCache(tc.repos)
+			name, version, sum, err := rc.ModVersion(tc.modPath, tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q; want %q", name, tc.wantName)
+			}
+			if version != tc.wantVersion {
+				t.Errorf("version: got %q; want %q", version, tc.wantVersion)
+			}
+			if sum != tc.wantSum {
+				t.Errorf("sum: got %q; want %q", sum, tc.wantSum)
+			}
+		})
+	}
+}

--- a/repo/stubs_test.go
+++ b/repo/stubs_test.go
@@ -129,6 +129,7 @@ func NewStubRemoteCache(rs []Repo) *RemoteCache {
 	rc.RepoRootForImportPath = stubRepoRootForImportPath
 	rc.HeadCmd = stubHeadCmd
 	rc.ModInfo = stubModInfo
+	rc.ModVersionInfo = stubModVersionInfo
 	return rc
 }
 
@@ -176,4 +177,11 @@ func stubModInfo(importPath string) (string, error) {
 		return "example.com/stub", nil
 	}
 	return "", fmt.Errorf("could not find module path for %s", importPath)
+}
+
+func stubModVersionInfo(modPath, query string) (version, sum string, err error) {
+	if modPath == "example.com/known" || modPath == "example.com/unknown" {
+		return "v1.2.3", "h1:abcdef", nil
+	}
+	return "", "", fmt.Errorf("no such module: %s", modPath)
 }


### PR DESCRIPTION
'gazelle update-repos <modpath>' will now add or update go_repository
rules in module mode. If a rule is not already in module mode, it will
be changed to module mode.

Fixes #505