### PR TITLE
rule.CheckInternalVisibility: scope rules internally when composing internal/BUILD

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -831,9 +831,11 @@ func ShouldKeep(e bzl.Expr) bool {
 // CheckInternalVisibility overrides the given visibility if the package is
 // internal.
 func CheckInternalVisibility(rel, visibility string) string {
-	if i := strings.LastIndex(rel, "/internal/"); i >= 0 {
+	if strings.HasSuffix(rel, "/internal") {
+		visibility = fmt.Sprintf("//%s:__subpackages__", rel[:len(rel)-len("/internal")])
+	} else if i := strings.LastIndex(rel, "/internal/"); i >= 0 {
 		visibility = fmt.Sprintf("//%s:__subpackages__", rel[:i])
-	} else if strings.HasPrefix(rel, "internal/") {
+	} else if strings.HasPrefix(rel, "internal/") || rel == "internal" {
 		visibility = "//:__subpackages__"
 	}
 	return visibility

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -346,3 +346,23 @@ func TestShouldKeepExpr(t *testing.T) {
 		})
 	}
 }
+
+func TestInternalVisibility(t *testing.T) {
+	var tests = []struct {
+		rel      string
+		expected string
+	}{
+		{rel: "internal", expected: "//:__subpackages__"},
+		{rel: "a/b/internal", expected: "//a/b:__subpackages__"},
+		{rel: "a/b/internal/c", expected: "//a/b:__subpackages__"},
+		{rel: "a/b/internal/c/d", expected: "//a/b:__subpackages__"},
+		{rel: "a/b/internal/c/internal", expected: "//a/b/internal/c:__subpackages__"},
+		{rel: "a/b/internal/c/internal/d", expected: "//a/b/internal/c:__subpackages__"},
+	}
+
+	for _, tt := range tests {
+		if actual := CheckInternalVisibility(tt.rel, "default"); actual != tt.expected {
+			t.Errorf("got %v; want %v", actual, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
My understanding of the "internal packages" behavior is that it should extend to
rules directly in the internal package, not just its subdirectories.

Add some tests to verify behavior.