### PR TITLE
language/go: workaround Bazel compatibility issue

### DIFF
--- a/language/go/def.bzl
+++ b/language/go/def.bzl
@@ -18,7 +18,7 @@ std_package_list = go_rule(
     attrs = {
         "out": attr.output(mandatory = True),
         "_gen_std_package_list": attr.label(
-            default = "//language/go/gen_std_package_list",
+            default = "@bazel_gazelle//language/go/gen_std_package_list",
             cfg = "host",
             executable = True,
         ),

--- a/language/go/gen_std_package_list/BUILD.bazel
+++ b/language/go/gen_std_package_list/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_binary(
     name = "gen_std_package_list",
     embed = [":go_default_library"],
-    visibility = ["//language/go:__subpackages__"],
+    # TODO(bazelbuild/rules_go#2302): needs to be public in order to use as
+    # a default value in std_package_list, which is defined with go_rule.
+    # std_package_list should not be defined with go_rule.
+    visibility = ["//visibility:public"],
 )
 
 go_library(


### PR DESCRIPTION
This is a workaround for a visibility issue, possibly introduced by
the --incompatible_remap_main_repo flag or something similar.

We should stop using go_rule though.

Fixes #676
Updates bazelbuild/rules_go#2302