### PR TITLE
fix-update: only write changed build files to disk 

### DIFF
--- a/cmd/gazelle/diff.go
+++ b/cmd/gazelle/diff.go
@@ -18,7 +18,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,12 +42,10 @@ func diffFile(c *config.Config, f *rule.File) error {
 		ToDate:   date,
 	}
 
-	if oldContent, err := ioutil.ReadFile(f.Path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("error reading original file: %v", err)
-	} else if err != nil {
+	if len(f.Content) == 0 {
 		diff.FromFile = "/dev/null"
-	} else if err == nil {
-		diff.A = difflib.SplitLines(string(oldContent))
+	} else {
+		diff.A = difflib.SplitLines(string(f.Content))
 		if c.ReadBuildFilesDir == "" {
 			path, err := filepath.Rel(c.RepoRoot, f.Path)
 			if err != nil {

--- a/cmd/gazelle/fix.go
+++ b/cmd/gazelle/fix.go
@@ -19,15 +19,24 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 func fixFile(c *config.Config, f *rule.File) error {
+	newContent := f.Format()
+	if reflect.DeepEqual(f.Content, newContent) {
+		return nil
+	}
 	outPath := findOutputPath(c, f)
 	if err := os.MkdirAll(filepath.Dir(outPath), 0777); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(outPath, f.Format(), 0666)
+	if err := ioutil.WriteFile(outPath, newContent, 0666); err != nil {
+		return err
+	}
+	f.Content = newContent
+	return nil
 }

--- a/cmd/gazelle/fix.go
+++ b/cmd/gazelle/fix.go
@@ -16,10 +16,10 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -27,7 +27,7 @@ import (
 
 func fixFile(c *config.Config, f *rule.File) error {
 	newContent := f.Format()
-	if reflect.DeepEqual(f.Content, newContent) {
+	if bytes.Equal(f.Content, newContent) {
 		return nil
 	}
 	outPath := findOutputPath(c, f)

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -197,7 +197,6 @@ go_binary(
 
 	// Ensure that Gazelle does not write to the BUILD file.
 	run(defaultArgs(dir))
-	data, err := ioutil.ReadFile(buildFile)
 	if st, err := os.Stat(buildFile); err != nil {
 		t.Errorf("could not stat BUILD: %v", err)
 	} else if !modTime.Equal(st.ModTime()) {

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -157,6 +157,54 @@ func TestUpdateFile(t *testing.T) {
 	}
 }
 
+func TestNoChanges(t *testing.T) {
+	// Create a directory with a BUILD file that doesn't need any changes.
+	tmpdir := os.Getenv("TEST_TMPDIR")
+	dir, err := ioutil.TempDir(tmpdir, "")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir(%q, %q) failed with %v; want success", tmpdir, "", err)
+	}
+	defer os.RemoveAll(dir)
+
+	goFile := filepath.Join(dir, "main.go")
+	if err = ioutil.WriteFile(goFile, []byte("package main"), 0600); err != nil {
+		t.Fatalf("error writing file %q: %v", goFile, err)
+	}
+
+	buildFile := filepath.Join(dir, "BUILD")
+	if err = ioutil.WriteFile(buildFile, []byte(`load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "example.com/repo",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "hello",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+`), 0600); err != nil {
+		t.Fatalf("error writing file %q: %v", buildFile, err)
+	}
+	st, err := os.Stat(buildFile)
+	if err != nil {
+		t.Errorf("could not stat BUILD: %v", err)
+	}
+	modTime := st.ModTime()
+
+	// Ensure that Gazelle does not write to the BUILD file.
+	run(defaultArgs(dir))
+	data, err := ioutil.ReadFile(buildFile)
+	if st, err := os.Stat(buildFile); err != nil {
+		t.Errorf("could not stat BUILD: %v", err)
+	} else if !modTime.Equal(st.ModTime()) {
+		t.Errorf("unexpected modificaiton to BUILD")
+	}
+}
+
 func TestFixReadWriteDir(t *testing.T) {
 	buildInFile := testtools.FileSpec{
 		Path: "in/BUILD.in",

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -71,6 +71,12 @@ type File struct {
 	// Rules is a list of rules within the file (or function calls that look like
 	// rules). This should not be modified directly; use Rule methods instead.
 	Rules []*Rule
+
+	// Content is the file's underlying disk content, which is recorded when the
+	// file is initially loaded and whenever it is saved back to disk. If the file
+	// is modified outside of Rule methods, Content must be manually updated in
+	// order to keep it in sync.
+	Content []byte
 }
 
 // EmptyFile creates a File wrapped around an empty syntax tree.
@@ -138,7 +144,9 @@ func LoadData(path, pkg string, data []byte) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ScanAST(pkg, ast), nil
+	f := ScanAST(pkg, ast)
+	f.Content = data
+	return f, nil
 }
 
 // LoadWorkspaceData is similar to LoadData but parses the data as a
@@ -148,7 +156,9 @@ func LoadWorkspaceData(path, pkg string, data []byte) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ScanAST(pkg, ast), nil
+	f := ScanAST(pkg, ast)
+	f.Content = data
+	return f, nil
 }
 
 // LoadMacroData parses a bzl file from a byte slice and scans for the load
@@ -161,7 +171,9 @@ func LoadMacroData(path, pkg, defName string, data []byte) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ScanASTBody(pkg, defName, ast), nil
+	f := ScanASTBody(pkg, defName, ast)
+	f.Content = data
+	return f, nil
 }
 
 // ScanAST creates a File wrapped around the given syntax tree. This tree
@@ -372,8 +384,8 @@ func (f *File) Format() []byte {
 // Save writes the build file to disk. This method calls Sync internally.
 func (f *File) Save(path string) error {
 	f.Sync()
-	data := bzl.Format(f.File)
-	return ioutil.WriteFile(path, data, 0666)
+	f.Content = bzl.Format(f.File)
+	return ioutil.WriteFile(path, f.Content, 0666)
 }
 
 // HasDefaultVisibility returns whether the File contains a "package" rule with


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds the `Content` field to `rule.File`, which contains the file's underlying disk content. `file.Content` is then used by `gazelle/fix` and `gazelle/diff` to avoid unnecessary file operations.

**Which issues(s) does this PR fix?**

Fixes #807
