### PR TITLE
cmd/gazelle: hack to fix repository name hfor @go_googleapis

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -502,12 +502,20 @@ func removeLegacyGoRepository(f *rule.File) {
 }
 
 func findWorkspaceName(f *rule.File) string {
+	var name string
 	for _, r := range f.Rules {
 		if r.Kind() == "workspace" {
-			return r.Name()
+			name = r.Name()
+			break
 		}
 	}
-	return ""
+	// HACK(bazelbuild/rules_go#2355, bazelbuild/rules_go#2387):
+	// We can't patch the WORKSPACE file with the correct name because Bazel
+	// writes it first; our patches won't apply.
+	if name == "com_google_googleapis" {
+		return "go_googleapis"
+	}
+	return name
 }
 
 func isDescendingDir(dir, root string) bool {


### PR DESCRIPTION
Normally, Gazelle detects the repository name by reading the WORKSPACE
file and looking for a workspace rule. In go_googleapis, the proper
workspace name is com_google_googleapis. Before
bazelbuild/rules_go#2355, we patched the WORKSPACE file before running
Gazelle so the repository name would be set to
go_googleapis. Unfortunately, in newer versions of Bazel, WORKSPACE is
overwritten, so the patch doesn't apply.

This change just adds a hack to set the repository name to
go_googleapis if com_google_googleapis is detected.

Updates bazelbuild/rules_go#2387