### PR TITLE
repo: add version/commit select for update-repos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -389,11 +389,11 @@ The following flags are accepted:
 ``update-repos``
 ~~~~~~~~~~~~~~~~
 
-The ``update-repos`` command updates repository rules.
-It can write the rules to either the WORKSPACE (by default) or a .bzl file macro function.
-It can be used to add new repository rules or update existing rules to specified
-version. It can also import repository rules from a ``go.mod`` file or
-a ``Gopkg.lock`` file.
+The ``update-repos`` command updates repository rules.  It can write the rules
+to either the WORKSPACE (by default) or a .bzl file macro function.  It can be
+used to add new repository rules or update existing rules to the specified
+version. It can also import repository rules from a ``go.mod`` file or a
+``Gopkg.lock`` file.
 
 .. code:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -391,14 +391,17 @@ The following flags are accepted:
 
 The ``update-repos`` command updates repository rules.
 It can write the rules to either the WORKSPACE (by default) or a .bzl file macro function.
-It can be used to add new repository rules or update existing rules to the
-latest version. It can also import repository rules from a ``go.mod`` file or
+It can be used to add new repository rules or update existing rules to specified
+version. It can also import repository rules from a ``go.mod`` file or
 a ``Gopkg.lock`` file.
 
 .. code:: bash
 
-  # Add or update a repository by import path
+  # Add or update a repository to latest version by import path
   $ gazelle update-repos example.com/new/repo
+
+  # Add or update a repository to specified version/commit by import path
+  $ gazelle update-repos example.com/new/repo@v1.3.1
 
   # Import repositories from go.mod
   $ gazelle update-repos -from_file=go.mod

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -73,8 +73,8 @@ go_test(
         "//testtools:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
-    data = ["@go_sdk//:files"],
-    args = ["-goroot", "$(location @go_sdk//:ROOT)"],
+    data = ["@go_sdk//:files", "@go_sdk//:ROOT"],
+    args = ["-goroot=$(location @go_sdk//:ROOT)"],
 )
 
 filegroup(

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -65,6 +65,11 @@ go_test(
         "langs.go",  # keep
         "update_repos_test.go",
     ],
+    args = ["-goroot=$(location @go_sdk//:ROOT)"],
+    data = [
+        "@go_sdk//:ROOT",
+        "@go_sdk//:files",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//config:go_default_library",
@@ -73,8 +78,6 @@ go_test(
         "//testtools:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
-    data = ["@go_sdk//:files", "@go_sdk//:ROOT"],
-    args = ["-goroot=$(location @go_sdk//:ROOT)"],
 )
 
 filegroup(

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -73,6 +73,8 @@ go_test(
         "//testtools:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
+    data = ["@go_sdk//:files"],
+    args = ["-goroot", "$(location @go_sdk//:ROOT)"],
 )
 
 filegroup(

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -65,11 +65,8 @@ go_test(
         "langs.go",  # keep
         "update_repos_test.go",
     ],
-    args = ["-goroot=$(location @go_sdk//:ROOT)"],
-    data = [
-        "@go_sdk//:ROOT",
-        "@go_sdk//:files",
-    ],
+    args = ["-go_sdk=go_sdk"],
+    data = ["@go_sdk//:files"],
     embed = [":go_default_library"],
     deps = [
         "//config:go_default_library",
@@ -77,6 +74,7 @@ go_test(
         "//rule:go_default_library",
         "//testtools:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
 

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -48,9 +47,15 @@ func TestMain(m *testing.M) {
 	flag.Set("repo_root", tmpdir)
 	flag.Parse()
 
-	fmt.Println("goroot: ", goroot)
 	if goroot != "" {
-		os.Setenv("GOROOT", filepath.Dir(goroot))
+		gorootDir := filepath.Dir(goroot)
+		dir, err := filepath.Abs(gorootDir)
+		if err != nil {
+			panic(err)
+		}
+		dir = strings.TrimRight(dir, gorootDir)
+		dir = filepath.Join(filepath.Dir(filepath.Dir(dir)), gorootDir)
+		os.Setenv("GOROOT", dir)
 	}
 	os.Exit(m.Run())
 }

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,9 +27,31 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/testtools"
 )
 
+var goroot string
+
+func init() {
+	flag.StringVar(&goroot, "goroot", "", "define GOROOT")
+}
+
 func TestMain(m *testing.M) {
 	tmpdir := os.Getenv("TEST_TMPDIR")
+
+	f, err := ioutil.TempDir("", "gazelle_test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(f)
+
+	os.Setenv("GOCACHE", f)
+	os.Setenv("GOPATH", f)
+
 	flag.Set("repo_root", tmpdir)
+	flag.Parse()
+
+	fmt.Println("goroot: ", goroot)
+	if goroot != "" {
+		os.Setenv("GOROOT", filepath.Dir(goroot))
+	}
 	os.Exit(m.Run())
 }
 

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1205,8 +1205,6 @@ gazelle_dependencies()
 	dir, cleanup := testtools.CreateFiles(t, files)
 	defer cleanup()
 
-	os.Setenv("GOCACHE", os.TempDir())
-	os.Setenv("GOPATH", os.TempDir())
 	args := []string{"update-repos", "github.com/sirupsen/logrus@v1.3.0"}
 	if err := runGazelle(dir, args); err != nil {
 		t.Fatal(err)

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -41,7 +41,12 @@ import (
 // information may already be locally available. Frequently though, information
 // will be fetched over the network, so this function may be slow.
 func UpdateRepo(rc *RemoteCache, modPath string) (Repo, error) {
-	name, version, sum, err := rc.ModVersion(modPath, "latest")
+	query := "latest"
+	if i := strings.IndexByte(modPath, '@'); i >= 0 {
+		query = modPath[i+1:]
+		modPath = modPath[:i]
+	}
+	name, version, sum, err := rc.ModVersion(modPath, query)
 	if err != nil {
 		return Repo{}, err
 	}


### PR DESCRIPTION
make `bazel run //:gazelle update-repos` can support version select as follow:

```
bazel run //:gazelle update-repos github.com/sirupsen/logrus@v1.4.0
bazel run //:gazelle update-repos github.com/sirupsen/logrus@dae0fa8
```