### PR TITLE
Prevent Gazelle from generating duplicate repository rules

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -22,6 +22,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -2874,4 +2875,66 @@ go_test(
 )
 `,
 	}})
+}
+
+func TestImportCollision(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+		},
+		{
+			Path: "go.mod",
+			Content: `
+module example.com/importcases
+
+go 1.13
+
+require (
+	github.com/Selvatico/go-mocket v1.0.7
+	github.com/selvatico/go-mocket v1.0.7
+)
+`,
+		},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	args := []string{"update-repos", "--from_file=go.mod"}
+	errMsg := "imports github.com/Selvatico/go-mocket and github.com/selvatico/go-mocket resolve to the same repository rule name com_github_selvatico_go_mocket"
+	if err := runGazelle(dir, args); err == nil {
+		t.Fatal("expected error, got nil")
+	} else if err.Error() != errMsg {
+		t.Error(fmt.Sprintf("want %s, got %s", errMsg, err.Error()))
+	}
+}
+
+func TestImportCollisionWithReplace(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+			Content: "# gazelle:repo bazel_gazelle",
+		},
+		{
+			Path: "go.mod",
+			Content: `
+module github.com/linzhp/go_examples/importcases
+
+go 1.13
+
+require (
+	github.com/Selvatico/go-mocket v1.0.7
+	github.com/selvatico/go-mocket v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/selvatico/go-mocket => github.com/Selvatico/go-mocket v1.0.7
+`,
+		},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	args := []string{"update-repos", "--from_file=go.mod"}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2937,4 +2937,22 @@ replace github.com/selvatico/go-mocket => github.com/Selvatico/go-mocket v1.0.7
 	if err := runGazelle(dir, args); err != nil {
 		t.Fatal(err)
 	}
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+			Content: `
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+# gazelle:repo bazel_gazelle
+
+go_repository(
+    name = "com_github_selvatico_go_mocket",
+    importpath = "github.com/selvatico/go-mocket",
+    replace = "github.com/Selvatico/go-mocket",
+    sum = "h1:sXuFMnMfVL9b/Os8rGXPgbOFbr4HJm8aHsulD/uMTUk=",
+    version = "v1.0.7",
+)
+`,
+		},
+	})
 }

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -175,15 +175,15 @@ func updateRepos(args []string) (err error) {
 	var newGen []*rule.Rule
 	genForFiles := make(map[*rule.File][]*rule.Rule)
 	emptyForFiles := make(map[*rule.File][]*rule.Rule)
-	ruleSet := make(map[string]*rule.Rule)
+	genNames := make(map[string]*rule.Rule)
 	for _, r := range gen {
-		if existingRule, exist := ruleSet[r.Name()]; exist {
+		if existingRule := genNames[r.Name()]; existingRule != nil {
 			import1 := existingRule.AttrString("importpath")
 			import2 := r.AttrString("importpath")
 			return fmt.Errorf("imports %s and %s resolve to the same repository rule name %s",
 				import1, import2, r.Name())
 		} else {
-			ruleSet[r.Name()] = r
+			genNames[r.Name()] = r
 		}
 		f := uc.repoFileMap[r.Name()]
 		if f != nil {

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -175,7 +175,16 @@ func updateRepos(args []string) (err error) {
 	var newGen []*rule.Rule
 	genForFiles := make(map[*rule.File][]*rule.Rule)
 	emptyForFiles := make(map[*rule.File][]*rule.Rule)
+	ruleSet := make(map[string]*rule.Rule)
 	for _, r := range gen {
+		if existingRule, exist := ruleSet[r.Name()]; exist {
+			import1 := existingRule.AttrString("importpath")
+			import2 := r.AttrString("importpath")
+			return fmt.Errorf("imports %s and %s resolve to the same repository rule name %s",
+				import1, import2, r.Name())
+		} else {
+			ruleSet[r.Name()] = r
+		}
 		f := uc.repoFileMap[r.Name()]
 		if f != nil {
 			genForFiles[f] = append(genForFiles[f], r)


### PR DESCRIPTION
When a `go.mod` file has:

```
require (
	github.com/Selvatico/go-mocket v1.0.7
	github.com/selvatico/go-mocket v1.0.7
)
```

`gazelle update-repos` would generate two `go_repository` rules with the same name, causing indeterminism in the order of resulting `go_repository` rules. In most cases, users should not import both `github.com/Selvatico/go-mocket` and `github.com/selvatico/go-mocket` in the same module, so `gazelle update-repos` should report errors. However, if that's what users really want, they should to add a `replace` statement in the `go.mod` file like this:

```
require (
	github.com/Selvatico/go-mocket v1.0.7
	github.com/selvatico/go-mocket v0.0.0-00010101000000-000000000000
)

replace github.com/selvatico/go-mocket => github.com/Selvatico/go-mocket v1.0.7
```

In this case, only one `go_repository` rule is generated.