### PR TITLE
Ignore Go files consumed by existing rules

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -232,7 +232,12 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 		// Some of the generated files may have been consumed by other rules
 		consumedFileSet := make(map[string]bool)
-		for _, r := range args.OtherGen {
+		var otherRules []*rule.Rule
+		otherRules = append(otherRules, args.OtherGen...)
+		if args.File != nil {
+			otherRules = append(otherRules, args.File.Rules...)
+		}
+		for _, r := range otherRules {
 			for _, f := range r.AttrStrings("srcs") {
 				consumedFileSet[f] = true
 			}

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -236,14 +236,20 @@ func TestGenerateRulesPrebuiltGoProtoRules(t *testing.T) {
 func TestConsumedGenFiles(t *testing.T) {
 	args := language.GenerateArgs{
 		RegularFiles: []string{"regular.go"},
-		GenFiles:     []string{"mocks.go"},
+		GenFiles:     []string{"mocks1.go", "mocks2.go"},
 		Config: &config.Config{
 			Exts: make(map[string]interface{}),
 		},
 	}
-	otherRule := rule.NewRule("go_library", "go_mock_library")
-	otherRule.SetAttr("srcs", []string{"mocks.go"})
-	args.OtherGen = append(args.OtherGen, otherRule)
+	otherGenRule := rule.NewRule("go_library", "generated_go_mock_library1")
+	otherGenRule.SetAttr("srcs", []string{"mocks1.go"})
+	args.OtherGen = append(args.OtherGen, otherGenRule)
+
+	otherManualRule := rule.NewRule("go_library", "manual_go_mock_library")
+	otherManualRule.SetAttr("srcs", []string{"mocks2.go"})
+	args.File = &rule.File{
+		Rules: []*rule.Rule{otherManualRule},
+	}
 
 	gl := goLang{
 		goPkgRels: make(map[string]bool),


### PR DESCRIPTION
Related to #643

Users may want some generated file to be build in a different `go_library` rule than the `go_default_library`. So they may create a `go_library` rule manually with the generated Go files. In this case, we should not add those Go files into `go_default_library`