### PR TITLE
label: trim non-word chars for import path to repo

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -185,17 +185,19 @@ func (l Label) Contains(other Label) bool {
 	return result
 }
 
+var nonWordRe = regexp.MustCompile(`\W+`)
+
 // ImportPathToBazelRepoName converts a Go import path into a bazel repo name
 // following the guidelines in http://bazel.io/docs/be/functions.html#workspace
 func ImportPathToBazelRepoName(importpath string) string {
 	importpath = strings.ToLower(importpath)
 	components := strings.Split(importpath, "/")
 	labels := strings.Split(components[0], ".")
-	var reversed []string
+	reversed := make([]string, 0, len(labels)+len(components)-1)
 	for i := range labels {
 		l := labels[len(labels)-i-1]
 		reversed = append(reversed, l)
 	}
-	repo := strings.Join(append(reversed, components[1:]...), "_")
-	return strings.NewReplacer("-", "_", ".", "_").Replace(repo)
+	repo := strings.Join(append(reversed, components[1:]...), ".")
+	return nonWordRe.ReplaceAllString(repo, "_")
 }

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -85,3 +85,14 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestImportPathToBazelRepoName(t *testing.T) {
+	for path, want := range map[string]string{
+		"git.sr.ht/~urandom/errors": "ht_sr_git_urandom_errors",
+		"golang.org/x/mod":          "org_golang_x_mod",
+	} {
+		if got := ImportPathToBazelRepoName(path); got != want {
+			t.Errorf(`ImportPathToBazelRepoName(%q) = %q; want %q`, path, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Currently ImportPathToBazelRepoName converts `-`s and `.`s to `_`s. This does
not appear to be required by Bazel's repo name conventions, but may
follow best practices. Unfortunately, this means characters valid for
import paths cause build failures, like `git.sr.ht/~sircmpwn/go-example`.
This change replaces all non-word, `\W` or `[^A-Za-z0-9_]` characters, not
just `-` and `.`, with `_`.

This change also preallocates reversed, since its length is known.