### PR TITLE
Add bzl_library targets to Gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//:def.bzl", "gazelle", "gazelle_binary")
 
 # gazelle:prefix github.com/bazelbuild/bazel-gazelle
@@ -21,6 +22,7 @@ gazelle_binary(
         "//language/proto",
         "//language/go",
         "//internal/language/test_filegroup",
+        "@bazel_skylib//gazelle/bzl",
     ],
 )
 
@@ -70,4 +72,29 @@ filegroup(
         "//walk:all_files",
     ],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//internal:gazelle_binary",
+        "//internal:go_repository",
+        "//internal:overlay_repository",
+        "@bazel_skylib//lib:shell",
+    ],
+)
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_gazelle//internal:go_repository",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_gazelle//internal:go_repository_config",
+        "@bazel_gazelle//internal:go_repository_tools",
+        "@bazel_tools//tools/build_defs/repo:git.bzl",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,16 @@
 workspace(name = "bazel_gazelle")
 
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+    name = "bazel_skylib",
+    commit = "df3c9e2735f02a7fe8cd80db4db00fec8e13d25f",  # `master` as of 2021-08-19
+    remote = "https://github.com/bazelbuild/bazel-skylib",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+load(
     "@bazel_gazelle//internal:go_repository.bzl",
     _go_repository = "go_repository",
 )
@@ -28,10 +32,6 @@ load(
     "@bazel_gazelle//internal:go_repository_config.bzl",
     "go_repository_config",
 )
-load(
-    "@bazel_tools//tools/build_defs/repo:git.bzl",
-    _tools_git_repository = "git_repository",
-)
 
 # Re-export go_repository . Users should get it from this file.
 go_repository = _go_repository
@@ -40,6 +40,14 @@ def gazelle_dependencies(
         go_sdk = "",
         go_repository_default_config = "@//:WORKSPACE",
         go_env = {}):
+    
+    _maybe(
+	git_repository,
+        name = "bazel_skylib",
+        commit = "df3c9e2735f02a7fe8cd80db4db00fec8e13d25f",  # `master` as of 2021-08-19
+        remote = "https://github.com/bazelbuild/bazel-skylib",
+    )
+    
     if go_sdk:
         go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",
@@ -73,13 +81,6 @@ def gazelle_dependencies(
     go_repository_config(
         name = "bazel_gazelle_go_repository_config",
         config = go_repository_default_config,
-    )
-
-    _maybe(
-        _tools_git_repository,
-        name = "bazel_skylib",
-        remote = "https://github.com/bazelbuild/bazel-skylib",
-        commit = "3fea8cb680f4a53a129f7ebace1a5a4d1e035914",  # 0.5.0 as of 2018-11-01
     )
 
     _maybe(

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 # gazelle:exclude *_test.go
 go_bazel_test(
@@ -30,6 +31,7 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
+        "common.bzl",
         "gazelle.bash.in",
         "gazelle_binary.bzl",
         "go_repository.bzl",
@@ -46,4 +48,68 @@ filegroup(
         "//internal/wspace:all_files",
     ],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "gazelle_binary",
+    srcs = ["gazelle_binary.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@io_bazel_rules_go//go:def"],
+)
+
+bzl_library(
+    name = "go_repository",
+    srcs = ["go_repository.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":common",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],
+)
+
+bzl_library(
+    name = "go_repository_cache",
+    srcs = ["go_repository_cache.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [":common"],
+)
+
+bzl_library(
+    name = "go_repository_config",
+    srcs = ["go_repository_config.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":common",
+        "@bazel_gazelle//internal:go_repository_cache",
+    ],
+)
+
+bzl_library(
+    name = "go_repository_tools",
+    srcs = ["go_repository_tools.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":common",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_gazelle//internal:go_repository_tools_srcs",
+    ],
+)
+
+bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "go_repository_tools_srcs",
+    srcs = ["go_repository_tools_srcs.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "overlay_repository",
+    srcs = ["overlay_repository.bzl"],
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/common.bzl
+++ b/internal/common.bzl
@@ -1,0 +1,38 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def env_execute(ctx, arguments, environment = {}, **kwargs):
+    """Executes a command in for a repository rule.
+    It prepends "env -i" to "arguments" before calling "ctx.execute".
+    Variables that aren't explicitly mentioned in "environment"
+    are removed from the environment. This should be preferred to "ctx.execute"
+    in most situations.
+    """
+    if ctx.os.name.startswith("windows"):
+        return ctx.execute(arguments, environment = environment, **kwargs)
+    env_args = ["env", "-i"]
+    environment = dict(environment)
+    for var in ["TMP", "TMPDIR"]:
+        if var in ctx.os.environ and not var in environment:
+            environment[var] = ctx.os.environ[var]
+    for k, v in environment.items():
+        env_args.append("%s=%s" % (k, v))
+    arguments = env_args + arguments
+    return ctx.execute(arguments, **kwargs)
+
+def executable_extension(ctx):
+    extension = ""
+    if ctx.os.name.startswith("windows"):
+        extension = ".exe"
+    return extension

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", "env_execute", "executable_extension")
+load("//internal:common.bzl", "env_execute", "executable_extension")
 load("@bazel_gazelle//internal:go_repository_cache.bzl", "read_cache_env")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
 

--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", "executable_extension")
+load("//internal:common.bzl", "executable_extension")
 
 # Change to trigger cache invalidation: 1
 

--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", "env_execute", "executable_extension")
+load("//internal:common.bzl", "env_execute", "executable_extension")
 load("@bazel_gazelle//internal:go_repository_cache.bzl", "read_cache_env")
 
 def _go_repository_config_impl(ctx):

--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go/private:common.bzl", "env_execute", "executable_extension")
+load("//internal:common.bzl", "env_execute", "executable_extension")
 load("@bazel_gazelle//internal:go_repository_cache.bzl", "read_cache_env")
 load("@bazel_gazelle//internal:go_repository_tools_srcs.bzl", "GO_REPOSITORY_TOOLS_SRCS")
 

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load(":def.bzl", "std_package_list")
 
@@ -119,4 +120,11 @@ alias(
     name = "go_default_library",
     actual = ":go",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go:def"],
 )

--- a/language/proto/gen/BUILD.bazel
+++ b/language/proto/gen/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -23,5 +24,11 @@ filegroup(
         "gen_known_imports.go",
         "update_proto_csv.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

This adds `bzl_library` targets for Gazelle. This is useful in generating `skydoc`s.