### PR TITLE
Making resolveGo public

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -106,6 +106,12 @@ var (
 	notFoundError   = errors.New("rule not found")
 )
 
+// ResolveGo resolves a Go import path to a Bazel label, possibly using the
+// given rule index and remote cache. Some special cases may be applied to
+// known proto import paths, depending on the current proto mode.
+//
+// This may be used directly by other language extensions related to Go
+// (gomock). Gazelle calls Language.Resolve instead.
 func ResolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, imp string, from label.Label) (label.Label, error) {
 	gc := getGoConfig(c)
 	pcMode := getProtoMode(c)

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -67,12 +67,12 @@ func (gl *goLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remo
 	}
 	imports := importsRaw.(rule.PlatformStrings)
 	r.DelAttr("deps")
-	resolve := resolveGo
+	resolve := ResolveGo
 	if r.Kind() == "go_proto_library" {
 		resolve = resolveProto
 	}
 	deps, errs := imports.Map(func(imp string) (string, error) {
-		l, err := resolve(c, ix, rc, r, imp, from)
+		l, err := resolve(c, ix, rc, imp, from)
 		if err == skipImportError {
 			return "", nil
 		} else if err != nil {
@@ -106,7 +106,7 @@ var (
 	notFoundError   = errors.New("rule not found")
 )
 
-func resolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
+func ResolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, imp string, from label.Label) (label.Label, error) {
 	gc := getGoConfig(c)
 	pcMode := getProtoMode(c)
 	if build.IsLocalImport(imp) {
@@ -286,7 +286,7 @@ func resolveVendored(rc *repo.RemoteCache, imp string) (label.Label, error) {
 	return label.New("", path.Join("vendor", imp), defaultLibName), nil
 }
 
-func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imp string, from label.Label) (label.Label, error) {
+func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, imp string, from label.Label) (label.Label, error) {
 	pcMode := getProtoMode(c)
 
 	if wellKnownProtos[imp] {


### PR DESCRIPTION
Other Gazelle extensions may need to resolve Go packages into Bazel labels too. For example, if an extension wants to generate `gomock` rule, the `library` parameter needs to be resolved.

This PR make `golang.resolveGo` public so it can be reused by other extensions.