### PR TITLE
proto_library for generated proto files

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -18,6 +18,7 @@ package proto
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -121,7 +122,10 @@ func buildPackages(pc *ProtoConfig, dir, rel string, protoFiles, genFiles []stri
 			log.Print(err)
 		}
 		if pkg == nil {
-			return nil // empty rule created in generateEmpty
+			if len(genFiles) == 0 {
+				return nil // empty rule created in generateEmpty
+			}
+			pkg = newPackage(filepath.Base(rel))
 		}
 		for _, name := range genFiles {
 			pkg.addGenFile(dir, name)

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -124,8 +124,8 @@ proto_library(
 		Rel:      "foo",
 		File:     old,
 		GenFiles: genFiles})
-	if len(res.Gen) > 0 {
-		t.Errorf("got %d generated rules; want 0", len(res.Gen))
+	if len(res.Gen) != 1 {
+		t.Errorf("got %d generated rules; want 1", len(res.Gen))
 	}
 	f := rule.EmptyFile("test", "")
 	for _, r := range res.Empty {

--- a/language/proto/testdata/generated/BUILD.old
+++ b/language/proto/testdata/generated/BUILD.old
@@ -1,0 +1,5 @@
+genrule(
+    name = "gen_foo_proto",
+    outs = ["foo_generated.proto"],
+    cmd = """echo 'syntax = "proto2"' > foo_generated.proto""",
+)

--- a/language/proto/testdata/generated/BUILD.want
+++ b/language/proto/testdata/generated/BUILD.want
@@ -1,0 +1,7 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "generated_proto",
+    srcs = ["foo_generated.proto"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
When a package only has generated proto files but no regular proto files, Gazelle should still generate `proto_library` for the generated proto files.