### PR TITLE
gazelle_runner: allow usage of transitive runfiles

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -76,7 +76,8 @@ def _gazelle_runner_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.gazelle,
         go_tool,
-    ])
+    ] + ctx.files._bash_runfile_helpers)
+    runfiles = runfiles.merge(ctx.attr.gazelle[DefaultInfo].default_runfiles)
     return [DefaultInfo(
         files = depset([out_file]),
         runfiles = runfiles,
@@ -109,6 +110,9 @@ _gazelle_runner = rule(
         "_template": attr.label(
             default = "@bazel_gazelle//internal:gazelle.bash.in",
             allow_single_file = True,
+        ),
+        "_bash_runfile_helpers": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
         ),
     },
     executable = True,

--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -17,6 +17,19 @@
 
 @@GENERATED_MESSAGE@@
 
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Export runfile vars so sub-processes can access them
+runfiles_export_envvars
+
 set -euo pipefail
 
 RUNNER_LABEL=@@RUNNER_LABEL@@


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

gazelle_runner

**What does this PR do? Why is it needed?**

Merges gazelle_binary runfiles into gazelle_runner and exports necessary envvars.

**Which issues(s) does this PR fix?**

Fixes #827

**Other notes for review**