### PR TITLE
language/go: export GetGoConfig, GoConfig, GoConfig.Prefix, GoConfig.PrefixRel

### DIFF
--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -66,14 +66,14 @@ func TestCommandLine(t *testing.T) {
 		"-go_prefix=example.com/repo",
 		"-external=vendored",
 		"-repo_root=.")
-	gc := getGoConfig(c)
+	gc := GetGoConfig(c)
 	for _, tag := range []string{"foo", "bar", "gc"} {
 		if !gc.genericTags[tag] {
 			t.Errorf("expected tag %q to be set", tag)
 		}
 	}
-	if gc.prefix != "example.com/repo" {
-		t.Errorf(`got prefix %q; want "example.com/repo"`, gc.prefix)
+	if gc.Prefix != "example.com/repo" {
+		t.Errorf(`got prefix %q; want "example.com/repo"`, gc.Prefix)
 	}
 	if gc.depMode != vendorMode {
 		t.Errorf("got dep mode %v; want %v", gc.depMode, vendorMode)
@@ -96,17 +96,17 @@ func TestDirectives(t *testing.T) {
 	for _, cext := range cexts {
 		cext.Configure(c, "test", f)
 	}
-	gc := getGoConfig(c)
+	gc := GetGoConfig(c)
 	for _, tag := range []string{"foo", "bar", "gc"} {
 		if !gc.genericTags[tag] {
 			t.Errorf("expected tag %q to be set", tag)
 		}
 	}
-	if gc.prefix != "y" {
-		t.Errorf(`got prefix %q; want "y"`, gc.prefix)
+	if gc.Prefix != "y" {
+		t.Errorf(`got prefix %q; want "y"`, gc.Prefix)
 	}
-	if gc.prefixRel != "test" {
-		t.Errorf(`got prefixRel %q; want "test"`, gc.prefixRel)
+	if gc.PrefixRel != "test" {
+		t.Errorf(`got PrefixRel %q; want "test"`, gc.PrefixRel)
 	}
 	if gc.importMapPrefix != "x" {
 		t.Errorf(`got importmapPrefix %q; want "x"`, gc.importMapPrefix)
@@ -138,7 +138,7 @@ func TestDirectives(t *testing.T) {
 	for _, cext := range cexts {
 		cext.Configure(c, "test/sub", f)
 	}
-	gc = getGoConfig(c)
+	gc = GetGoConfig(c)
 	if gc.goGrpcCompilersSet {
 		t.Error("expected goGrpcCompilersSet to be unset")
 	}
@@ -155,20 +155,20 @@ func TestDirectives(t *testing.T) {
 
 func TestVendorConfig(t *testing.T) {
 	c, _, cexts := testConfig(t)
-	gc := getGoConfig(c)
-	gc.prefix = "example.com/repo"
-	gc.prefixRel = ""
+	gc := GetGoConfig(c)
+	gc.Prefix = "example.com/repo"
+	gc.PrefixRel = ""
 	gc.importMapPrefix = "bad-importmap-prefix"
 	gc.importMapPrefixRel = ""
 	for _, cext := range cexts {
 		cext.Configure(c, "x/vendor", nil)
 	}
-	gc = getGoConfig(c)
-	if gc.prefix != "" {
-		t.Errorf(`prefix: got %q; want ""`, gc.prefix)
+	gc = GetGoConfig(c)
+	if gc.Prefix != "" {
+		t.Errorf(`prefix: got %q; want ""`, gc.Prefix)
 	}
-	if gc.prefixRel != "x/vendor" {
-		t.Errorf(`prefixRel: got %q; want "x/vendor"`, gc.prefixRel)
+	if gc.PrefixRel != "x/vendor" {
+		t.Errorf(`PrefixRel: got %q; want "x/vendor"`, gc.PrefixRel)
 	}
 	if gc.importMapPrefix != "example.com/repo/x/vendor" {
 		t.Errorf(`importMapPrefix: got %q; want "example.com/repo/x/vendor"`, gc.importMapPrefix)
@@ -307,15 +307,15 @@ gazelle(
 			for _, cext := range cexts {
 				cext.Configure(c, "x", f)
 			}
-			gc := getGoConfig(c)
+			gc := GetGoConfig(c)
 			if !gc.prefixSet {
 				t.Fatalf("prefix not set")
 			}
-			if gc.prefix != tc.want {
-				t.Errorf("prefix: want %q; got %q", gc.prefix, tc.want)
+			if gc.Prefix != tc.want {
+				t.Errorf("prefix: want %q; got %q", gc.Prefix, tc.want)
 			}
-			if gc.prefixRel != "x" {
-				t.Errorf("rel: got %q; want %q", gc.prefixRel, "x")
+			if gc.PrefixRel != "x" {
+				t.Errorf("rel: got %q; want %q", gc.PrefixRel, "x")
 			}
 		})
 	}

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -110,7 +110,7 @@ type tagGroup []string
 // are ignored. If the group contains an os or arch tag, but the os or arch
 // parameters are empty, check returns false even if the tag is negated.
 func (g tagGroup) check(c *config.Config, os, arch string) bool {
-	goConf := getGoConfig(c)
+	goConf := GetGoConfig(c)
 	for _, t := range g {
 		if strings.HasPrefix(t, "!!") { // bad syntax, reject always
 			return false

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -504,7 +504,7 @@ import "C"
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			c, _, _ := testConfig(t)
-			gc := getGoConfig(c)
+			gc := GetGoConfig(c)
 			gc.genericTags = tc.genericTags
 			if gc.genericTags == nil {
 				gc.genericTags = map[string]bool{"gc": true}

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -381,8 +381,8 @@ func emptyPackage(c *config.Config, dir, rel string) *goPackage {
 }
 
 func defaultPackageName(c *config.Config, rel string) string {
-	gc := getGoConfig(c)
-	return pathtools.RelBaseName(rel, gc.prefix, "")
+	gc := GetGoConfig(c)
+	return pathtools.RelBaseName(rel, gc.Prefix, "")
 }
 
 type generator struct {
@@ -398,7 +398,7 @@ func (g *generator) generateProto(mode proto.Mode, target protoTarget, importPat
 		return "", nil
 	}
 
-	gc := getGoConfig(g.c)
+	gc := GetGoConfig(g.c)
 	filegroupName := legacyProtoFilegroupName
 	protoName := target.name
 	if protoName == "" {
@@ -460,7 +460,7 @@ func (g *generator) generateLib(pkg *goPackage, embed string) *rule.Rule {
 }
 
 func (g *generator) generateBin(pkg *goPackage, library string) *rule.Rule {
-	name := pathtools.RelBaseName(pkg.rel, getGoConfig(g.c).prefix, g.c.RepoRoot)
+	name := pathtools.RelBaseName(pkg.rel, GetGoConfig(g.c).Prefix, g.c.RepoRoot)
 	goBinary := rule.NewRule("go_binary", name)
 	if !pkg.isCommand() || pkg.binary.sources.isEmpty() && library == "" {
 		return goBinary // empty
@@ -505,14 +505,14 @@ func (g *generator) setCommonAttrs(r *rule.Rule, pkgRel string, visibility []str
 }
 
 func (g *generator) setImportAttrs(r *rule.Rule, importPath string) {
-	gc := getGoConfig(g.c)
+	gc := GetGoConfig(g.c)
 	r.SetAttr("importpath", importPath)
 
 	// Set importpath_aliases if we need minimal module compatibility.
 	// If a package is part of a module with a v2+ semantic import version
 	// suffix, packages that are not part of modules may import it without
 	// the suffix.
-	if gc.goRepositoryMode && gc.moduleMode && pathtools.HasPrefix(importPath, gc.prefix) && gc.prefixRel == "" {
+	if gc.goRepositoryMode && gc.moduleMode && pathtools.HasPrefix(importPath, gc.Prefix) && gc.PrefixRel == "" {
 		if mmcImportPath := pathWithoutSemver(importPath); mmcImportPath != "" {
 			r.SetAttr("importpath_aliases", []string{mmcImportPath})
 		}
@@ -534,7 +534,7 @@ func (g *generator) commonVisibility(importPath string) []string {
 	// probably an internal submodule. Add visibility for all subpackages.
 	relIndex := pathtools.Index(g.rel, "internal")
 	importIndex := pathtools.Index(importPath, "internal")
-	visibility := getGoConfig(g.c).goVisibility
+	visibility := GetGoConfig(g.c).goVisibility
 	if relIndex >= 0 {
 		parent := strings.TrimSuffix(g.rel[:relIndex], "/")
 		visibility = append(visibility, fmt.Sprintf("//%s:__subpackages__", parent))
@@ -547,7 +547,7 @@ func (g *generator) commonVisibility(importPath string) []string {
 	// Add visibility for any submodules that have the internal parent as
 	// a prefix of their module path.
 	if importIndex >= 0 {
-		gc := getGoConfig(g.c)
+		gc := GetGoConfig(g.c)
 		internalRoot := strings.TrimSuffix(importPath[:importIndex], "/")
 		for _, m := range gc.submodules {
 			if strings.HasPrefix(m.modulePath, internalRoot) {

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -151,28 +151,28 @@ func (pkg *goPackage) inferImportPath(c *config.Config) error {
 	if pkg.importPath != "" {
 		log.Panic("importPath already set")
 	}
-	gc := getGoConfig(c)
+	gc := GetGoConfig(c)
 	if !gc.prefixSet {
 		return fmt.Errorf("%s: go prefix is not set, so importpath can't be determined for rules. Set a prefix with a '# gazelle:prefix' comment or with -go_prefix on the command line", pkg.dir)
 	}
 	pkg.importPath = InferImportPath(c, pkg.rel)
 
-	if pkg.rel == gc.prefixRel {
-		pkg.importPath = gc.prefix
+	if pkg.rel == gc.PrefixRel {
+		pkg.importPath = gc.Prefix
 	} else {
-		fromPrefixRel := strings.TrimPrefix(pkg.rel, gc.prefixRel+"/")
-		pkg.importPath = path.Join(gc.prefix, fromPrefixRel)
+		fromPrefixRel := strings.TrimPrefix(pkg.rel, gc.PrefixRel+"/")
+		pkg.importPath = path.Join(gc.Prefix, fromPrefixRel)
 	}
 	return nil
 }
 
 func InferImportPath(c *config.Config, rel string) string {
-	gc := getGoConfig(c)
-	if rel == gc.prefixRel {
-		return gc.prefix
+	gc := GetGoConfig(c)
+	if rel == gc.PrefixRel {
+		return gc.Prefix
 	} else {
-		fromPrefixRel := strings.TrimPrefix(rel, gc.prefixRel+"/")
-		return path.Join(gc.prefix, fromPrefixRel)
+		fromPrefixRel := strings.TrimPrefix(rel, gc.PrefixRel+"/")
+		return path.Join(gc.Prefix, fromPrefixRel)
 	}
 }
 
@@ -250,7 +250,7 @@ func (t *protoTarget) addFile(c *config.Config, info fileInfo) {
 // performance optimization to avoid evaluating constraints repeatedly.
 func getPlatformStringsAddFunction(c *config.Config, info fileInfo, cgoTags tagLine) func(sb *platformStringsBuilder, ss ...string) {
 	isOSSpecific, isArchSpecific := isOSArchSpecific(info, cgoTags)
-	v := getGoConfig(c).rulesGoVersion
+	v := GetGoConfig(c).rulesGoVersion
 
 	switch {
 	case !isOSSpecific && !isArchSpecific:

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -116,13 +116,13 @@ var (
 // This may be used directly by other language extensions related to Go
 // (gomock). Gazelle calls Language.Resolve instead.
 func ResolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, imp string, from label.Label) (label.Label, error) {
-	gc := getGoConfig(c)
+	gc := GetGoConfig(c)
 	if build.IsLocalImport(imp) {
 		cleanRel := path.Clean(path.Join(from.Pkg, imp))
 		if build.IsLocalImport(cleanRel) {
 			return label.NoLabel, fmt.Errorf("relative import path %q from %q points outside of repository", imp, from.Pkg)
 		}
-		imp = path.Join(gc.prefix, cleanRel)
+		imp = path.Join(gc.Prefix, cleanRel)
 	}
 
 	if IsStandard(imp) {
@@ -154,8 +154,8 @@ func ResolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, im
 	if !c.IndexLibraries {
 		// packages in current repo were not indexed, relying on prefix to decide what may have been in
 		// current repo
-		if pathtools.HasPrefix(imp, gc.prefix) {
-			pkg := path.Join(gc.prefixRel, pathtools.TrimPrefix(imp, gc.prefix))
+		if pathtools.HasPrefix(imp, gc.Prefix) {
+			pkg := path.Join(gc.PrefixRel, pathtools.TrimPrefix(imp, gc.Prefix))
 			return label.New("", pkg, defaultLibName), nil
 		}
 	}

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -1062,7 +1062,7 @@ func TestResolveExternal(t *testing.T) {
 	c, langs, _ := testConfig(
 		t,
 		"-go_prefix=example.com/local")
-	gc := getGoConfig(c)
+	gc := GetGoConfig(c)
 	ix := resolve.NewRuleIndex(nil)
 	ix.Finish()
 	gl := langs[1].(*goLang)

--- a/language/go/update.go
+++ b/language/go/update.go
@@ -48,7 +48,7 @@ func (*goLang) UpdateRepos(args language.UpdateReposArgs) language.UpdateReposRe
 			gen[i].SetAttr("importpath", modPath)
 			gen[i].SetAttr("version", version)
 			gen[i].SetAttr("sum", sum)
-			setBuildAttrs(getGoConfig(args.Config), gen[i])
+			setBuildAttrs(GetGoConfig(args.Config), gen[i])
 			return nil
 		})
 	}
@@ -71,7 +71,7 @@ func (*goLang) CanImport(path string) bool {
 func (*goLang) ImportRepos(args language.ImportReposArgs) language.ImportReposResult {
 	res := repoImportFuncs[filepath.Base(args.Path)](args)
 	for _, r := range res.Gen {
-		setBuildAttrs(getGoConfig(args.Config), r)
+		setBuildAttrs(GetGoConfig(args.Config), r)
 	}
 	if args.Prune {
 		genNamesSet := make(map[string]bool)
@@ -88,7 +88,7 @@ func (*goLang) ImportRepos(args language.ImportReposArgs) language.ImportReposRe
 	return res
 }
 
-func setBuildAttrs(gc *goConfig, r *rule.Rule) {
+func setBuildAttrs(gc *GoConfig, r *rule.Rule) {
 	if gc.buildExternalAttr != "" {
 		r.SetAttr("build_external", gc.buildExternalAttr)
 	}


### PR DESCRIPTION
Export `GoConfig` and related fields/methods so that they can be used by other language extensions. 

Has to do with https://github.com/bazelbuild/bazel-gazelle/issues/771#issuecomment-642127471, about having an extension which automatically updates a list of `resolve` directives.