### PR TITLE
gazelle_binary: use transition instead of aspect

### DIFF
--- a/extend.rst
+++ b/extend.rst
@@ -15,6 +15,7 @@ Extending Gazelle
 .. _rules_sass: https://github.com/bazelbuild/rules_sass
 .. _#75: https://github.com/bazelbuild/rules_sass/pull/75
 .. _bazel_rules_nodejs_contrib: https://github.com/ecosia/bazel_rules_nodejs_contrib#build-file-generation
+.. _#803: https://github.com/bazelbuild/bazel-gazelle/issues/803
 
 .. role:: cmd(code)
 .. role:: flag(code)
@@ -67,8 +68,7 @@ a stub implementation used for testing.
 
 ``//cmd/gazelle`` is a ``gazelle_binary`` rule that includes both of these
 libraries through the ``DEFAULT_LANGUAGES`` list (you may want to use
-``DEFAULT_LANGUAGES`` in your own rule). The ``msan``, ``pure``, ``race``,
-and ``static`` attributes are optional.
+``DEFAULT_LANGUAGES`` in your own rule).
 
 .. code:: bzl
 
@@ -77,10 +77,6 @@ and ``static`` attributes are optional.
     gazelle_binary(
         name = "gazelle",
         languages = DEFAULT_LANGUAGES,
-        msan = "off",
-        pure = "off",
-        race = "off",
-        static = "off",
         visibility = ["//visibility:public"],
     )
 
@@ -126,6 +122,12 @@ The following attributes are supported on the ``gazelle_binary`` rule.
 | must export a function named ``NewLanguage`` with no parameters that returns      |
 | a value assignable to `Language`_.                                                |
 +----------------------+---------------------+--------------------------------------+
+
+The following attributes are deprecated (`#803`_):
+
++----------------------+---------------------+--------------------------------------+
+| **Name**             | **Type**            | **Default value**                    |
++======================+=====================+======================================+
 | :param:`pure`        | :type:`string`      | :value:`auto`                        |
 +----------------------+---------------------+--------------------------------------+
 | Same meaning as `go_binary`_. It may be necessary to set this to avoid            |


### PR DESCRIPTION
go_archive_aspect should no longer be used anywhere. It probably
should have been deleted before v0.21.0. gazelle_binary has been using
it for cross compilation though.

With this change, go_transition_rule is used for cross-compilation
instead.

Cross-compilation in gazelle_binary should be removed entirely in the
future though. It requires private functionality in rules_go, and it
doesn't seem useful.

For bazelbuild/rules_go#2523
Updates #803
