### PR TITLE
[Feature] allow generated repo_configs in the `gazelle` rule

### DIFF
--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -24,6 +24,7 @@ GAZELLE_SHORT_PATH=@@GAZELLE_SHORT_PATH@@
 GAZELLE_LABEL=@@GAZELLE_LABEL@@
 ARGS=@@ARGS@@
 GOTOOL=@@GOTOOL@@
+FILE_ARGS=@@FILE_ARGS@@
 
 # find_runfile prints the location of a runfile in the source workspace,
 # either by reading the symbolic link or reading the runfiles manifest.
@@ -83,6 +84,19 @@ if [ "${1-}" = "-args" ]; then
   ARGS+=("$@")
 elif [ $# -ne 0 ]; then
   ARGS=("$@")
+fi
+
+if [ "${FILE_ARGS-}" != "" ]; then
+  for f in "${FILE_ARGS[@]}"
+  do
+    # If the arg starts with '-' just append
+    if [[ $f = -* ]]; then
+      ARGS=( "${ARGS[@]}" "$f" )
+    else
+      f=$(find_runfile "$f")
+      ARGS=( "${ARGS[@]}" "$f")
+    fi
+  done
 fi
 
 if [ "$is_bazel_run" = true ]; then


### PR DESCRIPTION
TLDR: I want to be able to pass the `gazelle` rule a generated repo_config so that I don't have to manually update dependencies from `go.mod`

Using the `update-repos` workflow to update repositories from a go.mod is pretty painful. To simplify this I want to be able to generate a repository config file automatically and have gazelle use it, without having to run `update-repos`. To do this I wrote a repository rule:

```
def _go_mod_impl(ctx):
    ctx.file("BUILD", content = 'exports_files(["repositories.bzl"])')
    ctx.file("WORKSPACE", content = "workspace(name = \"%s\")" % ctx.name)

    bzl = 'load("@bazel_gazelle//:deps.bzl", "go_repository")\n\ndef go_repositories():\n    pass\n\n# gazelle:repository_macro repositories.bzl%go_repositories'

    ctx.file("repositories.bzl", content = bzl)

    _gazelle = "@bazel_gazelle_go_repository_tools//:bin/gazelle"
    gazelle = ctx.path(Label(_gazelle))

    result = ctx.execute(
        [
            gazelle,
            "update-repos",
            "-from_file=%s" % ctx.path(ctx.attr.go_mod),
            "-to_macro=repositories.bzl%go_repositories",
        ],
    )

    if result.return_code:
        fail("failed go_mod %s: %s" % (ctx.name, result.stderr))
    if result.stderr:
        print("go_mod: " + result.stderr)


go_mod_download = repository_rule(
    implementation = _go_mod_impl,
    attrs = {
        "go_mod": attr.label(
            mandatory = True,
            allow_single_file = True,
        ),
    },
)
```

That is called like:

```
go_mod_download(
    name = "go_modules",
    go_mod = "//:go.mod",
)
load("@go_modules//:repositories.bzl", default_go_repositories = "go_repositories")
default_go_repositories()
```

This works great. Except because of the way gazelle optimizes resolution of repositories, it has made running gazelle **very slow**.

To solve this I want to be able to pass my generated `@go_modules//:repositories.bzl` as a repo config to gazelle, to tell it about all the repositories I already have defined. For example:

```
gazelle(
    name = "gazelle",
    repo_config = "@go_modules//:repositories.bzl",
)
```

This PR lets gazelle work with a generated repo_config. This is also very extensible, because now I can concat a bunch of files that have `go_repositories` in them, into a single repository config and have gazelle know what is what. 

With this approach, I can run `go get -u <package>` to update a package then run `bazel build <rule>` and it will have the new package immediately without having to ru `update-repos` AND if I run `bazel run gazelle` it doesn't take minutes.

### Other approach

I tried using something like  `# gazelle:repository_macro bazel-repo/external/repositories.bzl%go_repositories` this doesn't work because when running `bazel run gazelle` the file might not exist yet. So gazelle rule must know about this file before hand anyway.
