### PR TITLE
Suppress stderr from fetchrepo if successful

### DIFF
--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -62,13 +62,15 @@ func fetchModule(dest, importpath, version, sum string) error {
 	}
 
 	buf := &bytes.Buffer{}
+	bufErr := &bytes.Buffer{}
 	cmd := exec.Command(goPath, "mod", "download", "-json", importpath+"@"+version)
 	cmd.Stdout = buf
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = bufErr
 	dlErr := cmd.Run()
 	os.Remove("go.mod")
 	if dlErr != nil {
 		if _, ok := dlErr.(*exec.ExitError); !ok {
+			_, _ = os.Stderr.Write(bufErr.Bytes())
 			return dlErr
 		}
 	}


### PR DESCRIPTION
Without this change, most repos while fetching will print messages like
this on stderr:
  .../go_repository.bzl:127:13: fetch_repo: go: finding google.golang.org/api v0.1.0