### PR TITLE
go_repository takes Gazelle directives

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -88,7 +88,7 @@ def _go_repository_impl(ctx):
     generate = ctx.attr.build_file_generation == "on"
     if ctx.attr.build_file_generation == "auto":
         generate = True
-        for name in set(["BUILD", "BUILD.bazel"] + ctx.attr.build_file_name.split(",")):
+        for name in depset(["BUILD", "BUILD.bazel"] + ctx.attr.build_file_name.split(",")).to_list():
             path = ctx.path(name)
             if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
                 generate = False

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -92,10 +92,7 @@ def _go_repository_impl(ctx):
             existing_build_file = name
             break
 
-    if ctx.attr.build_file_generation == "on" or (not existing_build_file and ctx.attr.build_file_generation == "auto"):
-        generate = True
-    else:
-        generate = False
+    generate = (ctx.attr.build_file_generation == "on" or (not existing_build_file and ctx.attr.build_file_generation == "auto"))
 
     if fetch_repo_args or generate:
         env = read_cache_env(ctx, str(ctx.path(Label("@bazel_gazelle_go_repository_cache//:go.env"))))

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -152,10 +152,10 @@ def _go_repository_impl(ctx):
             build_file_name = existing_build_file
         else:
             build_file_name = "BUILD.bazel"
-        if len(ctx.attr.directives) > 0:
+        if len(ctx.attr.build_directives) > 0:
             ctx.file(
                 build_file_name,
-                "\n".join(["# " + d for d in ctx.attr.directives]),
+                "\n".join(["# " + d for d in ctx.attr.build_directives]),
             )
 
         # Run Gazelle
@@ -259,7 +259,7 @@ go_repository = repository_rule(
         ),
         "build_extra_args": attr.string_list(),
         "build_config": attr.label(default = "@//:WORKSPACE"),
-        "directives": attr.string_list(default = []),
+        "build_directives": attr.string_list(default = []),
 
         # Patches to apply after running gazelle.
         "patches": attr.label_list(),

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -44,6 +44,20 @@ go_repository(
     version = "v0.8.1",
     sum ="h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
 )
+
+go_repository(
+    name = "com_github_apache_mesos",
+    build_file_proto_mode = "package",
+    directives = [
+        "gazelle:proto_strip_import_prefix /include/",
+        "gazelle:exclude include/mesos/attributes.hpp",
+        "gazelle:exclude include/mesos/executor.hpp",
+        "gazelle:exclude include/mesos/hook.hpp",
+    ],
+    importpath = "github.com/apache/mesos",
+    sum = "h1:65atl5ZUZ7fzMM/oIVFV5VdO0plKO0hye9taZR6ssHw=",
+    version = "v0.0.0-20190710134757-4ae064484664",
+)
 `,
 }
 

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -47,11 +47,11 @@ go_repository(
 )
 
 go_repository(
-	name = "com_github_apex_log",
-	directives = ["gazelle:exclude handlers"],
-	importpath = "github.com/apex/log",
-	sum = "h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=",
-	version = "v1.1.0",
+		name = "com_github_apex_log",
+		build_directives = ["gazelle:exclude handlers"],
+		importpath = "github.com/apex/log",
+		sum = "h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=",
+		version = "v1.1.0",
 )
 `,
 }
@@ -66,7 +66,7 @@ func TestBuild(t *testing.T) {
 	}
 }
 
-func TestDirectives(t *testing.T)  {
+func TestDirectives(t *testing.T) {
 	err := bazel_testing.RunBazel("query", "@com_github_apex_log//handlers/...")
 	if err == nil {
 		t.Fatal("Should not generate build files for @com_github_apex_log//handlers/...")

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package go_repository_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
@@ -46,17 +47,11 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_apache_mesos",
-    build_file_proto_mode = "package",
-    directives = [
-        "gazelle:proto_strip_import_prefix /include/",
-        "gazelle:exclude include/mesos/attributes.hpp",
-        "gazelle:exclude include/mesos/executor.hpp",
-        "gazelle:exclude include/mesos/hook.hpp",
-    ],
-    importpath = "github.com/apache/mesos",
-    sum = "h1:65atl5ZUZ7fzMM/oIVFV5VdO0plKO0hye9taZR6ssHw=",
-    version = "v0.0.0-20190710134757-4ae064484664",
+	name = "com_github_apex_log",
+	directives = ["gazelle:exclude handlers"],
+	importpath = "github.com/apex/log",
+	sum = "h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=",
+	version = "v1.1.0",
 )
 `,
 }
@@ -68,5 +63,15 @@ func TestMain(m *testing.M) {
 func TestBuild(t *testing.T) {
 	if err := bazel_testing.RunBazel("build", "@errors_go_git//:errors", "@errors_go_mod//:go_default_library"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDirectives(t *testing.T)  {
+	err := bazel_testing.RunBazel("query", "@com_github_apex_log//handlers/...")
+	if err == nil {
+		t.Fatal("Should not generate build files for @com_github_apex_log//handlers/...")
+	}
+	if !strings.Contains(err.Error(), "no targets found beneath 'handlers'") {
+		t.Fatal("Unexpected error:\n", err)
 	}
 }

--- a/repository.rst
+++ b/repository.rst
@@ -264,11 +264,12 @@ returned by ``go env GOPATH``.
 | A list of additional command line arguments to pass to Gazelle when                                     |
 | generating build files.                                                                                 |
 +--------------------------------+----------------------+-------------------------------------------------+
-| :param:`gazelle_directives`    | :type:`string list`  | :value:`[]`                                     |
+| :param:`directives`            | :type:`string list`  | :value:`[]`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+
-| A list of Gazelle directives to be written to the root level build file before                          |
+| A list of directives to be written to the root level build file before                                  |
 | Calling Gazelle to generate build files. Each string in the list will be                                |
-| prefixed with `# gazelle:` automatically.                                                               |
+| prefixed with `#` automatically. A common use case is to pass a list of                                 |
+| Gazelle directives.                                                                                     |
 +--------------------------------+----------------------+-------------------------------------------------+
 | :param:`patches`               | :type:`label list`   | :value:`[]`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+

--- a/repository.rst
+++ b/repository.rst
@@ -264,6 +264,12 @@ returned by ``go env GOPATH``.
 | A list of additional command line arguments to pass to Gazelle when                                     |
 | generating build files.                                                                                 |
 +--------------------------------+----------------------+-------------------------------------------------+
+| :param:`gazelle_directives`    | :type:`string list`  | :value:`[]`                                     |
++--------------------------------+----------------------+-------------------------------------------------+
+| A list of Gazelle directives to be written to the root level build file before                          |
+| Calling Gazelle to generate build files. Each string in the list will be                                |
+| prefixed with `# gazelle:` automatically.                                                               |
++--------------------------------+----------------------+-------------------------------------------------+
 | :param:`patches`               | :type:`label list`   | :value:`[]`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+
 | A list of patches to apply to the repository after gazelle runs.                                        |

--- a/repository.rst
+++ b/repository.rst
@@ -264,7 +264,7 @@ returned by ``go env GOPATH``.
 | A list of additional command line arguments to pass to Gazelle when                                     |
 | generating build files.                                                                                 |
 +--------------------------------+----------------------+-------------------------------------------------+
-| :param:`directives`            | :type:`string list`  | :value:`[]`                                     |
+| :param:`build_directives`      | :type:`string list`  | :value:`[]`                                     |
 +--------------------------------+----------------------+-------------------------------------------------+
 | A list of directives to be written to the root level build file before                                  |
 | Calling Gazelle to generate build files. Each string in the list will be                                |


### PR DESCRIPTION
As discussed in #598, this PR make `go_repository` take a list of Gazelle directives to be written to the root level build file.

This PR supercedes #597 and #598 