### PR TITLE
language/go: simpler submodule visibility

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -16,6 +16,7 @@ limitations under the License.
 package golang
 
 import (
+	"fmt"
 	"go/build"
 	"log"
 	"path"
@@ -406,7 +407,7 @@ func (g *generator) generateProto(mode proto.Mode, target protoTarget, importPat
 		protoName = proto.RuleName(importPath)
 	}
 	goProtoName := strings.TrimSuffix(protoName, "_proto") + "_go_proto"
-	visibility := []string{rule.CheckInternalVisibility(g.rel, "//visibility:public")}
+	visibility := g.commonVisibility(importPath)
 
 	if mode == proto.LegacyMode {
 		filegroup := rule.NewRule("filegroup", filegroupName)
@@ -447,12 +448,12 @@ func (g *generator) generateLib(pkg *goPackage, embed string) *rule.Rule {
 	if !pkg.library.sources.hasGo() && embed == "" {
 		return goLibrary // empty
 	}
-	var visibility string
+	var visibility []string
 	if pkg.isCommand() {
 		// Libraries made for a go_binary should not be exposed to the public.
-		visibility = "//visibility:private"
+		visibility = []string{"//visibility:private"}
 	} else {
-		visibility = rule.CheckInternalVisibility(pkg.rel, "//visibility:public")
+		visibility = g.commonVisibility(pkg.importPath)
 	}
 	g.setCommonAttrs(goLibrary, pkg.rel, visibility, pkg.library, embed)
 	g.setImportAttrs(goLibrary, pkg.importPath)
@@ -465,7 +466,7 @@ func (g *generator) generateBin(pkg *goPackage, library string) *rule.Rule {
 	if !pkg.isCommand() || pkg.binary.sources.isEmpty() && library == "" {
 		return goBinary // empty
 	}
-	visibility := rule.CheckInternalVisibility(pkg.rel, "//visibility:public")
+	visibility := g.commonVisibility(pkg.importPath)
 	g.setCommonAttrs(goBinary, pkg.rel, visibility, pkg.binary, library)
 	return goBinary
 }
@@ -475,14 +476,14 @@ func (g *generator) generateTest(pkg *goPackage, library string) *rule.Rule {
 	if !pkg.test.sources.hasGo() {
 		return goTest // empty
 	}
-	g.setCommonAttrs(goTest, pkg.rel, "", pkg.test, library)
+	g.setCommonAttrs(goTest, pkg.rel, nil, pkg.test, library)
 	if pkg.hasTestdata {
 		goTest.SetAttr("data", rule.GlobValue{Patterns: []string{"testdata/**"}})
 	}
 	return goTest
 }
 
-func (g *generator) setCommonAttrs(r *rule.Rule, pkgRel, visibility string, target goTarget, embed string) {
+func (g *generator) setCommonAttrs(r *rule.Rule, pkgRel string, visibility []string, target goTarget, embed string) {
 	if !target.sources.isEmpty() {
 		r.SetAttr("srcs", target.sources.buildFlat())
 	}
@@ -495,8 +496,8 @@ func (g *generator) setCommonAttrs(r *rule.Rule, pkgRel, visibility string, targ
 	if !target.copts.isEmpty() {
 		r.SetAttr("copts", g.options(target.copts.build(), pkgRel))
 	}
-	if g.shouldSetVisibility && visibility != "" {
-		r.SetAttr("visibility", []string{visibility})
+	if g.shouldSetVisibility && len(visibility) > 0 {
+		r.SetAttr("visibility", visibility)
 	}
 	if embed != "" {
 		r.SetAttr("embed", []string{":" + embed})
@@ -525,6 +526,38 @@ func (g *generator) setImportAttrs(r *rule.Rule, importPath string) {
 			r.SetAttr("importmap", importMap)
 		}
 	}
+}
+
+func (g *generator) commonVisibility(importPath string) []string {
+	// If the Bazel package name (rel) contains "internal", add visibility for
+	// subpackages of the parent.
+	// If the import path contains "internal" but rel does not, this is
+	// probably an internal submodule. Add visibility for all subpackages.
+	relIndex := pathtools.Index(g.rel, "internal")
+	importIndex := pathtools.Index(importPath, "internal")
+	var visibility []string
+	if relIndex >= 0 {
+		parent := strings.TrimSuffix(g.rel[:relIndex], "/")
+		visibility = append(visibility, fmt.Sprintf("//%s:__subpackages__", parent))
+	} else if importIndex >= 0 {
+		visibility = append(visibility, "//:__subpackages__")
+	} else {
+		return []string{"//visibility:public"}
+	}
+
+	// Add visibility for any submodules that have the internal parent as
+	// a prefix of their module path.
+	if importIndex >= 0 {
+		gc := getGoConfig(g.c)
+		internalRoot := strings.TrimSuffix(importPath[:importIndex], "/")
+		for _, m := range gc.submodules {
+			if strings.HasPrefix(m.modulePath, internalRoot) {
+				visibility = append(visibility, fmt.Sprintf("@%s//:__subpackages__", m.repoName))
+			}
+		}
+	}
+
+	return visibility
 }
 
 var (

--- a/pathtools/path.go
+++ b/pathtools/path.go
@@ -65,3 +65,47 @@ func RelBaseName(rel, prefix, root string) string {
 	}
 	return base
 }
+
+// Index returns the starting index of the string sub within the non-absolute
+// slash-separated path p. sub must start and end at component boundaries
+// within p.
+func Index(p, sub string) int {
+	if sub == "" {
+		return 0
+	}
+	p = path.Clean(p)
+	sub = path.Clean(sub)
+	if path.IsAbs(sub) {
+		if HasPrefix(p, sub) {
+			return 0
+		} else {
+			return -1
+		}
+	}
+	if p == "" || p == "/" {
+		return -1
+	}
+
+	i := 0 // i is the index of the first byte of a path element
+	if len(p) > 0 && p[0] == '/' {
+		i++
+	}
+	for {
+		suffix := p[i:]
+		if len(suffix) < len(sub) {
+			return -1
+		}
+		if suffix[:len(sub)] == sub && (len(suffix) == len(sub) || suffix[len(sub)] == '/') {
+			return i
+		}
+		j := strings.IndexByte(suffix, '/')
+		if j < 0 {
+			return -1
+		}
+		i += j + 1
+		if i >= len(p) {
+			return -1
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
This change supercedes #637, which was reverted.

In #647, Gazelle now reads the repository configuration file (set with
-repo_config; WORKSPACE by default) and adds repository rules to the
Repos list, which all languages may access.

When language/go is configured, it reads Repos and makes a list of
submodules by looking for go_repository rules with importpaths that
have the current module path as a prefix. This is simpler than the
previous approach, which required explicitly adding build_submodule
attributes to go_repository.

When Go libraries and binaries are generated in internal directories,
the submodule list is used to add additional visibility entries.

Fixes #619.