### PR TITLE
Replace 'cat' tool call with repository_ctx.read() call.

### DIFF
--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -76,11 +76,8 @@ go_repository_cache = repository_rule(
 )
 
 def read_cache_env(ctx, path):
-    result = ctx.execute(["cat", path])
-    if result.return_code:
-        fail("failed to read cache environment: " + result.stderr)
+    lines = ctx.read(path).split("\n")
     env = {}
-    lines = result.stdout.split("\n")
     for line in lines:
         line = line.strip()
         if line == "" or line.startswith("#"):


### PR DESCRIPTION
Newer versions of bazel provide repository_ctx.read() (https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#read). 
On the other hand there is no standard 'cat' utility on Windows. 
