### PR TITLE
Use repository_ctx.read() instead of "cat".

### DIFF
--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -78,11 +78,9 @@ go_repository_cache = repository_rule(
 )
 
 def read_cache_env(ctx, path):
-    result = ctx.execute(["cat", path])
-    if result.return_code:
-        fail("failed to read cache environment: " + result.stderr)
+    contents = ctx.read(path)
     env = {}
-    lines = result.stdout.split("\n")
+    lines = contents.split("\n")
     for line in lines:
         line = line.strip()
         if line == "" or line.startswith("#"):

--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -70,14 +70,7 @@ def _find_macro_file_labels(ctx, label):
     seen = {}
     files = []
 
-    result = ctx.execute(["cat", str(ctx.path(label))])
-    if result.return_code == 0:
-        content = result.stdout
-    else:
-        # TODO(jayconrod): "type" might work on Windows, but I think
-        # it's a shell builtin, and I'm not sure if ctx.execute will work.
-        content = ""
-
+    content = ctx.read(ctx.path(label))
     lines = content.split("\n")
     for line in lines:
         i = line.find("#")


### PR DESCRIPTION
"cat" doesn't exist on Windows, and it seems
cleaner to use a built-in anyway.

Tested: Manually on Windows, and bazel test //...

The latter fails some tests, presumably because of
other Windows incompatibilities like autogazelle.