### PR TITLE
Add proto_strip_import_prefix to flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,10 +371,15 @@ The following flags are accepted:
 | Determines the proto option Gazelle uses to group .proto files into rules                             |
 | when in ``package`` mode. See details in `Directives`_ below.                                         |
 +--------------------------------------------------------------+----------------------------------------+
-| :flag:`-proto_import_prefix repo`                            |                                        |
+| :flag:`-proto_import_prefix prefx`                           |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | Sets the `import_prefix`_ attribute of generated ``proto_library`` rules. This is a prefix            |
 | to add to import paths of .proto files.                                                               |
++--------------------------------------------------------------+----------------------------------------+
+| :flag:`-proto_strip_import_prefix prefix`                    |                                        |
++--------------------------------------------------------------+----------------------------------------+
+| Sets the `strip_import_prefix`_ attribute of generated ``proto_library`` rules. This is a prefix      |
+| to strip from import paths of .proto files. The prefix should always start with "/".                  |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-repo_root dir`                                       |                                        |
 +--------------------------------------------------------------+----------------------------------------+

--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -186,6 +186,7 @@ func (_ *protoLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config
 	fs.Var(&modeFlag{&pc.Mode}, "proto", "default: generates a proto_library rule for one package\n\tpackage: generates a proto_library rule for for each package\n\tdisable: does not touch proto rules\n\tdisable_global: does not touch proto rules and does not use special cases for protos in dependency resolution")
 	fs.StringVar(&pc.groupOption, "proto_group", "", "option name used to group .proto files into proto_library rules")
 	fs.StringVar(&pc.importPrefix, "proto_import_prefix", "", "When set, .proto source files in the srcs attribute of the rule are accessible at their path with this prefix appended on.")
+	fs.StringVar(&pc.stripImportPrefix, "proto_strip_import_prefix", "", "When set, .proto source files in the srcs attribute of the rule are accessible at their path with this prefix stripped.")
 }
 
 func (_ *protoLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {


### PR DESCRIPTION
`proto_strip_import_prefix` is a Gazelle directive but not a flag. This PR adds it to the flags so it can be passed down from `go_repository` rule to generate proto rules properly in third-party libraries.