### PR TITLE
rule: add BzlExprValue interface and make PlatformStrings use it

### DIFF
--- a/cmd/generate_repo_config/generate_repo_config.go
+++ b/cmd/generate_repo_config/generate_repo_config.go
@@ -78,7 +78,14 @@ func generateRepoConfig(configDest, configSource string) error {
 	}
 	sort.Stable(byName(repos))
 
+	sortedRepoFiles := make([]*rule.File, 0, len(reposByFile))
 	for r := range reposByFile {
+		sortedRepoFiles = append(sortedRepoFiles, r)
+	}
+	sort.SliceStable(sortedRepoFiles, func(i, j int) bool {
+		return sortedRepoFiles[i].Path < sortedRepoFiles[j].Path
+	})
+	for _, r := range sortedRepoFiles {
 		for _, d := range r.Directives {
 			// skip repository_macro directives, because for the repo config we flatten
 			// macros into one file

--- a/rule/platform.go
+++ b/rule/platform.go
@@ -21,6 +21,9 @@ import (
 
 // Platform represents a GOOS/GOARCH pair. When Platform is used to describe
 // sources, dependencies, or flags, either OS or Arch may be empty.
+//
+// DEPRECATED: do not use outside language/go. This type is Go-specific
+// and should be moved to the Go extension.
 type Platform struct {
 	OS, Arch string
 }
@@ -43,6 +46,8 @@ func (p Platform) String() string {
 // KnownPlatforms is the set of target platforms that Go supports. Gazelle
 // will generate multi-platform build files using these tags. rules_go and
 // Bazel may not actually support all of these.
+//
+// DEPRECATED: do not use outside language/go.
 var KnownPlatforms = []Platform{
 	{"android", "386"},
 	{"android", "amd64"},
@@ -90,7 +95,7 @@ var KnownPlatforms = []Platform{
 
 var OSAliases = map[string][]string{
 	"android": []string{"linux"},
-	"ios": []string{"darwin"},
+	"ios":     []string{"darwin"},
 }
 
 var (


### PR DESCRIPTION
This allows types to define custom translation to Starlark
syntax. PlatformStrings implements this interface and uses it to emit
a select expression with Go-specific conditions.

SelectStringListValue is a new type that satisfies BzlExprValue and
translates map[string][]string to a generic select expression.

ExprFromValue now translates maps with string keys (not satisfying
BzlExprValue) as dictionaries.

rule.PlatformStrings and Platform are now deprecated and will be moved
to language/go eventually.

Also: deflake //cmd/generate_repo_config:generate_repo_config_test.
Map iteration order could break it.

Fixes #511