### PR TITLE
Cleaning strip import path before appending slash

### DIFF
--- a/pathtools/path.go
+++ b/pathtools/path.go
@@ -44,7 +44,7 @@ func TrimPrefix(p, prefix string) string {
 	if prefix == p {
 		return ""
 	}
-	return strings.TrimPrefix(p, prefix+"/")
+	return strings.TrimPrefix(p, filepath.Clean(prefix)+"/")
 }
 
 // RelBaseName returns the base name for rel, a slash-separated path relative


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What package or component does this PR mostly affect?**

language/proto

**What does this PR do? Why is it needed?**

#806 broke Uber's Go monorepo. Our `proto_strip_import_prefix` ends with "/" to make sure Gazelle respects path boundaries. After #806, language/proto/resolve.go calls `pathtools.TrimPrefix`, which appends "/" to all prefixes blindly. So our prefix to be stripped now ends with two slashes.

This PR clean the path before appending "/" to make sure it only has one slash at the end.

