### PR TITLE
language/proto: fix handling of trailing slashes in proto_strip_import_prefix

### DIFF
--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
@@ -281,8 +282,8 @@ func checkStripImportPrefix(prefix, rel string) error {
 	if !strings.HasPrefix(prefix, "/") {
 		return fmt.Errorf("proto_strip_import_prefix should start with '/' for a prefix relative to the repository root")
 	}
-	if rel != "" && !strings.HasPrefix(rel, prefix[1:]) {
-		return fmt.Errorf("invalid proto_strip_import_prefix %q at %s", prefix, rel)
+	if !pathtools.HasPrefix(rel, prefix[1:]) {
+		return fmt.Errorf("proto_strip_import_prefix %q not in directory %s", prefix, rel)
 	}
 	return nil
 }

--- a/language/proto/config_test.go
+++ b/language/proto/config_test.go
@@ -19,7 +19,7 @@ import "testing"
 
 func TestCheckStripImportPrefix(t *testing.T) {
 	e := checkStripImportPrefix("/example.com/idl", "example.com")
-	wantErr := "invalid proto_strip_import_prefix \"/example.com/idl\" at example.com"
+	wantErr := `proto_strip_import_prefix "/example.com/idl" not in directory example.com`
 	if e == nil || e.Error() != wantErr {
 		t.Errorf("got:\n%v\n\nwant:\n%s\n", e, wantErr)
 	}

--- a/pathtools/path.go
+++ b/pathtools/path.go
@@ -30,6 +30,8 @@ import (
 // boundaries, so "/home/foo" is not a prefix is "/home/foobar/baz". If the
 // prefix is empty, this function always returns true.
 func HasPrefix(p, prefix string) bool {
+	p = trimTrailingSlash(p)
+	prefix = trimTrailingSlash(prefix)
 	return prefix == "" || p == prefix || strings.HasPrefix(p, prefix+"/")
 }
 
@@ -38,8 +40,11 @@ func HasPrefix(p, prefix string) bool {
 // respects component boundaries (assuming slash-separated paths), so
 // TrimPrefix("foo/bar", "foo") returns "baz".
 func TrimPrefix(p, prefix string) string {
+	origPath := p
+	p = trimTrailingSlash(p)
+	prefix = trimTrailingSlash(prefix)
 	if prefix == "" {
-		return p
+		return origPath
 	}
 	if prefix == p {
 		return ""
@@ -107,4 +112,11 @@ func Index(p, sub string) int {
 			return -1
 		}
 	}
+}
+
+func trimTrailingSlash(p string) string {
+	for len(p) > 1 && p[len(p)-1] == '/' {
+		p = p[:len(p)-1]
+	}
+	return p
 }

--- a/pathtools/path_test.go
+++ b/pathtools/path_test.go
@@ -23,30 +23,40 @@ func TestHasPrefix(t *testing.T) {
 		want               bool
 	}{
 		{
-			desc:   "empty prefix",
+			desc:   "empty_prefix",
 			path:   "home/jr_hacker",
 			prefix: "",
 			want:   true,
 		}, {
-			desc:   "partial prefix",
+			desc:   "partial_prefix",
 			path:   "home/jr_hacker",
 			prefix: "home",
 			want:   true,
 		}, {
-			desc:   "full prefix",
+			desc:   "full_prefix",
 			path:   "home/jr_hacker",
 			prefix: "home/jr_hacker",
 			want:   true,
 		}, {
-			desc:   "too long",
+			desc:   "too_long",
 			path:   "home",
 			prefix: "home/jr_hacker",
 			want:   false,
 		}, {
-			desc:   "partial component",
+			desc:   "partial_component",
 			path:   "home/jr_hacker",
 			prefix: "home/jr_",
 			want:   false,
+		}, {
+			desc:   "trailing_slash_prefix",
+			path:   "home/jr_hacker",
+			prefix: "home/",
+			want:   true,
+		}, {
+			desc:   "trailing_slash_path",
+			path:   "home/jr_hacker/",
+			prefix: "home",
+			want:   true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -62,25 +72,35 @@ func TestTrimPrefix(t *testing.T) {
 		desc, path, prefix, want string
 	}{
 		{
-			desc:   "empty prefix",
+			desc:   "empty_prefix",
 			path:   "home/jr_hacker",
 			prefix: "",
 			want:   "home/jr_hacker",
 		}, {
-			desc:   "partial prefix",
+			desc:   "partial_prefix",
 			path:   "home/jr_hacker",
 			prefix: "home",
 			want:   "jr_hacker",
 		}, {
-			desc:   "full prefix",
+			desc:   "full_prefix",
 			path:   "home/jr_hacker",
 			prefix: "home/jr_hacker",
 			want:   "",
 		}, {
-			desc:   "partial component",
+			desc:   "partial_component",
 			path:   "home/jr_hacker",
 			prefix: "home/jr_",
 			want:   "home/jr_hacker",
+		}, {
+			desc:   "trailing_slash_prefix",
+			path:   "home/jr_hacker",
+			prefix: "home/",
+			want:   "jr_hacker",
+		}, {
+			desc:   "trailing_slash_path",
+			path:   "home/jr_hacker/",
+			prefix: "home",
+			want:   "jr_hacker",
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
pathtools.HasPrefix and TrimPrefix now support trailing slashes in
both path and prefix. This should fix validation of the
proto_strip_import_prefix directive, as well as indexing when that
directive is used.

Supercedes #813