### PR TITLE
walk: convert gazelle:exclude to a doublestar.Match pattern

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Gazelle build file generator
 .. _update: #fix-and-update
 .. _Avoiding conflicts with proto rules: https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#avoiding-conflicts
 .. _gazelle rule: #bazel-rule
-.. _doublestar.PathMatch: https://github.com/bmatcuk/doublestar#pathmatch
+.. _doublestar.Match: https://github.com/bmatcuk/doublestar#match
 .. _Extending Gazelle: extend.rst
 .. _Supported languages: extend.rst#supported-languages
 .. _extended: `Extending Gazelle`_
@@ -305,7 +305,7 @@ The following flags are accepted:
 | :flag:`-exclude pattern`                                     |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | Prevents Gazelle from processing a file or directory if the given                                     |
-| `doublestar.PathMatch`_ pattern matches. If the pattern refers to a source file,                      |
+| `doublestar.Match`_ pattern matches. If the pattern refers to a source file,                          |
 | Gazelle won't include it in any rules. If the pattern refers to a directory,                          |
 | Gazelle won't recurse into it.                                                                        |
 |                                                                                                       |
@@ -530,7 +530,7 @@ The following directives are recognized:
 | :direc:`# gazelle:exclude pattern`                | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
 | Prevents Gazelle from processing a file or directory if the given                          |
-| `doublestar.PathMatch`_ pattern matches. If the pattern refers to a source file,           |
+| `doublestar.Match`_ pattern matches. If the pattern refers to a source file,               |
 | Gazelle won't include it in any rules. If the pattern refers to a directory,               |
 | Gazelle won't recurse into it. This directive may be repeated to exclude                   |
 | multiple patterns, one per line.                                                           |

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Gazelle build file generator
 .. _update: #fix-and-update
 .. _Avoiding conflicts with proto rules: https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#avoiding-conflicts
 .. _gazelle rule: #bazel-rule
+.. _doublestar.PathMatch: https://github.com/bmatcuk/doublestar#pathmatch
 .. _Extending Gazelle: extend.rst
 .. _Supported languages: extend.rst#supported-languages
 .. _extended: `Extending Gazelle`_
@@ -301,14 +302,15 @@ The following flags are accepted:
 | Bazel may still filter sources with these tags. Use                                                   |
 | ``bazel build --define gotags=foo,bar`` to set tags at build time.                                    |
 +--------------------------------------------------------------+----------------------------------------+
-| :flag:`-exclude path`                                        |                                        |
+| :flag:`-exclude pattern`                                     |                                        |
 +--------------------------------------------------------------+----------------------------------------+
-| Prevents Gazelle from processing a file or directory. If the path refers to                           |
-| a source file, Gazelle won't include it in any rules. If the path refers to                           |
-| a directory, Gazelle won't recurse into it.                                                           |
+| Prevents Gazelle from processing a file or directory if the given                                     |
+| `doublestar.PathMatch`_ pattern matches. If the pattern refers to a source file,                      |
+| Gazelle won't include it in any rules. If the pattern refers to a directory,                          |
+| Gazelle won't recurse into it.                                                                        |
 |                                                                                                       |
-| This option may be repeated. Paths must be slash-separated, relative to the                           |
-| repository root. This is equivalent to the ``# gazelle:exclude path``                                 |
+| This option may be repeated. Patterns must be slash-separated, relative to the                        |
+| repository root. This is equivalent to the ``# gazelle:exclude pattern``                              |
 | directive.                                                                                            |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-external external|vendored`                          | :value:`external`                      |
@@ -525,14 +527,13 @@ The following directives are recognized:
 | Bazel may still filter sources with these tags. Use                                        |
 | ``bazel build --define gotags=foo,bar`` to set tags at build time.                         |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:exclude path`                   | n/a                                    |
+| :direc:`# gazelle:exclude pattern`                | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
-| Prevents Gazelle from processing a file or directory. If the path refers to                |
-| a source file, Gazelle won't include it in any rules. If the path refers to                |
-| a directory, Gazelle won't recurse into it. The path may refer to something                |
-| withinin a subdirectory, for example, a testdata directory somewhere in a                  |
-| vendor tree. This directive may be repeated to exclude multiple paths, one                 |
-| per line.                                                                                  |
+| Prevents Gazelle from processing a file or directory if the given                          |
+| `doublestar.PathMatch`_ pattern matches. If the pattern refers to a source file,           |
+| Gazelle won't include it in any rules. If the pattern refers to a directory,               |
+| Gazelle won't recurse into it. This directive may be repeated to exclude                   |
+| multiple patterns, one per line.                                                           |
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:follow path`                    | n/a                                    |
 +---------------------------------------------------+----------------------------------------+

--- a/deps.bzl
+++ b/deps.bzl
@@ -134,6 +134,14 @@ def gazelle_dependencies(
         version = "v1.0.0",
     )
 
+    _maybe(
+        go_repository,
+        name = "com_github_bmatcuk_doublestar",
+        importpath = "github.com/bmatcuk/doublestar",
+        sum = "h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=",
+        version = "v1.2.2",
+    )
+
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/bazelbuild/buildtools v0.0.0-20190731111112-f720930ceb60
 	github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab
+	github.com/bmatcuk/doublestar v1.2.2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bazelbuild/buildtools v0.0.0-20190731111112-f720930ceb60 h1:OfyUN/Msd
 github.com/bazelbuild/buildtools v0.0.0-20190731111112-f720930ceb60/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab h1:wzbawlkLtl2ze9w/312NHZ84c7kpUCtlkD8HgFY27sw=
 github.com/bazelbuild/rules_go v0.0.0-20190719190356-6dae44dc5cab/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
+github.com/bmatcuk/doublestar v1.2.2 h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=
+github.com/bmatcuk/doublestar v1.2.2/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/vendor/github.com/bmatcuk/doublestar/.gitignore
+++ b/vendor/github.com/bmatcuk/doublestar/.gitignore
@@ -1,0 +1,32 @@
+# vi
+*~
+*.swp
+*.swo
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# test directory
+test/

--- a/vendor/github.com/bmatcuk/doublestar/.travis.yml
+++ b/vendor/github.com/bmatcuk/doublestar/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - 1.11
+  - 1.12
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+

--- a/vendor/github.com/bmatcuk/doublestar/LICENSE
+++ b/vendor/github.com/bmatcuk/doublestar/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Bob Matcuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/bmatcuk/doublestar/README.md
+++ b/vendor/github.com/bmatcuk/doublestar/README.md
@@ -1,0 +1,109 @@
+![Release](https://img.shields.io/github/release/bmatcuk/doublestar.svg?branch=master)
+[![Build Status](https://travis-ci.org/bmatcuk/doublestar.svg?branch=master)](https://travis-ci.org/bmatcuk/doublestar)
+[![codecov.io](https://img.shields.io/codecov/c/github/bmatcuk/doublestar.svg?branch=master)](https://codecov.io/github/bmatcuk/doublestar?branch=master)
+
+# doublestar
+
+**doublestar** is a [golang](http://golang.org/) implementation of path pattern
+matching and globbing with support for "doublestar" (aka globstar: `**`)
+patterns.
+
+doublestar patterns match files and directories recursively. For example, if
+you had the following directory structure:
+
+```
+grandparent
+`-- parent
+    |-- child1
+    `-- child2
+```
+
+You could find the children with patterns such as: `**/child*`,
+`grandparent/**/child?`, `**/parent/*`, or even just `**` by itself (which will
+return all files and directories recursively).
+
+Bash's globstar is doublestar's inspiration and, as such, works similarly.
+Note that the doublestar must appear as a path component by itself. A pattern
+such as `/path**` is invalid and will be treated the same as `/path*`, but
+`/path*/**` should achieve the desired result. Additionally, `/path/**` will
+match all directories and files under the path directory, but `/path/**/` will
+only match directories.
+
+## Installation
+
+**doublestar** can be installed via `go get`:
+
+```bash
+go get github.com/bmatcuk/doublestar
+```
+
+To use it in your code, you must import it:
+
+```go
+import "github.com/bmatcuk/doublestar"
+```
+
+## Functions
+
+### Match
+```go
+func Match(pattern, name string) (bool, error)
+```
+
+Match returns true if `name` matches the file name `pattern`
+([see below](#patterns)). `name` and `pattern` are split on forward slash (`/`)
+characters and may be relative or absolute.
+
+Note: `Match()` is meant to be a drop-in replacement for `path.Match()`. As
+such, it always uses `/` as the path separator. If you are writing code that
+will run on systems where `/` is not the path separator (such as Windows), you
+want to use `PathMatch()` (below) instead.
+
+
+### PathMatch
+```go
+func PathMatch(pattern, name string) (bool, error)
+```
+
+PathMatch returns true  if `name` matches the file name `pattern`
+([see below](#patterns)). The difference between Match and PathMatch is that
+PathMatch will automatically use your system's path separator to split `name`
+and `pattern`.
+
+`PathMatch()` is meant to be a drop-in replacement for `filepath.Match()`.
+
+### Glob
+```go
+func Glob(pattern string) ([]string, error)
+```
+
+Glob finds all files and directories in the filesystem that match `pattern`
+([see below](#patterns)). `pattern` may be relative (to the current working
+directory), or absolute.
+
+`Glob()` is meant to be a drop-in replacement for `filepath.Glob()`.
+
+## Patterns
+
+**doublestar** supports the following special terms in the patterns:
+
+Special Terms | Meaning
+------------- | -------
+`*`           | matches any sequence of non-path-separators
+`**`          | matches any sequence of characters, including path separators
+`?`           | matches any single non-path-separator character
+`[class]`     | matches any single non-path-separator character against a class of characters ([see below](#character-classes))
+`{alt1,...}`  | matches a sequence of characters if one of the comma-separated alternatives matches
+
+Any character with a special meaning can be escaped with a backslash (`\`).
+
+### Character Classes
+
+Character classes support the following:
+
+Class      | Meaning
+---------- | -------
+`[abc]`    | matches any single character within the set
+`[a-z]`    | matches any single character in the range
+`[^class]` | matches any single character which does *not* match the class
+

--- a/vendor/github.com/bmatcuk/doublestar/doublestar.go
+++ b/vendor/github.com/bmatcuk/doublestar/doublestar.go
@@ -1,0 +1,628 @@
+package doublestar
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+// ErrBadPattern indicates a pattern was malformed.
+var ErrBadPattern = path.ErrBadPattern
+
+// Split a path on the given separator, respecting escaping.
+func splitPathOnSeparator(path string, separator rune) (ret []string) {
+	idx := 0
+	if separator == '\\' {
+		// if the separator is '\\', then we can just split...
+		ret = strings.Split(path, string(separator))
+		idx = len(ret)
+	} else {
+		// otherwise, we need to be careful of situations where the separator was escaped
+		cnt := strings.Count(path, string(separator))
+		if cnt == 0 {
+			return []string{path}
+		}
+
+		ret = make([]string, cnt+1)
+		pathlen := len(path)
+		separatorLen := utf8.RuneLen(separator)
+		emptyEnd := false
+		for start := 0; start < pathlen; {
+			end := indexRuneWithEscaping(path[start:], separator)
+			if end == -1 {
+				emptyEnd = false
+				end = pathlen
+			} else {
+				emptyEnd = true
+				end += start
+			}
+			ret[idx] = path[start:end]
+			start = end + separatorLen
+			idx++
+		}
+
+		// If the last rune is a path separator, we need to append an empty string to
+		// represent the last, empty path component. By default, the strings from
+		// make([]string, ...) will be empty, so we just need to icrement the count
+		if emptyEnd {
+			idx++
+		}
+	}
+
+	return ret[:idx]
+}
+
+// Find the first index of a rune in a string,
+// ignoring any times the rune is escaped using "\".
+func indexRuneWithEscaping(s string, r rune) int {
+	end := strings.IndexRune(s, r)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		start := end + utf8.RuneLen(r)
+		end = indexRuneWithEscaping(s[start:], r)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
+}
+
+// Find the last index of a rune in a string,
+// ignoring any times the rune is escaped using "\".
+func lastIndexRuneWithEscaping(s string, r rune) int {
+	end := strings.LastIndex(s, string(r))
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		end = lastIndexRuneWithEscaping(s[:end-1], r)
+	}
+	return end
+}
+
+// Find the index of the first instance of one of the unicode characters in
+// chars, ignoring any times those characters are escaped using "\".
+func indexAnyWithEscaping(s, chars string) int {
+	end := strings.IndexAny(s, chars)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		_, adj := utf8.DecodeRuneInString(s[end:])
+		start := end + adj
+		end = indexAnyWithEscaping(s[start:], chars)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
+}
+
+// Split a set of alternatives such as {alt1,alt2,...} and returns the index of
+// the rune after the closing curly brace. Respects nested alternatives and
+// escaped runes.
+func splitAlternatives(s string) (ret []string, idx int) {
+	ret = make([]string, 0, 2)
+	idx = 0
+	slen := len(s)
+	braceCnt := 1
+	esc := false
+	start := 0
+	for braceCnt > 0 {
+		if idx >= slen {
+			return nil, -1
+		}
+
+		sRune, adj := utf8.DecodeRuneInString(s[idx:])
+		if esc {
+			esc = false
+		} else if sRune == '\\' {
+			esc = true
+		} else if sRune == '{' {
+			braceCnt++
+		} else if sRune == '}' {
+			braceCnt--
+		} else if sRune == ',' && braceCnt == 1 {
+			ret = append(ret, s[start:idx])
+			start = idx + adj
+		}
+
+		idx += adj
+	}
+	ret = append(ret, s[start:idx-1])
+	return
+}
+
+// Returns true if the pattern is "zero length", meaning
+// it could match zero or more characters.
+func isZeroLengthPattern(pattern string) (ret bool, err error) {
+	// * can match zero
+	if pattern == "" || pattern == "*" || pattern == "**" {
+		return true, nil
+	}
+
+	// an alternative with zero length can match zero, for example {,x} - the
+	// first alternative has zero length
+	r, adj := utf8.DecodeRuneInString(pattern)
+	if r == '{' {
+		options, endOptions := splitAlternatives(pattern[adj:])
+		if endOptions == -1 {
+			return false, ErrBadPattern
+		}
+		if ret, err = isZeroLengthPattern(pattern[adj+endOptions:]); !ret || err != nil {
+			return
+		}
+		for _, o := range options {
+			if ret, err = isZeroLengthPattern(o); ret || err != nil {
+				return
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// Match returns true if name matches the shell file name pattern.
+// The pattern syntax is:
+//
+//  pattern:
+//    { term }
+//  term:
+//    '*'         matches any sequence of non-path-separators
+//    '**'        matches any sequence of characters, including
+//                path separators.
+//    '?'         matches any single non-path-separator character
+//    '[' [ '^' ] { character-range } ']'
+//          character class (must be non-empty)
+//    '{' { term } [ ',' { term } ... ] '}'
+//    c           matches character c (c != '*', '?', '\\', '[')
+//    '\\' c      matches character c
+//
+//  character-range:
+//    c           matches character c (c != '\\', '-', ']')
+//    '\\' c      matches character c
+//    lo '-' hi   matches character c for lo <= c <= hi
+//
+// Match requires pattern to match all of name, not just a substring.
+// The path-separator defaults to the '/' character. The only possible
+// returned error is ErrBadPattern, when pattern is malformed.
+//
+// Note: this is meant as a drop-in replacement for path.Match() which
+// always uses '/' as the path separator. If you want to support systems
+// which use a different path separator (such as Windows), what you want
+// is the PathMatch() function below.
+//
+func Match(pattern, name string) (bool, error) {
+	return matchWithSeparator(pattern, name, '/')
+}
+
+// PathMatch is like Match except that it uses your system's path separator.
+// For most systems, this will be '/'. However, for Windows, it would be '\\'.
+// Note that for systems where the path separator is '\\', escaping is
+// disabled.
+//
+// Note: this is meant as a drop-in replacement for filepath.Match().
+//
+func PathMatch(pattern, name string) (bool, error) {
+	pattern = filepath.ToSlash(pattern)
+	return matchWithSeparator(pattern, name, os.PathSeparator)
+}
+
+// Match returns true if name matches the shell file name pattern.
+// The pattern syntax is:
+//
+//  pattern:
+//    { term }
+//  term:
+//    '*'         matches any sequence of non-path-separators
+//              '**'        matches any sequence of characters, including
+//                          path separators.
+//    '?'         matches any single non-path-separator character
+//    '[' [ '^' ] { character-range } ']'
+//          character class (must be non-empty)
+//    '{' { term } [ ',' { term } ... ] '}'
+//    c           matches character c (c != '*', '?', '\\', '[')
+//    '\\' c      matches character c
+//
+//  character-range:
+//    c           matches character c (c != '\\', '-', ']')
+//    '\\' c      matches character c, unless separator is '\\'
+//    lo '-' hi   matches character c for lo <= c <= hi
+//
+// Match requires pattern to match all of name, not just a substring.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
+func matchWithSeparator(pattern, name string, separator rune) (bool, error) {
+	nameComponents := splitPathOnSeparator(name, separator)
+	return doMatching(pattern, nameComponents)
+}
+
+func doMatching(pattern string, nameComponents []string) (matched bool, err error) {
+	// check for some base-cases
+	patternLen, nameLen := len(pattern), len(nameComponents)
+	if patternLen == 0 && nameLen == 0 {
+		return true, nil
+	}
+	if patternLen == 0 || nameLen == 0 {
+		return false, nil
+	}
+
+	slashIdx := indexRuneWithEscaping(pattern, '/')
+	lastComponent := slashIdx == -1
+	if lastComponent {
+		slashIdx = len(pattern)
+	}
+	if pattern[:slashIdx] == "**" {
+		// if our last pattern component is a doublestar, we're done -
+		// doublestar will match any remaining name components, if any.
+		if lastComponent {
+			return true, nil
+		}
+
+		// otherwise, try matching remaining components
+		for nameIdx := 0; nameIdx < nameLen; nameIdx++ {
+			if m, _ := doMatching(pattern[slashIdx+1:], nameComponents[nameIdx:]); m {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	var matches []string
+	matches, err = matchComponent(pattern, nameComponents[0])
+	if matches == nil || err != nil {
+		return
+	}
+	if len(matches) == 0 && nameLen == 1 {
+		return true, nil
+	}
+
+	if nameLen > 1 {
+		for _, alt := range matches {
+			matched, err = doMatching(alt, nameComponents[1:])
+			if matched || err != nil {
+				return
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// Glob returns the names of all files matching pattern or nil
+// if there is no matching file. The syntax of pattern is the same
+// as in Match. The pattern may describe hierarchical names such as
+// /usr/*/bin/ed (assuming the Separator is '/').
+//
+// Glob ignores file system errors such as I/O errors reading directories.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
+// Your system path separator is automatically used. This means on
+// systems where the separator is '\\' (Windows), escaping will be
+// disabled.
+//
+// Note: this is meant as a drop-in replacement for filepath.Glob().
+//
+func Glob(pattern string) (matches []string, err error) {
+	if len(pattern) == 0 {
+		return nil, nil
+	}
+
+	// if the pattern starts with alternatives, we need to handle that here - the
+	// alternatives may be a mix of relative and absolute
+	if pattern[0] == '{' {
+		options, endOptions := splitAlternatives(pattern[1:])
+		if endOptions == -1 {
+			return nil, ErrBadPattern
+		}
+		for _, o := range options {
+			m, e := Glob(o + pattern[endOptions+1:])
+			if e != nil {
+				return nil, e
+			}
+			matches = append(matches, m...)
+		}
+		return matches, nil
+	}
+
+	// If the pattern is relative or absolute and we're on a non-Windows machine,
+	// volumeName will be an empty string. If it is absolute and we're on a
+	// Windows machine, volumeName will be a drive letter ("C:") for filesystem
+	// paths or \\<server>\<share> for UNC paths.
+	isAbs := filepath.IsAbs(pattern) || pattern[0] == '\\' || pattern[0] == '/'
+	volumeName := filepath.VolumeName(pattern)
+	isWindowsUNC := strings.HasPrefix(volumeName, `\\`)
+	if isWindowsUNC || isAbs {
+		startIdx := len(volumeName) + 1
+		return doGlob(fmt.Sprintf("%s%s", volumeName, string(os.PathSeparator)), filepath.ToSlash(pattern[startIdx:]), matches)
+	}
+
+	// otherwise, it's a relative pattern
+	return doGlob(".", filepath.ToSlash(pattern), matches)
+}
+
+// Perform a glob
+func doGlob(basedir, pattern string, matches []string) (m []string, e error) {
+	m = matches
+	e = nil
+
+	// if the pattern starts with any path components that aren't globbed (ie,
+	// `path/to/glob*`), we can skip over the un-globbed components (`path/to` in
+	// our example).
+	globIdx := indexAnyWithEscaping(pattern, "*?[{\\")
+	if globIdx > 0 {
+		globIdx = lastIndexRuneWithEscaping(pattern[:globIdx], '/')
+	} else if globIdx == -1 {
+		globIdx = lastIndexRuneWithEscaping(pattern, '/')
+	}
+	if globIdx > 0 {
+		basedir = filepath.Join(basedir, pattern[:globIdx])
+		pattern = pattern[globIdx+1:]
+	}
+
+	// Lstat will return an error if the file/directory doesn't exist
+	fi, err := os.Lstat(basedir)
+	if err != nil {
+		return
+	}
+
+	// if the pattern is empty, we've found a match
+	if len(pattern) == 0 {
+		m = append(m, basedir)
+		return
+	}
+
+	// otherwise, we need to check each item in the directory...
+	// first, if basedir is a symlink, follow it...
+	if (fi.Mode() & os.ModeSymlink) != 0 {
+		fi, err = os.Stat(basedir)
+		if err != nil {
+			return
+		}
+	}
+
+	// confirm it's a directory...
+	if !fi.IsDir() {
+		return
+	}
+
+	// read directory
+	dir, err := os.Open(basedir)
+	if err != nil {
+		return
+	}
+	defer dir.Close()
+
+	files, _ := dir.Readdir(-1)
+	slashIdx := indexRuneWithEscaping(pattern, '/')
+	lastComponent := slashIdx == -1
+	if lastComponent {
+		slashIdx = len(pattern)
+	}
+	if pattern[:slashIdx] == "**" {
+		// if the current component is a doublestar, we'll try depth-first
+		for _, file := range files {
+			// if symlink, we may want to follow
+			if (file.Mode() & os.ModeSymlink) != 0 {
+				file, err = os.Stat(filepath.Join(basedir, file.Name()))
+				if err != nil {
+					continue
+				}
+			}
+
+			if file.IsDir() {
+				// recurse into directories
+				if lastComponent {
+					m = append(m, filepath.Join(basedir, file.Name()))
+				}
+				m, e = doGlob(filepath.Join(basedir, file.Name()), pattern, m)
+			} else if lastComponent {
+				// if the pattern's last component is a doublestar, we match filenames, too
+				m = append(m, filepath.Join(basedir, file.Name()))
+			}
+		}
+		if lastComponent {
+			return // we're done
+		}
+
+		pattern = pattern[slashIdx+1:]
+	}
+
+	// check items in current directory and recurse
+	var match []string
+	for _, file := range files {
+		match, e = matchComponent(pattern, file.Name())
+		if e != nil {
+			return
+		}
+		if match != nil {
+			if len(match) == 0 {
+				m = append(m, filepath.Join(basedir, file.Name()))
+			} else {
+				for _, alt := range match {
+					m, e = doGlob(filepath.Join(basedir, file.Name()), alt, m)
+				}
+			}
+		}
+	}
+	return
+}
+
+// Attempt to match a single path component with a pattern. Note that the
+// pattern may include multiple components but that the "name" is just a single
+// path component. The return value is a slice of patterns that should be
+// checked against subsequent path components or nil, indicating that the
+// pattern does not match this path. It is assumed that pattern components are
+// separated by '/'
+func matchComponent(pattern, name string) ([]string, error) {
+	// check for matches one rune at a time
+	patternLen, nameLen := len(pattern), len(name)
+	patIdx, nameIdx := 0, 0
+	for patIdx < patternLen && nameIdx < nameLen {
+		patRune, patAdj := utf8.DecodeRuneInString(pattern[patIdx:])
+		nameRune, nameAdj := utf8.DecodeRuneInString(name[nameIdx:])
+		if patRune == '/' {
+			patIdx++
+			break
+		} else if patRune == '\\' {
+			// handle escaped runes, only if separator isn't '\\'
+			patIdx += patAdj
+			patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:])
+			if patRune == utf8.RuneError {
+				return nil, ErrBadPattern
+			} else if patRune == nameRune {
+				patIdx += patAdj
+				nameIdx += nameAdj
+			} else {
+				return nil, nil
+			}
+		} else if patRune == '*' {
+			// handle stars - a star at the end of the pattern or before a separator
+			// will always match the rest of the path component
+			if patIdx += patAdj; patIdx >= patternLen {
+				return []string{}, nil
+			}
+			if patRune, patAdj = utf8.DecodeRuneInString(pattern[patIdx:]); patRune == '/' {
+				return []string{pattern[patIdx+patAdj:]}, nil
+			}
+
+			// check if we can make any matches
+			for ; nameIdx < nameLen; nameIdx += nameAdj {
+				if m, e := matchComponent(pattern[patIdx:], name[nameIdx:]); m != nil || e != nil {
+					return m, e
+				}
+			}
+			return nil, nil
+		} else if patRune == '[' {
+			// handle character sets
+			patIdx += patAdj
+			endClass := indexRuneWithEscaping(pattern[patIdx:], ']')
+			if endClass == -1 {
+				return nil, ErrBadPattern
+			}
+			endClass += patIdx
+			classRunes := []rune(pattern[patIdx:endClass])
+			classRunesLen := len(classRunes)
+			if classRunesLen > 0 {
+				classIdx := 0
+				matchClass := false
+				if classRunes[0] == '^' {
+					classIdx++
+				}
+				for classIdx < classRunesLen {
+					low := classRunes[classIdx]
+					if low == '-' {
+						return nil, ErrBadPattern
+					}
+					classIdx++
+					if low == '\\' {
+						if classIdx < classRunesLen {
+							low = classRunes[classIdx]
+							classIdx++
+						} else {
+							return nil, ErrBadPattern
+						}
+					}
+					high := low
+					if classIdx < classRunesLen && classRunes[classIdx] == '-' {
+						// we have a range of runes
+						if classIdx++; classIdx >= classRunesLen {
+							return nil, ErrBadPattern
+						}
+						high = classRunes[classIdx]
+						if high == '-' {
+							return nil, ErrBadPattern
+						}
+						classIdx++
+						if high == '\\' {
+							if classIdx < classRunesLen {
+								high = classRunes[classIdx]
+								classIdx++
+							} else {
+								return nil, ErrBadPattern
+							}
+						}
+					}
+					if low <= nameRune && nameRune <= high {
+						matchClass = true
+					}
+				}
+				if matchClass == (classRunes[0] == '^') {
+					return nil, nil
+				}
+			} else {
+				return nil, ErrBadPattern
+			}
+			patIdx = endClass + 1
+			nameIdx += nameAdj
+		} else if patRune == '{' {
+			// handle alternatives such as {alt1,alt2,...}
+			patIdx += patAdj
+			options, endOptions := splitAlternatives(pattern[patIdx:])
+			if endOptions == -1 {
+				return nil, ErrBadPattern
+			}
+			patIdx += endOptions
+
+			results := make([][]string, 0, len(options))
+			totalResults := 0
+			for _, o := range options {
+				m, e := matchComponent(o+pattern[patIdx:], name[nameIdx:])
+				if e != nil {
+					return nil, e
+				}
+				if m != nil {
+					results = append(results, m)
+					totalResults += len(m)
+				}
+			}
+			if len(results) > 0 {
+				lst := make([]string, 0, totalResults)
+				for _, m := range results {
+					lst = append(lst, m...)
+				}
+				return lst, nil
+			}
+
+			return nil, nil
+		} else if patRune == '?' || patRune == nameRune {
+			// handle single-rune wildcard
+			patIdx += patAdj
+			nameIdx += nameAdj
+		} else {
+			return nil, nil
+		}
+	}
+	if nameIdx >= nameLen {
+		if patIdx >= patternLen {
+			return []string{}, nil
+		}
+
+		pattern = pattern[patIdx:]
+		slashIdx := indexRuneWithEscaping(pattern, '/')
+		testPattern := pattern
+		if slashIdx >= 0 {
+			testPattern = pattern[:slashIdx]
+		}
+
+		zeroLength, err := isZeroLengthPattern(testPattern)
+		if err != nil {
+			return nil, err
+		}
+		if zeroLength {
+			if slashIdx == -1 {
+				return []string{}, nil
+			} else {
+				return []string{pattern[slashIdx+1:]}, nil
+			}
+		}
+	}
+	return nil, nil
+}

--- a/vendor/github.com/bmatcuk/doublestar/go.mod
+++ b/vendor/github.com/bmatcuk/doublestar/go.mod
@@ -1,0 +1,3 @@
+module github.com/bmatcuk/doublestar
+
+go 1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,6 +5,8 @@ github.com/bazelbuild/buildtools/tables
 github.com/bazelbuild/rules_go/go/tools/bazel
 github.com/bazelbuild/rules_go/go/tools/bazel_testing
 github.com/bazelbuild/rules_go/go/tools/internal/txtar
+# github.com/bmatcuk/doublestar v1.2.2
+github.com/bmatcuk/doublestar
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/pelletier/go-toml v1.2.0

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//flag:go_default_library",
         "//pathtools:go_default_library",
         "//rule:go_default_library",
+        "@com_github_bmatcuk_doublestar//:go_default_library",
     ],
 )
 

--- a/walk/config.go
+++ b/walk/config.go
@@ -51,8 +51,11 @@ func (wc *walkConfig) isExcluded(rel, base string) bool {
 	for _, x := range wc.excludes {
 		matched, err := doublestar.Match(x, f)
 		if err != nil {
-			log.Printf("error running doublestar.PathMatch(%q, %q): %s", x, f, err)
-			continue
+			// doublestar.Match returns only one possible error, and only if the
+			// pattern is not valid. During the configuration of the walker (see
+			// Configure below), we discard any invalid pattern and thus an error
+			// here should not be possible.
+			log.Panicf("error during doublestar.Match. This should not happen, please file an issue https://github.com/bazelbuild/bazel-gazelle/issues/new: %s", err)
 		}
 		if matched {
 			return true
@@ -75,7 +78,7 @@ func (_ *Configurer) KnownDirectives() []string {
 	return []string{"exclude", "follow", "ignore"}
 }
 
-func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
+func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	wc := getWalkConfig(c)
 	wcCopy := &walkConfig{}
 	*wcCopy = *wc
@@ -85,6 +88,10 @@ func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 		for _, d := range f.Directives {
 			switch d.Key {
 			case "exclude":
+				if err := checkPathMatchPattern(path.Join(rel, d.Value)); err != nil {
+					log.Printf("the exclusion pattern is not valid %q: %s", path.Join(rel, d.Value), err)
+					continue
+				}
 				wcCopy.excludes = append(wcCopy.excludes, path.Join(rel, d.Value))
 			case "follow":
 				wcCopy.follow = append(wcCopy.follow, path.Join(rel, d.Value))
@@ -95,4 +102,9 @@ func (_ *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	}
 
 	c.Exts[walkName] = wcCopy
+}
+
+func checkPathMatchPattern(pattern string) error {
+	_, err := doublestar.Match(pattern, "x")
+	return err
 }

--- a/walk/config.go
+++ b/walk/config.go
@@ -69,7 +69,7 @@ type Configurer struct{}
 func (_ *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	wc := &walkConfig{}
 	c.Exts[walkName] = wc
-	fs.Var(&gzflag.MultiFlag{Values: &wc.excludes}, "exclude", "path.Match pattern that should be ignored (may be repeated)")
+	fs.Var(&gzflag.MultiFlag{Values: &wc.excludes}, "exclude", "pattern that should be ignored (may be repeated)")
 }
 
 func (_ *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }

--- a/walk/config.go
+++ b/walk/config.go
@@ -49,7 +49,7 @@ func (wc *walkConfig) isExcluded(rel, base string) bool {
 	}
 	f := path.Join(rel, base)
 	for _, x := range wc.excludes {
-		matched, err := doublestar.PathMatch(x, f)
+		matched, err := doublestar.Match(x, f)
 		if err != nil {
 			log.Printf("error running doublestar.PathMatch(%q, %q): %s", x, f, err)
 			continue

--- a/walk/config_test.go
+++ b/walk/config_test.go
@@ -1,0 +1,28 @@
+package walk
+
+import (
+	"testing"
+
+	"github.com/bmatcuk/doublestar"
+)
+
+func TestCheckPathMatchPattern(t *testing.T) {
+	testCases := []struct {
+		pattern string
+		err     error
+	}{
+
+		{pattern: "*.pb.go", err: nil},
+		{pattern: "**/*.pb.go", err: nil},
+		{pattern: "**/*.pb.go", err: nil},
+		{pattern: "[]a]", err: doublestar.ErrBadPattern},
+		{pattern: "[a-]", err: doublestar.ErrBadPattern},
+		{pattern: "[c-", err: doublestar.ErrBadPattern},
+	}
+
+	for _, testCase := range testCases {
+		if want, got := testCase.err, checkPathMatchPattern(testCase.pattern); want != got {
+			t.Errorf("checkPathMatchPattern %q: got %q want %q", testCase.pattern, got, want)
+		}
+	}
+}

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -185,15 +185,16 @@ gen(
 		{Path: "a/a.proto"},  // not ignored
 		{Path: "a/b.gen.go"}, // not ignored
 
-		{Path: "a.gen.go"},    // ignored by '*.gen.go'
-		{Path: "a.go"},        // ignored by 'a.go'
-		{Path: "a.pb.go"},     // ignored by '**/*.pb.go'
-		{Path: "a/a.pb.go"},   // ignored by '**/*.pb.go'
-		{Path: "a/b/a.pb.go"}, // ignored by '**/*.pb.go'
-		{Path: "c/x/b/foo"},   // ignored by 'c/**/b'
-		{Path: "c/x/y/b/bar"}, // ignored by 'c/**/b'
-		{Path: "ign/bad"},     // ignored by 'ign'
-		{Path: "sub/b.go"},    // ignored by 'sub/b.go'
+		{Path: "a.gen.go"},        // ignored by '*.gen.go'
+		{Path: "a.go"},            // ignored by 'a.go'
+		{Path: "a.pb.go"},         // ignored by '**/*.pb.go'
+		{Path: "a/a.pb.go"},       // ignored by '**/*.pb.go'
+		{Path: "a/b/a.pb.go"},     // ignored by '**/*.pb.go'
+		{Path: "c/x/b/foo"},       // ignored by 'c/**/b'
+		{Path: "c/x/y/b/bar"},     // ignored by 'c/**/b'
+		{Path: "c/x/y/b/foo/bar"}, // ignored by 'c/**/b'
+		{Path: "ign/bad"},         // ignored by 'ign'
+		{Path: "sub/b.go"},        // ignored by 'sub/b.go'
 	})
 	defer cleanup()
 

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -169,6 +169,7 @@ func TestExcludeFiles(t *testing.T) {
 # gazelle:exclude **/*.pb.go
 # gazelle:exclude *.gen.go
 # gazelle:exclude a.go
+# gazelle:exclude c/**/b
 # gazelle:exclude gen
 # gazelle:exclude ign
 # gazelle:exclude sub/b.go
@@ -187,9 +188,11 @@ gen(
 		{Path: "a.gen.go"},    // ignored by '*.gen.go'
 		{Path: "a.go"},        // ignored by 'a.go'
 		{Path: "a.pb.go"},     // ignored by '**/*.pb.go'
-		{Path: "ign/bad"},     // ignored by 'ign'
 		{Path: "a/a.pb.go"},   // ignored by '**/*.pb.go'
 		{Path: "a/b/a.pb.go"}, // ignored by '**/*.pb.go'
+		{Path: "c/x/b/foo"},   // ignored by 'c/**/b'
+		{Path: "c/x/y/b/bar"}, // ignored by 'c/**/b'
+		{Path: "ign/bad"},     // ignored by 'ign'
 		{Path: "sub/b.go"},    // ignored by 'sub/b.go'
 	})
 	defer cleanup()


### PR DESCRIPTION
To make editors happy we generate the equivalent `.pb.go` for all `go_proto_library` targets, the `.gen.go` for all `go_embed_data` and then create a symbolic link to those files from Bazel's sandbox back to the source code. I'm pretty that's not the best approach, but it has worked for months. However, there's an issue with Gazelle where it tries to add these files to the target. It happens randomly as most of the time it ignores them, but I've noticed it happens mostly if the symlink got broken (bazel clean or other reason).

This pull request allows us to ignore files based on [path.Match](https://pkg.go.dev/path?tab=doc#Match) pattern relative location in the repository.

closes #750 