### PR TITLE
Propagate standard SSL certificate environment variables

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -95,6 +95,8 @@ def _go_repository_impl(ctx):
 
         # Settings below are used by vcs tools.
         "SSH_AUTH_SOCK",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
         "HTTP_PROXY",
         "HTTPS_PROXY",
         "NO_PROXY",


### PR DESCRIPTION
This passes through the environment variables `SSL_CERT_FILE` and `SSL_CERT_DIR`, which the Go standard library [will use](https://golang.org/pkg/crypto/x509/) to override the system default locations for SSL root certificates.

This is helpful in cases where either (a) the files aren't at the expected location, or (b) you want to fetch from a server that's using TLS with a non-public root certificate.