### PR TITLE
config: add configuration for selecting languages to process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -390,6 +390,12 @@ The following flags are accepted:
 |                                                                                                       |
 | Gazelle will not process packages outside this directory.                                             |
 +--------------------------------------------------------------+----------------------------------------+
+| :flag:`-lang lang1,lang2,...`                                | :value:`""`                            |
++--------------------------------------------------------------+----------------------------------------+
+| Selects languages for which to compose rules.                                                         |
+|                                                                                                       |
+| By default, all languages that this Gazelle was built with are processed.                             |
++--------------------------------------------------------------+----------------------------------------+
 .. _Predefined plugins: https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#predefined-plugins
 
 ``update-repos``
@@ -705,6 +711,11 @@ The following directives are recognized:
 | By default, internal packages are only visible to its siblings. This directive adds a label|
 | internal packages should be visible to additionally. This directive can be used several    |
 | times, adding a list of labels.                                                            |
++---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:lang lang1,lang2,...`           | n/a                                    |
++---------------------------------------------------+----------------------------------------+
+| Sets the language selection flag for this and descendent packages, which gazelle to        |
+| process just the languages named in this directive.
 +---------------------------------------------------+----------------------------------------+
 
 Gazelle also reads directives from the WORKSPACE file. They may be used to

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -285,7 +285,7 @@ func runFixUpdate(cmd command, args []string) (err error) {
 
 		// Fix any problems in the file.
 		if f != nil {
-			for _, l := range languages {
+			for _, l := range filterLanguages(c, languages) {
 				l.Fix(c, f)
 			}
 		}
@@ -293,7 +293,7 @@ func runFixUpdate(cmd command, args []string) (err error) {
 		// Generate rules.
 		var empty, gen []*rule.Rule
 		var imports []interface{}
-		for _, l := range languages {
+		for _, l := range filterLanguages(c, languages) {
 			res := l.GenerateRules(language.GenerateArgs{
 				Config:       c,
 				Dir:          dir,

--- a/cmd/gazelle/gazelle.go
+++ b/cmd/gazelle/gazelle.go
@@ -22,6 +22,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
 )
 
 type command int
@@ -121,4 +124,29 @@ without notice.
 
 `)
 	return flag.ErrHelp
+}
+
+// filterLanguages returns the subset of input languages that pass the config's
+// filter, if any. Gazelle should not generate rules for languages not returned.
+func filterLanguages(c *config.Config, langs []language.Language) []language.Language {
+	if len(c.Langs) == 0 {
+		return langs
+	}
+
+	var result []language.Language
+	for _, inputLang := range langs {
+		if containsLang(c.Langs, inputLang) {
+			result = append(result, inputLang)
+		}
+	}
+	return result
+}
+
+func containsLang(langNames []string, lang language.Language) bool {
+	for _, langName := range langNames {
+		if langName == lang.Name() {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -155,7 +155,7 @@ func updateRepos(args []string) (err error) {
 	}()
 
 	// Fix the workspace file with each language.
-	for _, lang := range languages {
+	for _, lang := range filterLanguages(c, languages) {
 		lang.Fix(c, uc.workspace)
 	}
 
@@ -339,7 +339,7 @@ func updateRepoImports(c *config.Config, rc *repo.RemoteCache) (gen []*rule.Rule
 	// For now, only use the first language that implements the interface.
 	uc := getUpdateReposConfig(c)
 	var updater language.RepoUpdater
-	for _, lang := range languages {
+	for _, lang := range filterLanguages(c, languages) {
 		if u, ok := lang.(language.RepoUpdater); ok {
 			updater = u
 			break
@@ -360,7 +360,7 @@ func importRepos(c *config.Config, rc *repo.RemoteCache) (gen, empty []*rule.Rul
 	uc := getUpdateReposConfig(c)
 	importSupported := false
 	var importer language.RepoImporter
-	for _, lang := range languages {
+	for _, lang := range filterLanguages(c, languages) {
 		if i, ok := lang.(language.RepoImporter); ok {
 			importSupported = true
 			if i.CanImport(uc.repoFilePath) {

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,10 @@ type Config struct {
 	// generation and dependency resolution.
 	Repos []*rule.Rule
 
+	// Langs is a list of language names which Gazelle should process.
+	// An empty list means "all languages".
+	Langs []string
+
 	// Exts is a set of configurable extensions. Generally, each language
 	// has its own set of extensions, but other modules may provide their own
 	// extensions as well. Values in here may be populated by command line
@@ -177,6 +181,7 @@ type Configurer interface {
 type CommonConfigurer struct {
 	repoRoot, buildFileNames, readBuildFilesDir, writeBuildFilesDir string
 	indexLibraries                                                  bool
+	langCsv                                                         string
 }
 
 func (cc *CommonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *Config) {
@@ -185,6 +190,7 @@ func (cc *CommonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *Confi
 	fs.BoolVar(&cc.indexLibraries, "index", true, "when true, gazelle will build an index of libraries in the workspace for dependency resolution")
 	fs.StringVar(&cc.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
 	fs.StringVar(&cc.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
+	fs.StringVar(&cc.langCsv, "lang", "", "if non-empty, process only these languages (e.g. \"go,proto\")")
 }
 
 func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
@@ -217,11 +223,14 @@ func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
 		}
 	}
 	c.IndexLibraries = cc.indexLibraries
+	if len(cc.langCsv) > 0 {
+		c.Langs = strings.Split(cc.langCsv, ",")
+	}
 	return nil
 }
 
 func (cc *CommonConfigurer) KnownDirectives() []string {
-	return []string{"build_file_name", "map_kind"}
+	return []string{"build_file_name", "map_kind", "lang"}
 }
 
 func (cc *CommonConfigurer) Configure(c *Config, rel string, f *rule.File) {
@@ -246,6 +255,13 @@ func (cc *CommonConfigurer) Configure(c *Config, rel string, f *rule.File) {
 				FromKind: vals[0],
 				KindName: vals[1],
 				KindLoad: vals[2],
+			}
+
+		case "lang":
+			if len(d.Value) > 0 {
+				c.Langs = strings.Split(d.Value, ",")
+			} else {
+				c.Langs = nil
 			}
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,7 @@ func TestCommonConfigurerFlags(t *testing.T) {
 	cc := &CommonConfigurer{}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cc.RegisterFlags(fs, "test", c)
-	args := []string{"-repo_root", dir, "-build_file_name", "x,y"}
+	args := []string{"-repo_root", dir, "-build_file_name", "x,y", "-lang", "go"}
 	if err := fs.Parse(args); err != nil {
 		t.Fatal(err)
 	}
@@ -60,12 +60,18 @@ func TestCommonConfigurerFlags(t *testing.T) {
 	if !reflect.DeepEqual(c.ValidBuildFileNames, wantBuildFileNames) {
 		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, wantBuildFileNames)
 	}
+
+	wantLangs := []string{"go"}
+	if !reflect.DeepEqual(c.Langs, wantLangs) {
+		t.Errorf("for Langs, got %#v, want %#v", c.Langs, wantLangs)
+	}
 }
 
 func TestCommonConfigurerDirectives(t *testing.T) {
 	c := New()
 	cc := &CommonConfigurer{}
-	buildData := []byte(`# gazelle:build_file_name x,y`)
+	buildData := []byte(`# gazelle:build_file_name x,y
+# gazelle:lang go`)
 	f, err := rule.LoadData(filepath.Join("test", "BUILD.bazel"), "", buildData)
 	if err != nil {
 		t.Fatal(err)
@@ -74,5 +80,10 @@ func TestCommonConfigurerDirectives(t *testing.T) {
 	want := []string{"x", "y"}
 	if !reflect.DeepEqual(c.ValidBuildFileNames, want) {
 		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, want)
+	}
+
+	wantLangs := []string{"go"}
+	if !reflect.DeepEqual(c.Langs, wantLangs) {
+		t.Errorf("for Langs, got %#v, want %#v", c.Langs, wantLangs)
 	}
 }


### PR DESCRIPTION
This adds a `-lang` flag and `gazelle:lang` directive to restrict the languages
composed by Gazelle.

Fixes #687
