### PR TITLE
Setting GO111MODULE=on in fetch_repo

### DIFF
--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -79,6 +79,7 @@ func fetchModule(dest, importpath, version, sum string) error {
 		cmd.Args = append(cmd.Args, "-modcacherw")
 	}
 	cmd.Args = append(cmd.Args, importpath+"@"+version)
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	cmd.Stdout = buf
 	cmd.Stderr = bufErr
 	dlErr := cmd.Run()
@@ -93,9 +94,11 @@ func fetchModule(dest, importpath, version, sum string) error {
 	// Parse the JSON output.
 	var dl struct{ Dir, Sum, Error string }
 	if err := json.Unmarshal(buf.Bytes(), &dl); err != nil {
+		_, _ = os.Stderr.Write(bufErr.Bytes())
 		return err
 	}
 	if dl.Error != "" {
+		_, _ = os.Stderr.Write(bufErr.Bytes())
 		return errors.New(dl.Error)
 	}
 	if dlErr != nil {

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -110,12 +110,12 @@ def _go_repository_impl(ctx):
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 
     if fetch_repo_args:
-        # Override external GO111MODULE, because it is needed by module mode, no-op in repository mode
-        fetch_repo_env["GO111MODULE"] = "on"
         # Disable sumdb in fetch_repo. In module mode, the sum is a mandatory
         # attribute of go_repository, so we don't need to look it up.
         fetch_repo_env = dict(env)
         fetch_repo_env["GOSUMDB"] = "off"
+        # Override external GO111MODULE, because it is needed by module mode, no-op in repository mode
+        fetch_repo_env["GO111MODULE"] = "on"
 
         fetch_repo = str(ctx.path(Label("@bazel_gazelle_go_repository_tools//:bin/fetch_repo{}".format(executable_extension(ctx)))))
         result = env_execute(

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -110,6 +110,8 @@ def _go_repository_impl(ctx):
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 
     if fetch_repo_args:
+        # Override external GO111MODULE, because it is needed by module mode, no-op in repository mode
+        fetch_repo_env["GO111MODULE"] = "on"
         # Disable sumdb in fetch_repo. In module mode, the sum is a mandatory
         # attribute of go_repository, so we don't need to look it up.
         fetch_repo_env = dict(env)


### PR DESCRIPTION

**What type of PR is this?**

Bug fix


**What package or component does this PR mostly affect?**

cmd/fetch_repo

**What does this PR do? Why is it needed?**

When `GO111MODULE=off` externally, fetch_repo fails with errors like:

```
ERROR: An error occurred during the fetch of repository 'com_github_bazelbuild_buildtools':
  failed to fetch com_github_bazelbuild_buildtools: fetch_repo: unexpected end of JSON input
ERROR: Skipping '//:gazelle': no such package '@com_github_bazelbuild_buildtools//buildifier': failed to fetch com_github_bazelbuild_buildtools: fetch_repo: unexpected end of JSON input
```

Which give no information about the root cause. This PR print out more information from stderr of `go mod` command when there are errors and explicit turn on `GO111MODULE` before running `go mod` to be immune of external env.

