### PR TITLE
cmd/gazelle: add resolvers for activated languages only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -394,7 +394,7 @@ The following flags are accepted:
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-lang lang1,lang2,...`                                | :value:`""`                            |
 +--------------------------------------------------------------+----------------------------------------+
-| Selects languages for which to compose rules.                                                         |
+| Selects languages for which to compose and index rules.                                               |
 |                                                                                                       |
 | By default, all languages that this Gazelle was built with are processed.                             |
 +--------------------------------------------------------------+----------------------------------------+
@@ -716,8 +716,8 @@ The following directives are recognized:
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:lang lang1,lang2,...`           | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
-| Sets the language selection flag for this and descendent packages, which gazelle to        |
-| process just the languages named in this directive.                                        |
+| Sets the language selection flag for this and descendent packages, which causes gazelle to |
+| index and generate rules for only the languages named in this directive.                   |
 +---------------------------------------------------+----------------------------------------+
 
 Gazelle also reads directives from the WORKSPACE file. They may be used to

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3125,6 +3125,60 @@ func TestConfigLang(t *testing.T) {
 		{Path: "bar/bar.go", Content: "package bar"},
 		{Path: "baz/BUILD.bazel", Content: "# gazelle:lang go,proto"},
 		{Path: "baz/baz.go", Content: "package baz"},
+
+		// Verify that Gazelle does not index go_library rules in // or //baz/protos.
+		// In those directories, lang is set to proto by flag and directive, respectively.
+		// Confirm it does index and resolve a rule in a directory where go is activated.
+		{Path: "invisible1.go", Content: "package invisible1"},
+		{Path: "BUILD.bazel", Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:prefix root
+
+go_library(
+    name = "go_default_library",
+    srcs = ["invisible1.go"],
+    importpath = "root",
+    visibility = ["//visibility:public"],
+)
+`},
+		{Path: "baz/protos/invisible2.go", Content: "package invisible2"},
+		{Path: "baz/protos/BUILD.bazel", Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:lang proto
+# gazelle:prefix github.com/rule_indexing/invisible2
+
+go_library(
+    name = "go_default_library",
+    srcs = ["invisible2.go"],
+    importpath = "github.com/rule_indexing/invisible2",
+    visibility = ["//visibility:public"],
+)
+`},
+		{Path: "visible/visible.go", Content: "package visible"},
+		{Path: "visible/BUILD.bazel", Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:lang go,proto
+# gazelle:prefix github.com/rule_indexing/visible
+
+go_library(
+    name = "go_default_library",
+    srcs = ["visible.go"],
+    importpath = "github.com/rule_indexing/visible",
+    visibility = ["//visibility:public"],
+)
+`},
+		{Path: "baz/test_no_index/test_no_index.go", Content: `
+package test_no_index
+
+import (
+	_ "github.com/rule_indexing/invisible1"
+	_ "github.com/rule_indexing/invisible2"
+	_ "github.com/rule_indexing/visible"
+)
+`},
 	}
 
 	dir, cleanup := testtools.CreateFiles(t, files)
@@ -3159,7 +3213,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["bar.go"],
-    importpath = "",
+    importpath = "root/bar",
     visibility = ["//visibility:public"],
 )`,
 		},
@@ -3173,10 +3227,27 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["baz.go"],
-    importpath = "",
+    importpath = "root/baz",
     visibility = ["//visibility:public"],
 )`,
-		}})
+		},
+
+		{Path: "baz/test_no_index/BUILD.bazel", Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["test_no_index.go"],
+    importpath = "root/baz/test_no_index",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//visible:go_default_library",
+        "@com_github_rule_indexing_invisible1//:go_default_library",
+        "@com_github_rule_indexing_invisible2//:go_default_library",
+    ],
+)
+`},
+	})
 }
 
 func TestUpdateRepos_LangFilter(t *testing.T) {

--- a/resolve/index.go
+++ b/resolve/index.go
@@ -112,7 +112,9 @@ func NewRuleIndex(mrslv func(r *rule.Rule, pkgRel string) Resolver) *RuleIndex {
 func (ix *RuleIndex) AddRule(c *config.Config, r *rule.Rule, f *rule.File) {
 	var imps []ImportSpec
 	if rslv := ix.mrslv(r, f.Pkg); rslv != nil {
-		imps = rslv.Imports(c, r, f)
+		if passesLanguageFilter(c.Langs, rslv.Name()) {
+			imps = rslv.Imports(c, r, f)
+		}
 	}
 	// If imps == nil, the rule is not importable. If imps is the empty slice,
 	// it may still be importable if it embeds importable libraries.
@@ -239,6 +241,20 @@ func (r FindResult) IsSelfImport(from label.Label) bool {
 	}
 	for _, e := range r.Embeds {
 		if from.Equal(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// passesLanguageFilter returns true if the filter is empty (disabled) or if the
+// given language name appears in it.
+func passesLanguageFilter(langFilter []string, langName string) bool {
+	if len(langFilter) == 0 {
+		return true
+	}
+	for _, l := range langFilter {
+		if l == langName {
 			return true
 		}
 	}


### PR DESCRIPTION
This disables processing of rules for languages which are disabled via the -lang
flag. Concretely, this halves the time it takes for Gazelle to update our Go
rules by skipping processing of all closure_js rules. 

That's partially because processing JS is sort of slow, but I think the basic idea here is sound. 

Updates #687 