### PR TITLE
language/go: exclude _grpc.pb.go files matching .proto files

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -81,9 +81,12 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	genFiles := append([]string{}, args.GenFiles...)
 	if !pcMode.ShouldIncludePregeneratedFiles() {
 		keep := func(f string) bool {
-			if strings.HasSuffix(f, ".pb.go") {
-				_, ok := protoFileInfo[strings.TrimSuffix(f, ".pb.go")+".proto"]
-				return !ok
+			for _, suffix := range []string{".pb.go", "_grpc.pb.go"} {
+				if strings.HasSuffix(f, suffix) {
+					if _, ok := protoFileInfo[strings.TrimSuffix(f, suffix)+".proto"]; ok {
+						return false
+					}
+				}
 			}
 			return true
 		}

--- a/language/go/testdata/filter_pbgo/BUILD.want
+++ b/language/go/testdata/filter_pbgo/BUILD.want
@@ -1,0 +1,27 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "filter_pbgo_proto",
+    srcs = ["a.proto"],
+    _gazelle_imports = [],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "filter_pbgo_go_proto",
+    _gazelle_imports = [],
+    importpath = "example.com/repo/filter_pbgo",
+    proto = ":filter_pbgo_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["b.pb.go"],
+    _gazelle_imports = [],
+    embed = [":filter_pbgo_go_proto"],
+    importpath = "example.com/repo/filter_pbgo",
+    visibility = ["//visibility:public"],
+)

--- a/language/go/testdata/filter_pbgo/a.pb.go
+++ b/language/go/testdata/filter_pbgo/a.pb.go
@@ -1,0 +1,1 @@
+package a

--- a/language/go/testdata/filter_pbgo/a.proto
+++ b/language/go/testdata/filter_pbgo/a.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+option go_package = "example.com/repo/filter_pbgo";

--- a/language/go/testdata/filter_pbgo/a_grpc.pb.go
+++ b/language/go/testdata/filter_pbgo/a_grpc.pb.go
@@ -1,0 +1,1 @@
+package a

--- a/language/go/testdata/filter_pbgo/b.pb.go
+++ b/language/go/testdata/filter_pbgo/b.pb.go
@@ -1,0 +1,1 @@
+package a


### PR DESCRIPTION
The new APIv2 proto compiler,
google.golang.org/protobuf/cmd/protoc-gen-go, does not generate gRPC
stubs in .pb.go files. Instead, a separate compiler,
google.golang.org/grpc/cmd/protoc-gen-go-grpc, will generate gRPC code
in _grpc.pb.go files.

With this change, Gazelle will exclude _grpc.pb.go files in addition
to .pb.go files when there's a matching .proto file in the same
directory. This should prevent conflicts between definitions in
generated .pb.go files and static _grpc.pb.go files.

The gRPC compiler is not part of a released version yet, but it's
already being used to generate code checked into gRPC 1.30.0. This
change should fix the build issue in #819, though I'm not entirely
sure it's safe to generate that code using protoc-gen-go from APIv1,
so I'll leave that issue open to confirm.

Fixes #798
Updates #819
