### PR TITLE
update-repos: add repository macro call and directive if missing

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//resolve:go_default_library",
         "//rule:go_default_library",
         "//walk:go_default_library",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_pmezard_go_difflib//difflib:go_default_library",
     ],
 )

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1811,6 +1811,14 @@ func TestImportReposFromDepToEmptyMacro(t *testing.T) {
 
 	testtools.CheckFiles(t, dir, []testtools.FileSpec{
 		{
+			Path: "WORKSPACE",
+			Content: `
+load("//:repositories.bzl", "go_repositories")
+
+# gazelle:repository_macro repositories.bzl%go_repositories
+go_repositories()
+`,
+		}, {
 			Path: "repositories.bzl",
 			Content: `
 load("@bazel_gazelle//:deps.bzl", "go_repository")


### PR DESCRIPTION
In update-repos, if the -to_macro flag is used on a macro that isn't
mentioned in a '# gazelle:repository_macro' directive in WORKSPACE,
add a directive.

Gazelle needs to be able to read repositories from WORKSPACE for
accurate and efficient dependency resolution. Macros must be declared
with '# gazelle:repository_macro'. It's a common mistake to use
'-to_macro', then call the macro without declaring it. This change
removes that sharp edge by adding a call with a directive
automatically. If a call is already present without a directive, a
directive will be added, but if a directive is present without a
call, it will be left alone.

Updates #689
Fixes #680
Updates #665