### PR TITLE
Excluding consumed generated files from go_library

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -236,6 +236,9 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			for _, f := range r.AttrStrings("srcs") {
 				consumedFileSet[f] = true
 			}
+			if f := r.AttrString("src"); f != "" {
+				consumedFileSet[f] = true
+			}
 		}
 		for _, f := range genFiles {
 			if regularFileSet[f] || consumedFileSet[f] {

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -230,8 +230,15 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		for _, f := range regularFiles {
 			regularFileSet[f] = true
 		}
+		// Some of the generated files may have been consumed by other rules
+		consumedFileSet := make(map[string]bool)
+		for _, r := range args.OtherGen {
+			for _, f := range r.AttrStrings("srcs") {
+				consumedFileSet[f] = true
+			}
+		}
 		for _, f := range genFiles {
-			if regularFileSet[f] {
+			if regularFileSet[f] || consumedFileSet[f] {
 				continue
 			}
 			info := fileNameInfo(filepath.Join(args.Dir, f))

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -231,12 +231,14 @@ func TestGenerateRulesPrebuiltGoProtoRules(t *testing.T) {
 	}
 }
 
-func TestConsumedGenFiles(t *testing.T)  {
+// Test generated files that have been consumed by other rules should not be
+// added to the go_default_library rule
+func TestConsumedGenFiles(t *testing.T) {
 	args := language.GenerateArgs{
-		RegularFiles:[]string{"regular.go"},
-		GenFiles:[]string{"mocks.go"},
-		Config:&config.Config{
-			Exts:make(map[string]interface{}),
+		RegularFiles: []string{"regular.go"},
+		GenFiles:     []string{"mocks.go"},
+		Config: &config.Config{
+			Exts: make(map[string]interface{}),
 		},
 	}
 	otherRule := rule.NewRule("go_library", "go_mock_library")

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -231,6 +231,30 @@ func TestGenerateRulesPrebuiltGoProtoRules(t *testing.T) {
 	}
 }
 
+func TestConsumedGenFiles(t *testing.T)  {
+	args := language.GenerateArgs{
+		RegularFiles:[]string{"regular.go"},
+		GenFiles:[]string{"mocks.go"},
+		Config:&config.Config{
+			Exts:make(map[string]interface{}),
+		},
+	}
+	otherRule := rule.NewRule("go_library", "go_mock_library")
+	otherRule.SetAttr("srcs", []string{"mocks.go"})
+	args.OtherGen = append(args.OtherGen, otherRule)
+
+	gl := goLang{
+		goPkgRels: make(map[string]bool),
+	}
+	gl.Configure(args.Config, "", nil)
+	res := gl.GenerateRules(args)
+	got := res.Gen[0].AttrStrings("srcs")
+	want := []string{"regular.go"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func prebuiltProtoRules() []*rule.Rule {
 	protoRule := rule.NewRule("proto_library", "foo_proto")
 	protoRule.SetAttr("srcs", []string{"foo.proto"})


### PR DESCRIPTION
Some generated files may have been consumed by other rules, either handwritten or generated by other extensions. The `go` extension should not add them into the `go_default_library` rule in such case.