### PR TITLE
Create Bazel CI configuration file

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,42 @@
+---
+platforms:
+  ubuntu1804:
+    build_flags:
+    - "--build_tag_filters=-nolinux"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--features=race"
+    - "--test_tag_filters=-nolinux"
+    test_targets:
+    - "..."
+  ubuntu1604:
+    build_flags:
+    - "--build_tag_filters=-nolinux"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--features=race"
+    - "--test_tag_filters=-nolinux"
+    test_targets:
+    - "..."
+  macos:
+    build_flags:
+    - "--build_tag_filters=-nomacos"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--features=race"
+    - "--test_tag_filters=-nomacos"
+    test_targets:
+    - "..."
+  windows:
+    build_flags:
+    - "--build_tag_filters=-nowindows"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_tag_filters=-nowindows"
+    - "--experimental_enable_runfiles"
+    test_targets:
+    - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,42 +1,22 @@
 ---
 platforms:
   ubuntu1804:
-    build_flags:
-    - "--build_tag_filters=-nolinux"
     build_targets:
     - "..."
-    test_flags:
-    - "--features=race"
-    - "--test_tag_filters=-nolinux"
     test_targets:
     - "..."
   ubuntu1604:
-    build_flags:
-    - "--build_tag_filters=-nolinux"
     build_targets:
     - "..."
-    test_flags:
-    - "--features=race"
-    - "--test_tag_filters=-nolinux"
     test_targets:
     - "..."
   macos:
-    build_flags:
-    - "--build_tag_filters=-nomacos"
     build_targets:
     - "..."
-    test_flags:
-    - "--features=race"
-    - "--test_tag_filters=-nomacos"
     test_targets:
     - "..."
   windows:
-    build_flags:
-    - "--build_tag_filters=-nowindows"
     build_targets:
     - "..."
-    test_flags:
-    - "--test_tag_filters=-nowindows"
-    - "--experimental_enable_runfiles"
     test_targets:
     - "..."


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/issues/759

This will allow you to use the Bazel CI instead of (or in addition to) TravisCI