### PR TITLE
update-repos: fix build_tags emitting

### DIFF
--- a/language/go/kinds.go
+++ b/language/go/kinds.go
@@ -89,6 +89,7 @@ var goKinds = map[string]rule.KindInfo{
 		},
 		MergeableAttrs: map[string]bool{
 			"commit":       true,
+			"build_tags":   true,
 			"importpath":   true,
 			"remote":       true,
 			"replace":      true,

--- a/language/go/update.go
+++ b/language/go/update.go
@@ -99,7 +99,8 @@ func setBuildAttrs(gc *goConfig, r *rule.Rule) {
 		r.SetAttr("build_file_generation", gc.buildFileGenerationAttr)
 	}
 	if gc.buildTagsAttr != "" {
-		r.SetAttr("build_tags", gc.buildTagsAttr)
+		buildTags := strings.Split(gc.buildTagsAttr, ",")
+		r.SetAttr("build_tags", buildTags)
 	}
 	if gc.buildFileProtoModeAttr != "" {
 		r.SetAttr("build_file_proto_mode", gc.buildFileProtoModeAttr)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

It fixes `update-repos -build_tags`. It fixes #711 which caused the tags not to be emitted correctly when generating `go_repository` rules, and also drive-by fixes the `build_tags` attribute of said rules to merge correctly (ie. across subsequent `update-repos` calls).

**Which issues(s) does this PR fix?**

Fixes #711
