### PR TITLE
Fixing failing tests

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2987,16 +2987,15 @@ func TestMatchProtoLibrary(t *testing.T) {
 load("@rules_proto//proto:defs.bzl", "proto_library")
 # gazelle:prefix example.com/foo
 
-some_rule(
-	name = "gen_proto",
-	out = "foo.proto",
-)
-
 proto_library(
 	name = "existing_proto",
 	srcs = ["foo.proto"],
 )
 `,
+		},
+		{
+			Path:    "proto/foo.proto",
+			Content: `syntax = "proto3";`,
 		},
 	}
 	dir, cleanup := testtools.CreateFiles(t, files)
@@ -3016,11 +3015,6 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 # gazelle:prefix example.com/foo
 
-some_rule(
-    name = "gen_proto",
-    out = "foo.proto",
-)
-
 proto_library(
     name = "existing_proto",
     srcs = ["foo.proto"],
@@ -3028,7 +3022,7 @@ proto_library(
 )
 
 go_proto_library(
-    name = "proto_go_proto",
+    name = "foo_go_proto",
     importpath = "example.com/foo",
     proto = ":existing_proto",
     visibility = ["//visibility:public"],
@@ -3036,11 +3030,10 @@ go_proto_library(
 
 go_library(
     name = "go_default_library",
-    embed = [":proto_go_proto"],
+    embed = [":foo_go_proto"],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
-)
-`,
+)`,
 		},
 	})
 }

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2975,3 +2975,72 @@ go_repository(
 		},
 	})
 }
+
+func TestMatchProtoLibrary(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+		},
+		{
+			Path: "proto/BUILD.bazel",
+			Content: `
+load("@rules_proto//proto:defs.bzl", "proto_library")
+# gazelle:prefix example.com/foo
+
+some_rule(
+	name = "gen_proto",
+	out = "foo.proto",
+)
+
+proto_library(
+	name = "existing_proto",
+	srcs = ["foo.proto"],
+)
+`,
+		},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	args := []string{"update"}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "proto/BUILD.bazel",
+			Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+# gazelle:prefix example.com/foo
+
+some_rule(
+    name = "gen_proto",
+    out = "foo.proto",
+)
+
+proto_library(
+    name = "existing_proto",
+    srcs = ["foo.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "proto_go_proto",
+    importpath = "example.com/foo",
+    proto = ":existing_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":proto_go_proto"],
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+	})
+}

--- a/language/proto/kinds.go
+++ b/language/proto/kinds.go
@@ -19,6 +19,7 @@ import "github.com/bazelbuild/bazel-gazelle/rule"
 
 var protoKinds = map[string]rule.KindInfo{
 	"proto_library": {
+		MatchAttrs:    []string{"srcs"},
 		NonEmptyAttrs: map[string]bool{"srcs": true},
 		MergeableAttrs: map[string]bool{
 			"srcs": true,

--- a/merger/merger_test.go
+++ b/merger/merger_test.go
@@ -969,6 +969,15 @@ go_binary(name = "y")
 go_binary(name = "z")
 `,
 			wantError: true,
+		}, {
+			desc:      "srcs match",
+			gen:       `proto_library(name = "proto1", srcs = ["foo.proto", "bar.proto"])`,
+			old:       `proto_library(name = "proto2", srcs = ["bar.proto", "foo.proto"])`,
+			wantIndex: 0,
+		}, {
+			desc: "importpath match",
+			gen:  `go_proto_library(name = "go_proto1", importpath="example.com/foo")`,
+			old:  `go_proto_library(name = "go_proto2", importpath="example.com/foo")`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
When #730 was opened, it was based on top of #720. So the tests were passing on #730. However, #720 was reverted on master before #730 was merged. When merging #730 onto master, its tests started to fail. This PR reverted #743 and fixed the failing tests

Fixed #742