### PR TITLE
Fix invalid output for globs with `exclude` arguments.

### DIFF
--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -346,3 +346,16 @@ func TestShouldKeepExpr(t *testing.T) {
 		})
 	}
 }
+
+func TestGlobWithExclude(t *testing.T) {
+	want := `glob(
+    ["*.star"],
+    exclude = ["*.bzl"],
+)`
+	val := GlobValue{Patterns: []string{"*.star"}, Excludes: []string{"*.bzl"}}
+	expr := ExprFromValue(val)
+	got := bzl.FormatString(expr)
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}

--- a/rule/value.go
+++ b/rule/value.go
@@ -147,10 +147,10 @@ func ExprFromValue(val interface{}) bzl.Expr {
 			patternsValue := ExprFromValue(val.Patterns)
 			globArgs := []bzl.Expr{patternsValue}
 			if len(val.Excludes) > 0 {
-				excludesValue := ExprFromValue(val.Excludes)
-				globArgs = append(globArgs, &bzl.KeyValueExpr{
-					Key:   &bzl.StringExpr{Value: "excludes"},
-					Value: excludesValue,
+				globArgs = append(globArgs, &bzl.AssignExpr{
+					LHS: &bzl.Ident{Name: "exclude"},
+					Op:  "=",
+					RHS: ExprFromValue(val.Excludes),
 				})
 			}
 			return &bzl.CallExpr{


### PR DESCRIPTION
Currently, output is a KV pair as appropriate for a starlark dict,
where it should be a function argument. Parameter name is `exclude`.

Before:
    glob(
        ["*.star"],
        "excludes": ["*.bzl"],
    )

After:
    glob(
        ["*.star"],
        exclude = ["*.bzl"],
    )