### PR TITLE
language/go: several naming convention fixes plus auto-detection

### DIFF
--- a/cmd/gazelle/diff_test.go
+++ b/cmd/gazelle/diff_test.go
@@ -55,7 +55,7 @@ func TestDiffExisting(t *testing.T) {
  # gazelle:prefix example.com/hello
  
 +go_library(
-+    name = "go_default_library",
++    name = "hello",
 +    srcs = ["hello.go"],
 +    importpath = "example.com/hello",
 +    visibility = ["//visibility:public"],
@@ -91,7 +91,7 @@ func TestDiffNew(t *testing.T) {
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
-+    name = "go_default_library",
++    name = "hello",
 +    srcs = ["hello.go"],
 +    importpath = "example.com/hello",
 +    visibility = ["//visibility:public"],
@@ -138,7 +138,7 @@ func TestDiffReadWriteDir(t *testing.T) {
  # gazelle:prefix example.com/hello
 +
 +go_library(
-+    name = "go_default_library",
++    name = "hello",
 +    srcs = ["hello.go"],
 +    importpath = "example.com/hello",
 +    visibility = ["//visibility:public"],

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -257,13 +257,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "hello",
-    embed = [":go_default_library"],
+    embed = [":repo_lib"],
     pure = "on",
     visibility = ["//visibility:public"],
 )
 
 go_library(
-    name = "go_default_library",
+    name = "repo_lib",
     srcs = ["hello.go"],
     importpath = "example.com/repo",
     visibility = ["//visibility:private"],
@@ -291,7 +291,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 # src build file
 
 go_library(
-    name = "go_default_library",
+    name = "repo_lib",
     srcs = ["hello.go"],
     importpath = "example.com/repo",
     visibility = ["//visibility:private"],
@@ -299,7 +299,7 @@ go_library(
 
 go_binary(
     name = "repo",
-    embed = [":go_default_library"],
+    embed = [":repo_lib"],
     visibility = ["//visibility:public"],
 )
 `,
@@ -324,13 +324,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "hello",
-    embed = [":go_default_library"],
+    embed = [":repo_lib"],
     pure = "on",
     visibility = ["//visibility:public"],
 )
 
 go_library(
-    name = "go_default_library",
+    name = "repo_lib",
     srcs = ["hello.go"],
     importpath = "example.com/repo",
     visibility = ["//visibility:private"],

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -524,11 +524,11 @@ import _ "golang.org/x/baz"
 			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["a.go"],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/golang.org/x/bar:go_default_library"],
+    deps = ["//vendor/golang.org/x/bar"],
 )
 `,
 		}, {
@@ -536,12 +536,12 @@ go_library(
 			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importmap = "example.com/foo/vendor/golang.org/x/bar",
     importpath = "golang.org/x/bar",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/golang.org/x/baz:go_default_library"],
+    deps = ["//vendor/golang.org/x/baz"],
 )
 `,
 		},

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -898,11 +898,11 @@ import (
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importpath = "bar",
     visibility = ["//visibility:public"],
-    deps = ["//foo:go_default_library"],
+    deps = ["//foo"],
 )
 `,
 	}})
@@ -1007,7 +1007,7 @@ import _ "example.com/foo"
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importmap = "example.com/repo/sub/vendor/example.com/foo",
     importpath = "example.com/foo",
@@ -1020,11 +1020,11 @@ go_library(
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importpath = "example.com/repo/sub/bar",
     visibility = ["//visibility:public"],
-    deps = ["//sub/vendor/example.com/foo:go_default_library"],
+    deps = ["//sub/vendor/example.com/foo"],
 )
 `,
 		},
@@ -1140,11 +1140,11 @@ import _ "example.com/bar"
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
-    deps = ["@custom_repo//:go_default_library"],
+    deps = ["@custom_repo//:bar"],
 )
 `,
 		},
@@ -1179,6 +1179,7 @@ import _ "example.com/bar"
 	extDir := filepath.Join(dir, "ext")
 	args := []string{
 		"-go_prefix=example.com/foo",
+		"-go_naming_convention=import_alias",
 		"-mode=fix",
 		"-repo_root=" + extDir,
 		"-repo_config=" + filepath.Join(dir, "main", "WORKSPACE"),
@@ -1194,11 +1195,17 @@ import _ "example.com/bar"
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
-    deps = ["@custom_repo//:go_default_library"],
+    deps = ["@custom_repo//:bar"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":foo",
+    visibility = ["//visibility:public"],
 )
 `,
 		},
@@ -2246,7 +2253,7 @@ import _ "example.com/bar"
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importpath = "example.com/bar",
     visibility = ["//visibility:public"],
@@ -2272,11 +2279,11 @@ go_library(
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importpath = "example.com/repo/foo",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/example.com/bar:go_default_library"],
+    deps = ["//vendor/example.com/bar"],
 )
 `,
 	}})
@@ -2311,7 +2318,7 @@ import (
 
 # this should be ignored because -index=false
 go_library(
-    name = "go_default_library",
+    name = "baz",
     srcs = ["baz.go"],
     importpath = "example.com/dep/baz",
     visibility = ["//visibility:public"],
@@ -2342,11 +2349,11 @@ go_library(
 			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importpath = "example.com/repo/foo",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/example.com/dep/baz:go_default_library"],
+    deps = ["//vendor/example.com/dep/baz"],
 )
 `,
 		},
@@ -2394,13 +2401,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # gazelle:prefix example.com/sub
 
 go_library(
-    name = "go_default_library",
+    name = "sub",
     srcs = ["sub.go"],
     importpath = "example.com/sub",
     visibility = ["//visibility:public"],
     deps = [
-        "//sub/missing:go_default_library",
-        "//vendor/example.com/external:go_default_library",
+        "//sub/missing",
+        "//vendor/example.com/external",
     ],
 )
 `,
@@ -2564,8 +2571,11 @@ func TestMapKind(t *testing.T) {
 		{
 			Path: "WORKSPACE",
 		}, {
-			Path:    "BUILD.bazel",
-			Content: "# gazelle:prefix example.com/mapkind",
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:prefix example.com/mapkind
+# gazelle:go_naming_convention go_default_library
+`,
 		}, {
 			Path:    "root_lib.go",
 			Content: `package mapkind`,
@@ -2654,6 +2664,7 @@ go_library(
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 # gazelle:prefix example.com/mapkind
+# gazelle:go_naming_convention go_default_library
 
 go_library(
     name = "go_default_library",
@@ -2820,7 +2831,7 @@ func TestMinimalModuleCompatibilityAliases(t *testing.T) {
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     srcs = ["foo.go"],
     importpath = "example.com/foo/v2",
     importpath_aliases = ["example.com/foo"],
@@ -2833,7 +2844,7 @@ go_library(
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importpath = "example.com/foo/v2/bar",
     importpath_aliases = ["example.com/foo/bar"],
@@ -2880,7 +2891,7 @@ go_repository(
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "version",
     srcs = ["version.go"],
     importpath = "example.com/m/internal/version",
     visibility = [
@@ -2890,9 +2901,9 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "version_test",
     srcs = ["version_test.go"],
-    embed = [":go_default_library"],
+    embed = [":version"],
 )
 `,
 	}})
@@ -3101,7 +3112,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "foo",
     embed = [":foo_go_proto"],
     importpath = "example.com/foo",
     visibility = ["//visibility:public"],
@@ -3159,7 +3170,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # gazelle:lang
 
 go_library(
-    name = "go_default_library",
+    name = "bar",
     srcs = ["bar.go"],
     importpath = "",
     visibility = ["//visibility:public"],
@@ -3173,7 +3184,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # gazelle:lang go,proto
 
 go_library(
-    name = "go_default_library",
+    name = "baz",
     srcs = ["baz.go"],
     importpath = "",
     visibility = ["//visibility:public"],
@@ -3241,7 +3252,7 @@ proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "proto",
     srcs = ["foo.pb.go"],
     importpath = "example.com/proto",
     visibility = ["//visibility:public"],

--- a/internal/gazellebinarytest/gazellebinary_test.go
+++ b/internal/gazellebinarytest/gazellebinary_test.go
@@ -55,7 +55,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # gazelle:prefix example.com/test
 
 go_library(
-    name = "go_default_library",
+    name = "test",
     srcs = ["foo.go"],
     importpath = "example.com/test",
     visibility = ["//visibility:public"],

--- a/internal/runner_test.go
+++ b/internal/runner_test.go
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 	for _, target := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		got[target] = true
 	}
-	want := []string{"//:m", "//:go_default_library"}
+	want := []string{"//:m", "//:m_lib"}
 	for _, target := range want {
 		if !got[target] {
 			t.Errorf("target missing from query output: %s", target)

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -268,8 +268,11 @@ func (f *namingConventionFlag) String() string {
 type namingConvention int
 
 const (
+	// Try to detect the naming convention in use.
+	unknownNamingConvention namingConvention = iota
+
 	// 'go_default_library' and 'go_default_test'
-	goDefaultLibraryNamingConvention = iota
+	goDefaultLibraryNamingConvention
 
 	// For an import path that ends with foo, the go_library rules target is
 	// named 'foo', the go_test is named 'foo_test'.
@@ -296,6 +299,8 @@ func (nc namingConvention) String() string {
 
 func namingConventionFromString(s string) (namingConvention, error) {
 	switch s {
+	case "":
+		return unknownNamingConvention, nil
 	case "go_default_library":
 		return goDefaultLibraryNamingConvention, nil
 	case "import":
@@ -303,7 +308,7 @@ func namingConventionFromString(s string) (namingConvention, error) {
 	case "import_alias":
 		return importAliasNamingConvention, nil
 	default:
-		return goDefaultLibraryNamingConvention, fmt.Errorf("unknown naming convention %q", s)
+		return unknownNamingConvention, fmt.Errorf("unknown naming convention %q", s)
 	}
 }
 
@@ -456,7 +461,12 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 		for _, repo := range c.Repos {
 			if repo.Kind() == "go_repository" {
 				if attr := repo.AttrString("build_naming_convention"); attr == "" {
-					repoNamingConvention[repo.Name()] = goDefaultLibraryNamingConvention // default for go_repository
+					// No naming convention specified.
+					// go_repsitory uses importAliasNamingConvention by default, so we
+					// could use whichever name.
+					// resolveExternal should take that as a signal to follow the current
+					// naming convention to avoid churn.
+					repoNamingConvention[repo.Name()] = importAliasNamingConvention
 				} else if nc, err := namingConventionFromString(attr); err != nil {
 					log.Printf("in go_repository named %q: %v", repo.Name(), err)
 				} else {
@@ -543,6 +553,7 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 				setPrefix(d.Value)
 			}
 		}
+
 		if !gc.prefixSet {
 			for _, r := range f.Rules {
 				switch r.Kind() {
@@ -564,6 +575,10 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 				}
 			}
 		}
+	}
+
+	if gc.goNamingConvention == unknownNamingConvention {
+		gc.goNamingConvention = detectNamingConvention(c, f)
 	}
 }
 
@@ -615,3 +630,73 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 }
 
 var errRulesGoRepoNotFound = errors.New(config.RulesGoRepoName + " external repository not found")
+
+// detectNamingConvention attempts to detect the naming convention in use by
+// reading build files in subdirectories of the repository root directory.
+// If no build files are found (for example, in a new project), or if multiple
+// naming conventions are found, importNamingConvention is returned.
+func detectNamingConvention(c *config.Config, rootFile *rule.File) namingConvention {
+	detectInFile := func(f *rule.File) namingConvention {
+		for _, r := range f.Rules {
+			if r.Kind() != "go_library" {
+				continue
+			}
+			if name := r.Name(); name == defaultLibName {
+				return goDefaultLibraryNamingConvention
+			} else if name == path.Base(r.AttrString("importpath")) {
+				return importNamingConvention
+			}
+		}
+		return unknownNamingConvention
+	}
+
+	detectInDir := func(dir, rel string) namingConvention {
+		var f *rule.File
+		for _, name := range c.ValidBuildFileNames {
+			fpath := filepath.Join(dir, name)
+			data, err := ioutil.ReadFile(fpath)
+			if err != nil {
+				continue
+			}
+			f, err = rule.LoadData(fpath, rel, data)
+			if err != nil {
+				continue
+			}
+		}
+		if f == nil {
+			return unknownNamingConvention
+		}
+		return detectInFile(f)
+	}
+
+	nc := unknownNamingConvention
+	if rootFile != nil {
+		if rootNC := detectInFile(rootFile); rootNC != unknownNamingConvention {
+			return rootNC
+		}
+	}
+
+	infos, err := ioutil.ReadDir(c.RepoRoot)
+	if err != nil {
+		return importNamingConvention
+	}
+	for _, info := range infos {
+		if !info.IsDir() {
+			continue
+		}
+		dirName := info.Name()
+		dirNC := detectInDir(filepath.Join(c.RepoRoot, dirName), dirName)
+		if dirNC == unknownNamingConvention {
+			continue
+		}
+		if nc != unknownNamingConvention && dirNC != nc {
+			// Subdirectories use different conventions. Return the default.
+			return importNamingConvention
+		}
+		nc = dirNC
+	}
+	if nc == unknownNamingConvention {
+		return importNamingConvention
+	}
+	return nc
+}

--- a/language/go/fix.go
+++ b/language/go/fix.go
@@ -45,7 +45,7 @@ func migrateNamingConvention(c *config.Config, f *rule.File) {
 		return
 	}
 	var pkgName string // unknown unless there's a binary
-	if findBinary(f) {
+	if fileContainsGoBinary(c, f) {
 		pkgName = "main"
 	}
 	libName := libNameByConvention(nc, importPath, pkgName)
@@ -110,10 +110,17 @@ func migrateNamingConvention(c *config.Config, f *rule.File) {
 	}
 }
 
-// findBinary returns whether the file has a go_binary rule.
-func findBinary(f *rule.File) bool {
+// fileContainsGoBinary returns whether the file has a go_binary rule.
+func fileContainsGoBinary(c *config.Config, f *rule.File) bool {
+	if f == nil {
+		return false
+	}
 	for _, r := range f.Rules {
-		if r.Kind() == "go_binary" {
+		kind := r.Kind()
+		if mappedKind, ok := c.KindMap[kind]; ok {
+			kind = mappedKind.KindName
+		}
+		if kind == "go_binary" {
 			return true
 		}
 	}

--- a/language/go/fix_test.go
+++ b/language/go/fix_test.go
@@ -105,6 +105,49 @@ go_test(
 )
 `,
 		}, {
+			desc:             "go_naming_convention=go_default_library -> import conflict",
+			namingConvention: importNamingConvention,
+			old: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load(":build_defs.bzl", "x_binary")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+    importpath = "foo",
+    visibility = ["//visibility:private"],
+)
+
+x_binary(
+    name = "foo",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    embed = [":go_default_library"],
+)
+`,
+			want: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load(":build_defs.bzl", "x_binary")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+    importpath = "foo",
+    visibility = ["//visibility:private"],
+)
+
+x_binary(
+    name = "foo",
+)
+
+go_test(
+    name = "foo_test",
+    srcs = ["foo_test.go"],
+    embed = [":go_default_library"],
+)
+`,
+		}, {
 			desc:             "go_naming_convention=import -> go_default_library for lib",
 			namingConvention: goDefaultLibraryNamingConvention,
 			old: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -262,7 +262,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			libName = lib.Name()
 		}
 		rules = append(rules, lib)
-		if r := g.generateAlias(pkg, libName); r != nil {
+		if r := g.maybeGenerateAlias(pkg, libName); r != nil {
 			rules = append(rules, r)
 		}
 		rules = append(rules,
@@ -451,7 +451,7 @@ func (g *generator) generateLib(pkg *goPackage, binName, embed string) *rule.Rul
 	if pkg.isCommand() {
 		bn = binName
 	}
-	name := libNameByConvention(getGoConfig(g.c).goNamingConvention, bn, pkg.name)
+	name := libNameByConvention(getGoConfig(g.c).goNamingConvention, bn, pkg.importPath)
 	goLibrary := rule.NewRule("go_library", name)
 	if !pkg.library.sources.hasGo() && embed == "" {
 		return goLibrary // empty
@@ -468,7 +468,7 @@ func (g *generator) generateLib(pkg *goPackage, binName, embed string) *rule.Rul
 	return goLibrary
 }
 
-func (g *generator) generateAlias(pkg *goPackage, libName string) *rule.Rule {
+func (g *generator) maybeGenerateAlias(pkg *goPackage, libName string) *rule.Rule {
 	if pkg.isCommand() || libName == "" {
 		return nil
 	}
@@ -479,7 +479,7 @@ func (g *generator) generateAlias(pkg *goPackage, libName string) *rule.Rule {
 	alias := rule.NewRule("alias", defaultLibName)
 	alias.SetAttr("visibility", g.commonVisibility(pkg.importPath))
 	if gc.goNamingConvention == importAliasNamingConvention {
-		alias.SetAttr("actual", ":" + libName)
+		alias.SetAttr("actual", ":"+libName)
 	}
 	return alias
 }
@@ -499,7 +499,7 @@ func (g *generator) generateTest(pkg *goPackage, binName, library string) *rule.
 	if pkg.isCommand() {
 		bn = binName
 	}
-	name := testNameByConvention(getGoConfig(g.c).goNamingConvention, bn, pkg.name)
+	name := testNameByConvention(getGoConfig(g.c).goNamingConvention, bn, pkg.importPath)
 	goTest := rule.NewRule("go_test", name)
 	if !pkg.test.sources.hasGo() {
 		return goTest // empty

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -127,7 +127,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 						// if a go_proto_library rule already exists for this
 						// proto package, treat it as if the proto package
 						// doesn't exist.
-						pkg = emptyPackage(c, args.Dir, args.Rel)
+						pkg = emptyPackage(c, args.Dir, args.Rel, args.File)
 						break
 					}
 					pkg = &goPackage{
@@ -139,7 +139,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 					break
 				}
 			} else {
-				pkg = emptyPackage(c, args.Dir, args.Rel)
+				pkg = emptyPackage(c, args.Dir, args.Rel, args.File)
 			}
 		} else {
 			log.Print(err)
@@ -373,9 +373,18 @@ func selectPackage(c *config.Config, dir string, packageMap map[string]*goPackag
 	return nil, err
 }
 
-func emptyPackage(c *config.Config, dir, rel string) *goPackage {
+func emptyPackage(c *config.Config, dir, rel string, f *rule.File) *goPackage {
+	var pkgName string
+	if fileContainsGoBinary(c, f) {
+		// If the file contained a go_binary, its library may have a "_lib" suffix.
+		// Set the package name to "main" so that we generate an empty library rule
+		// with that name.
+		pkgName = "main"
+	} else {
+		pkgName = defaultPackageName(c, dir)
+	}
 	pkg := &goPackage{
-		name: defaultPackageName(c, dir),
+		name: pkgName,
 		dir:  dir,
 		rel:  rel,
 	}

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -266,7 +266,7 @@ func prebuiltProtoRules() []*rule.Rule {
 		proto.Package{
 			Name: "foo",
 			Files: map[string]proto.FileInfo{
-				"foo.proto": proto.FileInfo{},
+				"foo.proto": {},
 			},
 			Imports: map[string]bool{},
 			Options: map[string]string{},

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -105,7 +105,7 @@ func TestGenerateRules(t *testing.T) {
 }
 
 func TestGenerateRulesEmpty(t *testing.T) {
-	c, langs, _ := testConfig(t)
+	c, langs, _ := testConfig(t, "-go_prefix=example.com/repo")
 	goLang := langs[1].(*goLang)
 	res := goLang.GenerateRules(language.GenerateArgs{
 		Config: c,
@@ -125,11 +125,11 @@ filegroup(name = "go_default_library_protos")
 
 go_proto_library(name = "foo_go_proto")
 
-go_library(name = "go_default_library")
+go_library(name = "foo")
 
 go_binary(name = "foo")
 
-go_test(name = "go_default_test")
+go_test(name = "foo_test")
 `)
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
@@ -151,7 +151,7 @@ func TestGenerateRulesEmptyLegacyProto(t *testing.T) {
 }
 
 func TestGenerateRulesEmptyPackageProto(t *testing.T) {
-	c, langs, _ := testConfig(t, "-proto=package")
+	c, langs, _ := testConfig(t, "-proto=package", "-go_prefix=example.com/repo")
 	oldContent := []byte(`
 proto_library(
     name = "dead_proto",
@@ -187,11 +187,11 @@ filegroup(name = "go_default_library_protos")
 
 go_proto_library(name = "foo_go_proto")
 
-go_library(name = "go_default_library")
+go_library(name = "foo")
 
 go_binary(name = "foo")
 
-go_test(name = "go_default_test")
+go_test(name = "foo_test")
 `)
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -159,13 +159,6 @@ func (pkg *goPackage) inferImportPath(c *config.Config) error {
 		return fmt.Errorf("%s: go prefix is not set, so importpath can't be determined for rules. Set a prefix with a '# gazelle:prefix' comment or with -go_prefix on the command line", pkg.dir)
 	}
 	pkg.importPath = InferImportPath(c, pkg.rel)
-
-	if pkg.rel == gc.prefixRel {
-		pkg.importPath = gc.prefix
-	} else {
-		fromPrefixRel := strings.TrimPrefix(pkg.rel, gc.prefixRel+"/")
-		pkg.importPath = path.Join(gc.prefix, fromPrefixRel)
-	}
 	return nil
 }
 

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
+	"github.com/bazelbuild/bazel-gazelle/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
@@ -180,29 +181,42 @@ func libNameFromImportPath(dir string) string {
 	return name
 }
 
-// libNameByConvention returns a suitable lib name based on go_naming_convention
-// If go_default_library, "go_default_library" is returned.
-// Else if this is a 'main' package, 'foo_lib' is returned, where 'foo' is the name of the go_binary rule.
-// Else it is a regular package, the last segment of the importpath is returned. Major version suffixes (eg. "v1") are dropped.
-func libNameByConvention(nc namingConvention, binName, imp string) string {
+// libNameByConvention returns a suitable name for a go_library using the given
+// naming convention, the import path, and the package name.
+func libNameByConvention(nc namingConvention, imp string, pkgName string) string {
 	if nc == goDefaultLibraryNamingConvention {
 		return defaultLibName
 	}
-	if binName != "" {
-		return binName + "_lib"
+	name := libNameFromImportPath(imp)
+	isCommand := pkgName == "main"
+	if name == "" {
+		if isCommand {
+			name = "lib"
+		} else {
+			name = pkgName
+		}
+	} else if isCommand {
+		name += "_lib"
 	}
-	return libNameFromImportPath(imp)
+	return name
 }
 
-// testNameByConvention works like libNameByConvention, but always appends '_test'.
-func testNameByConvention(nc namingConvention, binName, imp string) string {
+// testNameByConvention returns a suitable name for a go_test using the given
+// naming convention and the import path.
+func testNameByConvention(nc namingConvention, imp string) string {
 	if nc == goDefaultLibraryNamingConvention {
 		return defaultTestName
 	}
-	if binName != "" {
-		return binName + "_test"
+	libName := libNameFromImportPath(imp)
+	if libName == "" {
+		libName = "lib"
 	}
-	return libNameFromImportPath(imp) + "_test"
+	return libName + "_test"
+}
+
+// binName returns a suitable name for a go_binary.
+func binName(rel, prefix, repoRoot string) string {
+	return pathtools.RelBaseName(rel, prefix, repoRoot)
 }
 
 func InferImportPath(c *config.Config, rel string) string {

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -156,7 +156,7 @@ func ResolveGo(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, im
 		// current repo
 		if pathtools.HasPrefix(imp, gc.prefix) {
 			pkg := path.Join(gc.prefixRel, pathtools.TrimPrefix(imp, gc.prefix))
-			libName := libNameByConvention(gc.goNamingConvention, "", imp)
+			libName := libNameByConvention(gc.goNamingConvention, imp, "")
 			return label.New("", pkg, libName), nil
 		}
 	}
@@ -277,12 +277,12 @@ func resolveExternal(c *config.Config, rc *repo.RemoteCache, imp string) (label.
 		nc = gc.goNamingConvention
 	}
 
-	name := libNameByConvention(nc, "", imp)
+	name := libNameByConvention(nc, imp, "")
 	return label.New(repo, pkg, name), nil
 }
 
 func resolveVendored(gc *goConfig, imp string) (label.Label, error) {
-	name := libNameByConvention(gc.goNamingConvention, "", imp)
+	name := libNameByConvention(gc.goNamingConvention, imp, "")
 	return label.New("", path.Join("vendor", imp), name), nil
 }
 
@@ -312,7 +312,7 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache,
 	if from.Pkg == "vendor" || strings.HasPrefix(from.Pkg, "vendor/") {
 		rel = path.Join("vendor", rel)
 	}
-	libName := libNameByConvention(getGoConfig(c).goNamingConvention, "", imp)
+	libName := libNameByConvention(getGoConfig(c).goNamingConvention, imp, "")
 	return label.New("", rel, libName), nil
 }
 

--- a/language/go/testdata/allcgolib/BUILD.want
+++ b/language/go/testdata/allcgolib/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "allcgolib",
     srcs = [
         "foo.c",
         "foo.go",
@@ -16,8 +16,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "allcgolib_test",
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
-    embed = [":go_default_library"],
+    embed = [":allcgolib"],
 )

--- a/language/go/testdata/bin/BUILD.want
+++ b/language/go/testdata/bin/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "bin_lib",
     srcs = ["main.go"],
     _gazelle_imports = [
         "example.com/repo/lib",
@@ -14,6 +14,6 @@ go_library(
 go_binary(
     name = "bin",
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":bin_lib"],
     visibility = ["//visibility:public"],
 )

--- a/language/go/testdata/bin_with_tests/BUILD.want
+++ b/language/go/testdata/bin_with_tests/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "bin_with_tests_lib",
     srcs = ["main.go"],
     _gazelle_imports = [
         "example.com/repo/lib",
@@ -14,13 +14,13 @@ go_library(
 go_binary(
     name = "bin_with_tests",
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":bin_with_tests_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "bin_with_tests_test",
     srcs = ["bin_test.go"],
     _gazelle_imports = ["testing"],
-    embed = [":go_default_library"],
+    embed = [":bin_with_tests_lib"],
 )

--- a/language/go/testdata/cgolib/BUILD.want
+++ b/language/go/testdata/cgolib/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "cgolib",
     srcs = [
         "asm.S",
         "foo.c",
@@ -25,8 +25,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "cgolib_test",
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
-    embed = [":go_default_library"],
+    embed = [":cgolib"],
 )

--- a/language/go/testdata/cgolib_with_build_tags/BUILD.want
+++ b/language/go/testdata/cgolib_with_build_tags/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "cgolib_with_build_tags",
     srcs = [
         "asm_linux.S",
         "asm_other.S",
@@ -90,8 +90,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "cgolib_with_build_tags_test",
     srcs = ["foo_test.go"],
     _gazelle_imports = ["testing"],
-    embed = [":go_default_library"],
+    embed = [":cgolib_with_build_tags"],
 )

--- a/language/go/testdata/default_visibility/BUILD.want
+++ b/language/go/testdata/default_visibility/BUILD.want
@@ -16,7 +16,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "default_visibility",
     srcs = ["lib.go"],
     _gazelle_imports = [],
     embed = [":default_visibility_go_proto"],
@@ -24,8 +24,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "default_visibility_test",
     srcs = ["a_test.go"],
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":default_visibility"],
 )

--- a/language/go/testdata/default_visibility/cmd/BUILD.want
+++ b/language/go/testdata/default_visibility/cmd/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "cmd_lib",
     srcs = ["main.go"],
     _gazelle_imports = [],
     importpath = "example.com/repo/default_visibility/cmd",
@@ -10,5 +10,5 @@ go_library(
 go_binary(
     name = "cmd",
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":cmd_lib"],
 )

--- a/language/go/testdata/gen_and_exclude/BUILD.want
+++ b/language/go/testdata/gen_and_exclude/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "gen_and_exclude",
     srcs = [
         "gen.go",
         "gen_linux.go",

--- a/language/go/testdata/importmap/BUILD.want
+++ b/language/go/testdata/importmap/BUILD.want
@@ -19,7 +19,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "importmap",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":hello_go_proto"],
@@ -29,8 +29,8 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "importmap_test",
     srcs = ["extra_test.go"],
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":importmap"],
 )

--- a/language/go/testdata/lib/BUILD.want
+++ b/language/go/testdata/lib/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "lib",
     srcs = [
         "asm.h",
         "asm.s",
@@ -19,7 +19,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "lib_test",
     srcs = [
         "lib_external_test.go",
         "lib_test.go",
@@ -28,5 +28,5 @@ go_test(
         "example.com/repo/lib",
         "testing",
     ],
-    embed = [":go_default_library"],
+    embed = [":lib"],
 )

--- a/language/go/testdata/lib/internal/deep/BUILD.want
+++ b/language/go/testdata/lib/internal/deep/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "deep",
     srcs = ["thought.go"],
     _gazelle_imports = [],
     importpath = "example.com/repo/lib/internal/deep",

--- a/language/go/testdata/lib/internal/go_visibility/BUILD.want
+++ b/language/go/testdata/lib/internal/go_visibility/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "go_visibility",
     srcs = ["thought.go"],
     _gazelle_imports = [],
     importpath = "example.com/repo/lib/internal/go_visibility",

--- a/language/go/testdata/lib/relativeimporter/BUILD.want
+++ b/language/go/testdata/lib/relativeimporter/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "relativeimporter",
     srcs = ["importer.go"],
     _gazelle_imports = [
         "../internal/deep",

--- a/language/go/testdata/main_test_only/BUILD.want
+++ b/language/go/testdata/main_test_only/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
-    name = "go_default_test",
+    name = "main_test_only_test",
     srcs = ["foo_test.go"],
     _gazelle_imports = [],
 )

--- a/language/go/testdata/naming_convention/import_alias/lib/lib.go
+++ b/language/go/testdata/naming_convention/import_alias/lib/lib.go
@@ -13,7 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lib
+// Package libbbbb has a name that doens't match its import path. It shouldn't
+// appear in the build file.
+package libbbbb
 
 // Answer returns the ultimate answer to life, the universe and everything.
 func Answer() int {

--- a/language/go/testdata/naming_convention/import_alias/lib/lib_test.go
+++ b/language/go/testdata/naming_convention/import_alias/lib/lib_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package lib
+package libbbbb
 
 import (
 	"testing"

--- a/language/go/testdata/platforms/BUILD.want
+++ b/language/go/testdata/platforms/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "platforms",
     srcs = [
         "cgo_generic.c",
         "cgo_generic.go",
@@ -52,11 +52,11 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "platforms_test",
     srcs = [
         "generic_test.go",
         "suffix_linux_test.go",
     ],
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":platforms"],
 )

--- a/language/go/testdata/proto_package_mode_extras/BUILD.want
+++ b/language/go/testdata/proto_package_mode_extras/BUILD.want
@@ -41,15 +41,15 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "proto_package_mode_extras",
     _gazelle_imports = [],
     embed = [":foo_go_proto"],
     importpath = "example.com/repo/proto_package_mode_extras",
 )
 
 go_test(
-    name = "go_default_test",
+    name = "proto_package_mode_extras_test",
     srcs = ["foo_test.go"],
     _gazelle_imports = [],
-    embed = [":go_default_library"],
+    embed = [":proto_package_mode_extras"],
 )

--- a/language/go/testdata/protos/BUILD.want
+++ b/language/go/testdata/protos/BUILD.want
@@ -24,7 +24,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":protos_go_proto"],

--- a/language/go/testdata/protos_explicit_default/BUILD.want
+++ b/language/go/testdata/protos_explicit_default/BUILD.want
@@ -25,7 +25,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_explicit_default",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":protos_explicit_default_go_proto"],

--- a/language/go/testdata/protos_gogo/BUILD.want
+++ b/language/go/testdata/protos_gogo/BUILD.want
@@ -25,7 +25,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_gogo",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":protos_gogo_go_proto"],

--- a/language/go/testdata/protos_gogo_subdir_reset/BUILD.want
+++ b/language/go/testdata/protos_gogo_subdir_reset/BUILD.want
@@ -22,7 +22,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_gogo",
     _gazelle_imports = [],
     embed = [":protos_gogo_go_proto"],
     importpath = "example.com/repo/protos_gogo",

--- a/language/go/testdata/protos_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/protos_gogo_subdir_reset/sub/BUILD.want
@@ -18,7 +18,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_gogo",
     _gazelle_imports = [],
     embed = [":protos_gogo_go_proto"],
     importpath = "example.com/repo/protos_gogo",

--- a/language/go/testdata/service/BUILD.want
+++ b/language/go/testdata/service/BUILD.want
@@ -25,7 +25,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "service",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":service_go_proto"],

--- a/language/go/testdata/service_gogo/BUILD.want
+++ b/language/go/testdata/service_gogo/BUILD.want
@@ -25,7 +25,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "service_gogo",
     srcs = ["extra.go"],
     _gazelle_imports = [],
     embed = [":service_gogo_go_proto"],

--- a/language/go/testdata/service_gogo_subdir_reset/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/BUILD.want
@@ -22,7 +22,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_gogo",
     _gazelle_imports = [],
     embed = [":protos_gogo_go_proto"],
     importpath = "example.com/repo/protos_gogo",

--- a/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
@@ -19,7 +19,7 @@ go_proto_library(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "protos_gogo",
     _gazelle_imports = [],
     embed = [":protos_gogo_go_proto"],
     importpath = "example.com/repo/protos_gogo",

--- a/language/go/testdata/tests_import_testdata/BUILD.want
+++ b/language/go/testdata/tests_import_testdata/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
-    name = "go_default_test",
+    name = "tests_import_testdata_test",
     srcs = [
         "external_test.go",
         "internal_test.go",

--- a/language/go/testdata/tests_with_testdata/BUILD.want
+++ b/language/go/testdata/tests_with_testdata/BUILD.want
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
-    name = "go_default_test",
+    name = "tests_with_testdata_test",
     srcs = [
         "external_test.go",
         "internal_test.go",


### PR DESCRIPTION
* For external dependency resolution, if we don't know what naming
  convention the external repository uses (for example, because
  there's no known repository), we'll now use
  goDefaultLibraryNamingConvention. This avoids assuming that
  repositories with build files fetched with http_archive have been
  updated.
* In migrateNamingConvention, print a warning and avoid renaming if
  there's already a target with the new name.
* Library, test, and alias actuals are now generated based on import
  path instead of package name.
* Added unknownNamingConvention, a new zero value.
* Added detectNamingConvention. It reads the root build file and build
  files in subdirectories one level deep to infer the naming
  convention used if one is not specified in the root build
  file. Defaults to importNamingConvention.
* Fixed tests.

For #5