### PR TITLE
Teach gazelle to add load statements for `proto_library`

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -602,6 +602,7 @@ go_proto_library(
 		}, {
 			args: []string{"fix", "-go_prefix", "example.com/repo"},
 			want: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -649,6 +650,7 @@ func TestRemoveProtoDeletesRules(t *testing.T) {
 		{
 			Path: config.DefaultValidBuildFileNames[0],
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -713,6 +715,7 @@ func TestAddServiceConvertsToGrpc(t *testing.T) {
 		{
 			Path: config.DefaultValidBuildFileNames[0],
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -758,6 +761,7 @@ service {}
 	testtools.CheckFiles(t, dir, []testtools.FileSpec{{
 		Path: config.DefaultValidBuildFileNames[0],
 		Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -791,6 +795,7 @@ func TestProtoImportPrefix(t *testing.T) {
 		{
 			Path: config.DefaultValidBuildFileNames[0],
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -832,6 +837,7 @@ go_library(
 	testtools.CheckFiles(t, dir, []testtools.FileSpec{{
 		Path: config.DefaultValidBuildFileNames[0],
 		Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
@@ -1033,6 +1039,7 @@ func TestDeleteProtoWithDeps(t *testing.T) {
 		{
 			Path: "foo/BUILD.bazel",
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -2398,6 +2405,7 @@ func TestGoGrpcProtoFlag(t *testing.T) {
 		}, {
 			Path: "BUILD.bazel",
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -2433,6 +2441,7 @@ message Bar {};
 		}, {
 			Path: "service/BUILD.bazel",
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -2480,6 +2489,7 @@ service {}
 		{
 			Path: "BUILD.bazel",
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -2508,6 +2518,7 @@ go_library(
 		{
 			Path: "service/BUILD.bazel",
 			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -2834,7 +2845,7 @@ func TestGoImportVisibility(t *testing.T) {
 			Content: `
 go_repository(
 		name = "com_example_m_logging",
-    importpath = "example.com/m/logging",		
+    importpath = "example.com/m/logging",
 )
 `,
 		}, {
@@ -2911,7 +2922,7 @@ require (
 func TestImportCollisionWithReplace(t *testing.T) {
 	files := []testtools.FileSpec{
 		{
-			Path: "WORKSPACE",
+			Path:    "WORKSPACE",
 			Content: "# gazelle:repo bazel_gazelle",
 		},
 		{

--- a/language/go/testdata/default_visibility/BUILD.want
+++ b/language/go/testdata/default_visibility/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/importmap/BUILD.want
+++ b/language/go/testdata/importmap/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/proto_package_mode/BUILD.want
+++ b/language/go/testdata/proto_package_mode/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(

--- a/language/go/testdata/proto_package_mode_extras/BUILD.want
+++ b/language/go/testdata/proto_package_mode_extras/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/protos/BUILD.want
+++ b/language/go/testdata/protos/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/protos_explicit_default/BUILD.want
+++ b/language/go/testdata/protos_explicit_default/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/protos_gogo/BUILD.want
+++ b/language/go/testdata/protos_gogo/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/protos_gogo_subdir_reset/BUILD.want
+++ b/language/go/testdata/protos_gogo_subdir_reset/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/protos_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/protos_gogo_subdir_reset/sub/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/service/BUILD.want
+++ b/language/go/testdata/service/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/service_gogo/BUILD.want
+++ b/language/go/testdata/service_gogo/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/service_gogo_subdir_reset/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/language/proto/kinds.go
+++ b/language/proto/kinds.go
@@ -27,5 +27,14 @@ var protoKinds = map[string]rule.KindInfo{
 	},
 }
 
+var protoLoads = []rule.LoadInfo{
+	{
+		Name: "@rules_proto//proto:defs.bzl",
+		Symbols: []string{
+			"proto_library",
+		},
+	},
+}
+
 func (_ *protoLang) Kinds() map[string]rule.KindInfo { return protoKinds }
-func (_ *protoLang) Loads() []rule.LoadInfo          { return nil }
+func (_ *protoLang) Loads() []rule.LoadInfo          { return protoLoads }

--- a/language/proto/testdata/default_visibility/BUILD.want
+++ b/language/proto/testdata/default_visibility/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],

--- a/language/proto/testdata/import_prefix/BUILD.want
+++ b/language/proto/testdata/import_prefix/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],

--- a/language/proto/testdata/multiple_packages/default_mode/BUILD.want
+++ b/language/proto/testdata/multiple_packages/default_mode/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "multiple_packages_default_mode_proto",
     srcs = ["foo.proto"],

--- a/language/proto/testdata/multiple_packages/package_mode/BUILD.want
+++ b/language/proto/testdata/multiple_packages/package_mode/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "bar_proto",
     srcs = [

--- a/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
+++ b/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "bar_proto",
     srcs = [

--- a/language/proto/testdata/protos/BUILD.want
+++ b/language/proto/testdata/protos/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "protos_proto",
     srcs = [

--- a/language/proto/testdata/strip_import_prefix/BUILD.want
+++ b/language/proto/testdata/strip_import_prefix/BUILD.want
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],


### PR DESCRIPTION
The native Protobuf rules are deprecated and will be replaced by
Starlark rules. As a first step towards this goal, starting with
Bazel 3.0, these rules will require explicit load statements.

See https://github.com/bazelbuild/bazel/issues/8922

This PR teaches gazelle to emit load statements for `proto_library`,
so Go projects can migrate using familiar tools.

Fixes #638