### PR TITLE
gazelle_binary: set package name to 'main' in GoLibrary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "313f2c7a23fecc33023563f082f381a32b9b7254f727a7dd2d6380ccc6dfe09b",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.0/rules_go-0.19.0.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz",
     ],
-    sha256 = "9fb16af4d4836c8222142e54c9efa0bb5fc562ffc893ce2abeac3e25daead144",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -56,7 +56,7 @@ var languages = []language.Language{{
     go.actions.write(langs_file, langs_content)
 
     # Build the gazelle binary.
-    library = go.new_library(go)
+    library = go.new_library(go, is_main = True)
     attr = struct(
         srcs = [struct(files = [langs_file])],
         deps = ctx.attr.languages,


### PR DESCRIPTION
Necessary to make the go1.13 linker happy.

Corresponding change in go_binary: bazelbuild/rules_go#2135

Also: upgrade to rules_go 0.19.3