### PR TITLE
autogazelle: use default syntax for expanding $1

### DIFF
--- a/cmd/autogazelle/autogazelle.bash
+++ b/cmd/autogazelle/autogazelle.bash
@@ -23,7 +23,7 @@
 
 set -euo pipefail
 
-case "$1" in
+case "${1:-}" in
   build|coverage|cquery|fetch|mobile-install|print_action|query|run|test)
     "$BAZEL_REAL" run @bazel_gazelle//cmd/autogazelle -- -gazelle=//:gazelle
     echo "done running autogazelle" 1>&2


### PR DESCRIPTION
When calling `bazel` without parameters, the script was giving an error `$1: unbound variable`.
This fixes it by using an explicit default value of an empty string.