### PR TITLE
Sorting repo rules in macros by name

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1744,16 +1744,17 @@ def go_repositories():
 
 def foo_repositories():
     go_repository(
-        name = "org_golang_x_net",
-        build_file_generation = "off",
-        commit = "66aacef3dd8a676686c7ae3716979581e8b03c47",
-        importpath = "golang.org/x/net",
-    )
-    go_repository(
         name = "com_github_pkg_errors",
         build_file_generation = "off",
         commit = "645ef00459ed84a119197bfb8d8205042c6df63d",
         importpath = "github.com/pkg/errors",
+    )
+
+    go_repository(
+        name = "org_golang_x_net",
+        build_file_generation = "off",
+        commit = "66aacef3dd8a676686c7ae3716979581e8b03c47",
+        importpath = "golang.org/x/net",
     )
 `,
 		},
@@ -2028,6 +2029,13 @@ def go_repositories():
 
 def foo_repositories():
     go_repository(
+        name = "com_github_pkg_errors",
+        build_file_generation = "off",
+        commit = "645ef00459ed84a119197bfb8d8205042c6df63d",
+        importpath = "github.com/pkg/errors",
+    )
+
+    go_repository(
         name = "org_golang_x_net",
         build_file_generation = "off",
         commit = "66aacef3dd8a676686c7ae3716979581e8b03c47",
@@ -2038,12 +2046,6 @@ def foo_repositories():
     go_repository(
         name = "stay",
         importpath = "stay",
-    )
-    go_repository(
-        name = "com_github_pkg_errors",
-        build_file_generation = "off",
-        commit = "645ef00459ed84a119197bfb8d8205042c6df63d",
-        importpath = "github.com/pkg/errors",
     )
 `,
 		},

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -280,6 +280,7 @@ func updateRepos(args []string) (err error) {
 	// Write updated files to disk.
 	for _, f := range sortedFiles {
 		if uf := updatedFiles[f.Path]; uf != nil {
+			uf.Sort()
 			if err := uf.Save(uf.Path); err != nil {
 				return err
 			}

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -280,7 +280,9 @@ func updateRepos(args []string) (err error) {
 	// Write updated files to disk.
 	for _, f := range sortedFiles {
 		if uf := updatedFiles[f.Path]; uf != nil {
-			uf.Sort()
+			if f.DefName != "" {
+				uf.SortMacro()
+			}
 			if err := uf.Save(uf.Path); err != nil {
 				return err
 			}

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -369,14 +369,15 @@ func (f *File) Format() []byte {
 	return bzl.Format(f.File)
 }
 
-// Sort rules in the macro of this File. It doesn't sort the rules if
+// SortMacros sorts rules in the macro of this File. It doesn't sort the rules if
 // this File does not have a macro, e.g., WORKSPACE.
 // This method calls Sync internally.
-func (f *File) Sort() {
+func (f *File) SortMacro() {
 	f.Sync()
-	//TODO: sort load statements too
 	if f.function != nil {
 		sort.Stable(byName{f.Rules, f.function.stmt.Body})
+	} else {
+		panic(fmt.Sprintf("no macros found in %s", f.Path))
 	}
 }
 

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -369,7 +369,7 @@ func (f *File) Format() []byte {
 	return bzl.Format(f.File)
 }
 
-// SortMacros sorts rules in the macro of this File. It doesn't sort the rules if
+// SortMacro sorts rules in the macro of this File. It doesn't sort the rules if
 // this File does not have a macro, e.g., WORKSPACE.
 // This method calls Sync internally.
 func (f *File) SortMacro() {
@@ -377,7 +377,7 @@ func (f *File) SortMacro() {
 	if f.function != nil {
 		sort.Stable(byName{f.Rules, f.function.stmt.Body})
 	} else {
-		panic(fmt.Sprintf("no macros found in %s", f.Path))
+		panic(fmt.Sprintf("%s: not loaded as macro file", f.Path))
 	}
 }
 

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -781,8 +781,7 @@ func (r *Rule) Args() []bzl.Expr {
 }
 
 // Insert marks this statement for insertion at the end of the file. Multiple
-// statements will be inserted in the order Insert is called. Inserted rules
-// will be sorted together with other rules at File.Save()
+// statements will be inserted in the order Insert is called.
 func (r *Rule) Insert(f *File) {
 	var stmt []bzl.Expr
 	if f.function == nil {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -369,8 +369,11 @@ func (f *File) Format() []byte {
 	return bzl.Format(f.File)
 }
 
-// Sort rules in this File
+// Sort rules in the macro of this File. It doesn't sort the rules if
+// this File does not have a macro, e.g., WORKSPACE.
+// This method calls Sync internally.
 func (f *File) Sort() {
+	f.Sync()
 	//TODO: sort load statements too
 	if f.function != nil {
 		sort.Stable(byName{f.Rules, f.function.stmt.Body})
@@ -380,7 +383,6 @@ func (f *File) Sort() {
 // Save writes the build file to disk. This method calls Sync internally.
 func (f *File) Save(path string) error {
 	f.Sync()
-	f.Sort()
 	data := bzl.Format(f.File)
 	return ioutil.WriteFile(path, data, 0666)
 }

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -376,41 +376,40 @@ func TestSortRulesByName(t *testing.T) {
 def repos():
     go_repository(
         name = "com_github_andybalholm_cascadia",
-        importpath = "github.com/andybalholm/cascadia",
-        sum = "h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=",
-        version = "v1.1.0",
     )
     go_repository(
         name = "com_github_bazelbuild_buildtools",
-        importpath = "github.com/bazelbuild/buildtools",
-        sum = "h1:OfyUN/Msd8yqJww6deQ9vayJWw+Jrbe6Qp9giv51QQI=",
-        version = "v0.0.0-20190731111112-f720930ceb60",
     )
     go_repository(
         name = "com_github_bazelbuild_rules_go",
-        importpath = "github.com/bazelbuild/rules_go",
-        sum = "h1:wzbawlkLtl2ze9w/312NHZ84c7kpUCtlkD8HgFY27sw=",
-        version = "v0.0.0-20190719190356-6dae44dc5cab",
     )
     go_repository(
         name = "com_github_bazelbuild_bazel_gazelle",
-        importpath = "github.com/bazelbuild/bazel-gazelle",
-        sum = "h1:buszGdD9d/Z691sxFDgOdcEUWli0ZT2tBXUxfbLMrb4=",
-        version = "v0.21.1",
     )
 `))
 	if err != nil {
 		t.Error(err)
 	}
-	gazelleRule := f.Rules[3]
-	if gazelleRule.Name() != "com_github_bazelbuild_bazel_gazelle" || gazelleRule.stmt.index != 3 {
-		t.Error("failed to parse repos.bzl")
-	}
 	sort.Stable(byName{
 		rules: f.Rules,
 		exprs: f.function.stmt.Body,
 	})
-	if gazelleRule.index != 1 {
-		t.Errorf("expect com_github_bazelbuild_bazel_gazelle to be at 1, found at %d", gazelleRule.index)
+	repos := []string{
+		"com_github_andybalholm_cascadia",
+		"com_github_bazelbuild_bazel_gazelle",
+		"com_github_bazelbuild_buildtools",
+		"com_github_bazelbuild_rules_go",
+	}
+	for i, r := range repos {
+		rule := f.Rules[i]
+		if rule.Name() != r {
+			t.Errorf("expect rule %s at %d, got %s", r, i, rule.Name())
+		}
+		if rule.Index() != i {
+			t.Errorf("expect rule %s with index %d, got %d", r, i, rule.Index())
+		}
+		if f.function.stmt.Body[i] != rule.expr {
+			t.Errorf("underlying syntax tree of rule %s not sorted", r)
+		}
 	}
 }


### PR DESCRIPTION
Developers working on the same repo may add external repos simultaneously. Appending new repos to the end often results in merge conflict. This PR sort repo rules by name to reduce the chance of conflict.

Note the it only sorts rules in macros by not in WORKSPACE, as the latter may have some repo rules that are better to keep at the top because of their importance, e.g., loading rules_go, gazelle, setting up go toolchain.

cc @blico 