### PR TITLE
Add ios platform and OS aliases

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -149,6 +149,28 @@ import (
 `,
 		},
 		{
+			Path: "foo_android_build_tag.go",
+			Content: `
+// +build android
+
+package foo
+
+import (
+    _ "example.com/foo/outer_android_build_tag"
+)
+`,
+		},
+		{
+			Path: "foo_android.go",
+			Content: `
+package foo
+
+import (
+    _ "example.com/foo/outer_android_suffix"
+)
+`,
+		},
+		{
 			Path: "bar.go",
 			Content: `// +build linux
 
@@ -156,6 +178,8 @@ package foo
 `,
 		},
 		{Path: "outer/outer.go", Content: "package outer"},
+		{Path: "outer_android_build_tag/outer.go", Content: "package outer_android_build_tag"},
+		{Path: "outer_android_suffix/outer.go", Content: "package outer_android_suffix"},
 		{Path: "outer/inner/inner.go", Content: "package inner"},
 	})
 	want := `load("@io_bazel_rules_go//go:def.bzl", "go_library")
@@ -167,10 +191,19 @@ go_library(
         "bar.go",
         # foo comment
         "foo.go",  # side comment
+        "foo_android.go",
+        "foo_android_build_tag.go",
     ],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
     deps = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//outer:go_default_library",
+            "//outer/inner:go_default_library",
+            "//outer_android_build_tag:go_default_library",
+            "//outer_android_suffix:go_default_library",
+            "@com_github_jr_hacker_tools//:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//outer:go_default_library",
             "//outer/inner:go_default_library",

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -128,7 +128,7 @@ func (g tagGroup) check(c *config.Config, os, arch string) bool {
 			if os == "" {
 				return false
 			}
-			match = os == t
+			match = matchesOS(os, t)
 		} else if _, ok := rule.KnownArchSet[t]; ok {
 			if arch == "" {
 				return false
@@ -594,6 +594,20 @@ func isOSArchSpecific(info fileInfo, cgoTags tagLine) (osSpecific, archSpecific 
 	return osSpecific, archSpecific
 }
 
+// matchesOS checks if a value is equal to either an OS value or to any of its
+// aliases.
+func matchesOS(os, value string) bool {
+	if os == value {
+		return true
+	}
+	for _, alias := range rule.OSAliases[os] {
+		if alias == value {
+			return true
+		}
+	}
+	return false
+}
+
 // checkConstraints determines whether build constraints are satisfied on
 // a given platform.
 //
@@ -608,7 +622,7 @@ func isOSArchSpecific(info fileInfo, cgoTags tagLine) (osSpecific, archSpecific 
 // is a list tags from +build comments found near the top of the file. cgoTags
 // is an extra set of tags in a #cgo directive.
 func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, fileTags []tagLine, cgoTags tagLine) bool {
-	if osSuffix != "" && osSuffix != os || archSuffix != "" && archSuffix != arch {
+	if osSuffix != "" && !matchesOS(os, osSuffix) || archSuffix != "" && archSuffix != arch {
 		return false
 	}
 	for _, l := range fileTags {

--- a/language/go/testdata/cgolib_with_build_tags/BUILD.want
+++ b/language/go/testdata/cgolib_with_build_tags/BUILD.want
@@ -28,6 +28,9 @@ go_library(
         "@io_bazel_rules_go//go/platform:freebsd": [
             "example.com/repo/lib/deep",
         ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "example.com/repo/lib/deep",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "example.com/repo/lib/deep",
         ],
@@ -56,7 +59,13 @@ go_library(
     copts = [
         "-I/weird/path",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "-DGOOS=linux",
+        ],
         "@io_bazel_rules_go//go/platform:darwin": [
+            "-DGOOS=darwin",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
             "-DGOOS=darwin",
         ],
         "@io_bazel_rules_go//go/platform:linux": [

--- a/language/go/testdata/gen_and_exclude/BUILD.want
+++ b/language/go/testdata/gen_and_exclude/BUILD.want
@@ -12,6 +12,9 @@ go_library(
         "@io_bazel_rules_go//go/platform:darwin": [
             "github.com/jr_hacker/darwin",
         ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "github.com/jr_hacker/darwin",
+        ],
         "//conditions:default": [],
     }),
     importpath = "example.com/repo/gen_and_exclude",

--- a/language/go/testdata/platforms/BUILD.want
+++ b/language/go/testdata/platforms/BUILD.want
@@ -21,7 +21,13 @@ go_library(
     _gazelle_imports = [
         "example.com/repo/platforms/generic",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "example.com/repo/platforms/linux",
+        ],
         "@io_bazel_rules_go//go/platform:darwin": [
+            "example.com/repo/platforms/darwin",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
             "example.com/repo/platforms/darwin",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
@@ -33,6 +39,9 @@ go_library(
     copts = [
         "-DGENERIC",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "-DLINUX",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "-DLINUX",
         ],

--- a/rule/platform.go
+++ b/rule/platform.go
@@ -56,6 +56,10 @@ var KnownPlatforms = []Platform{
 	{"freebsd", "386"},
 	{"freebsd", "amd64"},
 	{"freebsd", "arm"},
+	{"ios", "386"},
+	{"ios", "amd64"},
+	{"ios", "arm"},
+	{"ios", "arm64"},
 	{"linux", "386"},
 	{"linux", "amd64"},
 	{"linux", "arm"},
@@ -82,6 +86,11 @@ var KnownPlatforms = []Platform{
 	{"solaris", "amd64"},
 	{"windows", "386"},
 	{"windows", "amd64"},
+}
+
+var OSAliases = map[string][]string{
+	"android": []string{"linux"},
+	"ios": []string{"darwin"},
 }
 
 var (


### PR DESCRIPTION
Anything that matches `darwin` should match `ios`, but not the other way
around. Same for `android` & `linux`.

Introduce aliases and extend the matching to them.

I haven't tested it in situ but the build files look good. Also, not sure about the `android -> linux` alias.