### PR TITLE
apply patches before build file generation

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -127,6 +127,9 @@ def _go_repository_impl(ctx):
         if result.stderr:
             print("fetch_repo: " + result.stderr)
 
+    # Apply patches if necessary.
+    patch(ctx)
+
     # Repositories are fetched. Determine if build file generation is needed.
     build_file_names = ctx.attr.build_file_name.split(",")
     existing_build_file = ""
@@ -182,9 +185,6 @@ def _go_repository_impl(ctx):
             ))
         if result.stderr:
             print("%s: %s" % (ctx.name, result.stderr))
-
-    # Apply patches if necessary.
-    patch(ctx)
 
 go_repository = repository_rule(
     implementation = _go_repository_impl,


### PR DESCRIPTION
This commit forces patches be applied to just fetched repository before the
build file generation. This allows new files added by the patches be correctly
enlisted into build files.

Fixes #735