### PR TITLE
Remove use of genrules for computing known imports.

### DIFF
--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load(":def.bzl", "std_package_list")
+load("//language/proto/gen:def.bzl", "known_imports")
 
 # gazelle:exclude testdata
 
@@ -11,20 +12,24 @@ std_package_list(
     out = "std_package_list.go",
 )
 
-genrule(
+known_imports(
     name = "known_proto_imports",
-    srcs = ["//language/proto:proto.csv"],
-    outs = ["known_proto_imports.go"],
-    cmd = "$(location //language/proto/gen:gen_known_imports) -proto_csv $< -known_imports $@ -package golang -var knownProtoImports -key 0 -value 3",
-    tools = ["//language/proto/gen:gen_known_imports"],
+    src = "//language/proto:proto.csv",
+    out = "known_proto_imports.go",
+    key = 0,
+    package = "golang",
+    value = 3,
+    var = "knownProtoImports",
 )
 
-genrule(
+known_imports(
     name = "known_go_imports",
-    srcs = ["//language/proto:proto.csv"],
-    outs = ["known_go_imports.go"],
-    cmd = "$(location //language/proto/gen:gen_known_imports) -proto_csv $< -known_imports $@ -package golang -var knownGoProtoImports -key 2 -value 3",
-    tools = ["//language/proto/gen:gen_known_imports"],
+    src = "//language/proto:proto.csv",
+    out = "known_go_imports.go",
+    key = 2,
+    package = "golang",
+    value = 3,
+    var = "knownGoProtoImports",
 )
 
 go_library(

--- a/language/proto/BUILD.bazel
+++ b/language/proto/BUILD.bazel
@@ -1,13 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//language/proto/gen:def.bzl", "known_imports")
 
 # gazelle:exclude testdata
 
-genrule(
+known_imports(
     name = "known_imports",
-    srcs = ["proto.csv"],
-    outs = ["known_imports.go"],
-    cmd = "$(location //language/proto/gen:gen_known_imports) -proto_csv $< -known_imports $@ -package proto -var knownImports -key 0 -value 1",
-    tools = ["//language/proto/gen:gen_known_imports"],
+    src = "proto.csv",
+    out = "known_imports.go",
+    key = 0,
+    package = "proto",
+    value = 1,
+    var = "knownImports",
 )
 
 go_library(

--- a/language/proto/gen/BUILD.bazel
+++ b/language/proto/gen/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
+        "def.bzl",
         "gen_known_imports.go",
         "update_proto_csv.go",
     ],

--- a/language/proto/gen/def.bzl
+++ b/language/proto/gen/def.bzl
@@ -1,0 +1,50 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _known_imports_impl(ctx):
+    args = ctx.actions.args()
+    args.add("-proto_csv", ctx.file.src)
+    args.add("-known_imports", ctx.outputs.out)
+    args.add("-package", ctx.attr.package)
+    args.add("-var", ctx.attr.var)
+    args.add("-key", str(ctx.attr.key))
+    args.add("-value", str(ctx.attr.value))
+    ctx.actions.run(
+        executable = ctx.executable._bin,
+        inputs = [ctx.file.src],
+        outputs = [ctx.outputs.out],
+        arguments = [args],
+        mnemonic = "KnownImports",
+    )
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+known_imports = rule(
+    implementation = _known_imports_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "out": attr.output(mandatory = True),
+        "package": attr.string(mandatory = True),
+        "var": attr.string(mandatory = True),
+        "key": attr.int(mandatory = True),
+        "value": attr.int(mandatory = True),
+        "_bin": attr.label(
+            default = Label("//language/proto/gen:gen_known_imports"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)


### PR DESCRIPTION
genrules are not supported on Windows without a dependency
on mingw. We replace them with a small custom bzl rule.

The new rule should be 1:1 compatible with what the genrule
was doing.

**What type of PR is this?**

Bug fix is probably the closest I guess?

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Replaces genrules with custom bzl rules, so we can work without msys on Windows.