### PR TITLE
Include rule name in gazelle stderr output

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -179,7 +179,7 @@ def _go_repository_impl(ctx):
                 result.stderr,
             ))
         if result.stderr:
-            print("gazelle: " + result.stderr)
+            print("gazelle(%s): %s" % (ctx.name, result.stderr))
 
     # Apply patches if necessary.
     patch(ctx)


### PR DESCRIPTION
For the sake of making CI logs debuggable, record which gazelle
invocation produced an error message.