### PR TITLE
language/proto: adjust indexing for {strip_,}import_prefix attrs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -382,8 +382,9 @@ The following flags are accepted:
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-proto_import_prefix repo`                            |                                        |
 +--------------------------------------------------------------+----------------------------------------+
-| Sets the `import_prefix`_ attribute of generated ``proto_library`` rules. This is a prefix            |
-| to add to import paths of .proto files.                                                               |
+| Sets the `import_prefix`_ attribute of generated ``proto_library`` rules.                             |
+| This adds a prefix to the string used to import ``.proto`` files listed in                            |
+| the ``srcs`` attribute of generated rules.                                                            |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-repo_root dir`                                       |                                        |
 +--------------------------------------------------------------+----------------------------------------+
@@ -683,15 +684,31 @@ The following directives are recognized:
 | in the package name. For example, if the package is ``"foo/bar/baz"``, the                 |
 | ``proto_library`` rule will be named ``baz_proto``.                                        |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:proto_strip_import_prefix path` | n/a                                    |
-+---------------------------------------------------+----------------------------------------+
-| Sets the `strip_import_prefix`_ attribute of generated ``proto_library`` rules.            |
-| This is a prefix to strip from the import paths of .proto files.                           |
-+---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:proto_import_prefix path`       | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
 | Sets the `import_prefix`_ attribute of generated ``proto_library`` rules.                  |
-| This is a prefix to add to import paths of .proto files.                                   |
+| This adds a prefix to the string used to import ``.proto`` files listed in                 |
+| the ``srcs`` attribute of generated rules.                                                 |
+|                                                                                            |
+| For example, if the target ``//a:b_proto`` has ``srcs = ["b.proto"]`` and                  |
+| ``import_prefix = "github.com/x/y"``, then ``b.proto`` should be imported                  |
+| with the string ``"github.com/x/y/a/b.proto"``.                                            |
++---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:proto_strip_import_prefix path` | n/a                                    |
++---------------------------------------------------+----------------------------------------+
+| Sets the `strip_import_prefix`_ attribute of generated ``proto_library`` rules.            |
+| This is a prefix to strip from the strings used to import ``.proto`` files.                |
+|                                                                                            |
+| If the prefix starts with a slash, it's intepreted relative to the repository              |
+| root. Otherwise, it's relative to the directory containing the build file.                 |
+| The package-relative form is only useful when a single build file covers                   |
+| ``.proto`` files in subdirectories. Gazelle doesn't generate build files like              |
+| this, so only paths with a leading slash should be used. Gazelle will print                |
+| a warning when the package-relative form is used.                                          |
+|                                                                                            |
+| For example, if the target ``//proto/a:b_proto`` has ``srcs = ["b.proto"]``                |
+| and ``strip_import_prefix = "/proto"``, then ``b.proto`` should be imported                |
+| with the string ``"a/b.proto"``.                                                           |
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:resolve ...`                    | n/a                                    |
 +---------------------------------------------------+----------------------------------------+

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -879,17 +879,13 @@ go_library(
 		}, {
 			desc: "proto_import_prefix_and_strip_import_prefix",
 			index: []buildFile{{
-				rel: "",
-				content: `
-# gazelle:proto_strip_import_prefix /sub
-# gazelle:proto_import_prefix foo/
-`,
-			}, {
 				rel: "sub",
 				content: `
 proto_library(
     name = "foo_proto",
     srcs = ["bar.proto"],
+    import_prefix = "foo/",
+    strip_import_prefix = "/sub",
 )
 
 go_proto_library(
@@ -904,8 +900,7 @@ go_library(
     importpath = "example.com/foo",
 )
 `,
-			},
-			},
+			}},
 			old: buildFile{content: `
 go_proto_library(
     name = "dep_proto",

--- a/language/proto/BUILD.bazel
+++ b/language/proto/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//config:go_default_library",
         "//label:go_default_library",
         "//language:go_default_library",
+        "//pathtools:go_default_library",
         "//repo:go_default_library",
         "//resolve:go_default_library",
         "//rule:go_default_library",

--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -215,10 +215,8 @@ func (_ *protoLang) Configure(c *config.Config, rel string, f *rule.File) {
 				pc.groupOption = d.Value
 			case "proto_strip_import_prefix":
 				pc.StripImportPrefix = d.Value
-				if rel != "" {
-					if err := checkStripImportPrefix(pc.StripImportPrefix, rel); err != nil {
-						log.Print(err)
-					}
+				if err := checkStripImportPrefix(pc.StripImportPrefix, rel); err != nil {
+					log.Print(err)
 				}
 			case "proto_import_prefix":
 				pc.ImportPrefix = d.Value
@@ -277,7 +275,13 @@ outer:
 }
 
 func checkStripImportPrefix(prefix, rel string) error {
-	if !strings.HasPrefix(prefix, "/") || !strings.HasPrefix(rel, prefix[1:]) {
+	if prefix == "" {
+		return nil
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		return fmt.Errorf("proto_strip_import_prefix should start with '/' for a prefix relative to the repository root")
+	}
+	if rel != "" && !strings.HasPrefix(rel, prefix[1:]) {
 		return fmt.Errorf("invalid proto_strip_import_prefix %q at %s", prefix, rel)
 	}
 	return nil

--- a/language/proto/kinds.go
+++ b/language/proto/kinds.go
@@ -22,7 +22,9 @@ var protoKinds = map[string]rule.KindInfo{
 		MatchAttrs:    []string{"srcs"},
 		NonEmptyAttrs: map[string]bool{"srcs": true},
 		MergeableAttrs: map[string]bool{
-			"srcs": true,
+			"srcs":                true,
+			"import_prefix":       true,
+			"strip_import_prefix": true,
 		},
 		ResolveAttrs: map[string]bool{"deps": true},
 	},

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -256,20 +256,15 @@ proto_library(
 		}, {
 			desc: "strip_import_prefix",
 			index: []buildFile{{
-				rel: "",
-				content: `
-# gazelle:proto_strip_import_prefix /foo/bar/
-`,
-			}, {
 				rel: "foo/bar/sub",
 				content: `
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    strip_import_prefix = "/foo/bar",
 )
 `,
-			},
-			},
+			}},
 			old: `
 proto_library(
     name = "dep_proto",
@@ -285,20 +280,15 @@ proto_library(
 		}, {
 			desc: "skip bad strip_import_prefix",
 			index: []buildFile{{
-				rel: "",
-				content: `
-# gazelle:proto_strip_import_prefix /foo
-`,
-			}, {
 				rel: "bar",
 				content: `
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    strip_import_prefix = "/foo",
 )
 `,
-			},
-			},
+			}},
 			old: `
 proto_library(
     name = "dep_proto",
@@ -314,20 +304,15 @@ proto_library(
 		}, {
 			desc: "import_prefix",
 			index: []buildFile{{
-				rel: "",
-				content: `
-# gazelle:proto_import_prefix foo/
-`,
-			}, {
 				rel: "bar",
 				content: `
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    import_prefix = "foo/",
 )
 `,
-			},
-			},
+			}},
 			old: `
 proto_library(
     name = "dep_proto",
@@ -343,21 +328,16 @@ proto_library(
 		}, {
 			desc: "strip_import_prefix and import_prefix",
 			index: []buildFile{{
-				rel: "",
-				content: `
-# gazelle:proto_strip_import_prefix /foo
-# gazelle:proto_import_prefix bar/
-`,
-			}, {
 				rel: "foo",
 				content: `
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    import_prefix = "bar/",
+    strip_import_prefix = "/foo",
 )
 `,
-			},
-			},
+			}},
 			old: `
 proto_library(
     name = "dep_proto",


### PR DESCRIPTION
proto_library rules will now be indexed based on their import_prefix
and strip_import_prefix attributes, not the corresponding
directives. Generally, these will be consistent, but using the actual
attributes will let Gazelle correctly index hand-written targets and
targets with '# keep' directives.

The import_prefix and strip_import_prefix attributes are now
mergeable, so Gazelle may replace or delete existing attributes.

Fixes #805
