### PR TITLE
Excluding consumed generated files from proto_library

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -41,13 +41,29 @@ func (_ *protoLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 			regularProtoFiles = append(regularProtoFiles, name)
 		}
 	}
-	var genProtoFiles []string
+
+	// Some of the generated files may have been consumed by other rules
+	consumedFileSet := make(map[string]bool)
+	for _, r := range args.OtherGen {
+		for _, f := range r.AttrStrings("srcs") {
+			consumedFileSet[f] = true
+		}
+		if f := r.AttrString("src"); f != "" {
+			consumedFileSet[f] = true
+		}
+	}
+	var (
+		genProtoFiles, genProtoFilesNotConsumed []string
+	)
 	for _, name := range args.GenFiles {
 		if strings.HasSuffix(name, ".proto") {
 			genProtoFiles = append(genProtoFiles, name)
+			if !consumedFileSet[name] {
+				genProtoFilesNotConsumed = append(genProtoFilesNotConsumed, name)
+			}
 		}
 	}
-	pkgs := buildPackages(pc, args.Dir, args.Rel, regularProtoFiles, genProtoFiles)
+	pkgs := buildPackages(pc, args.Dir, args.Rel, regularProtoFiles, genProtoFilesNotConsumed)
 	shouldSetVisibility := args.File == nil || !args.File.HasDefaultVisibility()
 	var res language.GenerateResult
 	for _, pkg := range pkgs {

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -52,13 +52,12 @@ func (_ *protoLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 			consumedFileSet[f] = true
 		}
 	}
-	var (
-		// genProtoFilesNotConsumed represents only not consumed generetad files.
-		// genProtoFiles represents all generated files.
-		// This is required for not generating empty rules for consumed generated
-		// files.
-		genProtoFiles, genProtoFilesNotConsumed []string
-	)
+
+	// genProtoFilesNotConsumed represents only not consumed generetad files.
+	// genProtoFiles represents all generated files.
+	// This is required for not generating empty rules for consumed generated
+	// files.
+	var genProtoFiles, genProtoFilesNotConsumed []string
 	for _, name := range args.GenFiles {
 		if strings.HasSuffix(name, ".proto") {
 			genProtoFiles = append(genProtoFiles, name)

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -45,6 +45,9 @@ func (_ *protoLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 	// Some of the generated files may have been consumed by other rules
 	consumedFileSet := make(map[string]bool)
 	for _, r := range args.OtherGen {
+		if r.Kind() != "proto_library" {
+			continue
+		}
 		for _, f := range r.AttrStrings("srcs") {
 			consumedFileSet[f] = true
 		}

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -51,11 +51,12 @@ func (_ *protoLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 		for _, f := range r.AttrStrings("srcs") {
 			consumedFileSet[f] = true
 		}
-		if f := r.AttrString("src"); f != "" {
-			consumedFileSet[f] = true
-		}
 	}
 	var (
+		// genProtoFilesNotConsumed represents only not consumed generetad files.
+		// genProtoFiles represents all generated files.
+		// This is required for not generating empty rules for consumed generated
+		// files.
 		genProtoFiles, genProtoFilesNotConsumed []string
 	)
 	for _, name := range args.GenFiles {

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -192,6 +192,15 @@ func TestGeneratePackage(t *testing.T) {
 // Test generated files that have been consumed by other rules should not be
 // added to the  rule
 func TestConsumedGenFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// TODO(jayconrod): set up testdata directory on windows before running test
+		if _, err := os.Stat("testdata"); os.IsNotExist(err) {
+			t.Skip("testdata missing on windows due to lack of symbolic links")
+		} else if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	oldContent := []byte(`
 proto_library(
     name = "existing_gen_proto",

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -213,19 +213,19 @@ proto_library(
 	c, lang, _ := testConfig(t, "testdata")
 
 	args := language.GenerateArgs{
-		Config:   c,
+		Config:       c,
 		Dir:          filepath.FromSlash("testdata/foo"),
-		File: old,
+		File:         old,
 		Rel:          "foo",
 		RegularFiles: []string{"foo.proto"},
 		GenFiles:     []string{"gen.proto"},
-		OtherGen: []*rule.Rule{genRule},
+		OtherGen:     []*rule.Rule{genRule},
 	}
 
 	args.Config = c
 	res := lang.GenerateRules(args)
 	// Make sure that gen.proto is not added to existing foo_proto rule because it is consumed
-	if len(res.Gen)!=1 {
+	if len(res.Gen) != 1 {
 		t.Errorf("got gen files len :\n%d\nwant:\n1", len(res.Gen))
 	}
 	fmt.Println(res.Gen[0].AttrString("name"))

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -188,8 +188,8 @@ func TestGeneratePackage(t *testing.T) {
 	}
 }
 
-// Test generated files that have been consumed by other rules should not be
-// added to the  rule
+// TestConsumedGenFiles checks that generated files that have been consumed by
+// other rules should not be added to the rule
 func TestConsumedGenFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// TODO(jayconrod): set up testdata directory on windows before running test
@@ -231,8 +231,9 @@ proto_library(
 		GenFiles:     []string{"gen.proto", "gen_not_consumed.proto"},
 		OtherGen:     []*rule.Rule{genRule1, genRule2},
 	})
+
 	// Make sure that "gen.proto" is not added to existing foo_proto rule
-	// because it is consumed by existing_gen_proto proto_library
+	// because it is consumed by existing_gen_proto proto_library.
 	// "gen_not_consumed.proto" is added to existing foo_proto rule because
 	// it is not consumed by "proto_library". "filegroup" consumption is
 	// ignored.


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
language/proto

**What does this PR do? Why is it needed?**
Some generated files may have been consumed by other rules, either handwritten or generated by other extensions. The go extension should not add them into the proto_library rule in such case.

**Which issues(s) does this PR fix?**
https://github.com/bazelbuild/bazel-gazelle/issues/731
