### PR TITLE
Add file name to -mode=print

### DIFF
--- a/cmd/gazelle/print.go
+++ b/cmd/gazelle/print.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -23,6 +24,7 @@ import (
 )
 
 func printFile(c *config.Config, f *rule.File) error {
+	fmt.Printf(">>> %s\n", f.Path)
 	content := f.Format()
 	_, err := os.Stdout.Write(content)
 	return err


### PR DESCRIPTION


**What type of PR is this?**
> Feature

**What package or component does this PR mostly affect?**

> For example:
>
> language/go

**What does this PR do? Why is it needed?**

Adds file name to -mode=print. This will permit a gazelle check mode that ignores CRLF line endings, which gazelle normally does not emit.