### PR TITLE
doc: link to @bazel_skylib//gazelle/bzl [skip ci]

### DIFF
--- a/extend.rst
+++ b/extend.rst
@@ -12,10 +12,10 @@ Extending Gazelle
 .. _proto godoc: https://godoc.org/github.com/bazelbuild/bazel-gazelle/language/proto
 .. _proto.GetProtoConfig: https://godoc.org/github.com/bazelbuild/bazel-gazelle/language/proto#GetProtoConfig
 .. _proto.Package: https://godoc.org/github.com/bazelbuild/bazel-gazelle/language/proto#Package
-.. _rules_sass: https://github.com/bazelbuild/rules_sass
-.. _#75: https://github.com/bazelbuild/rules_sass/pull/75
 .. _bazel_rules_nodejs_contrib: https://github.com/ecosia/bazel_rules_nodejs_contrib#build-file-generation
 .. _#803: https://github.com/bazelbuild/bazel-gazelle/issues/803
+.. _bazel-skylib: https://github.com/bazelbuild/bazel-skylib
+.. _@bazel_skylib//gazelle/bzl: https://github.com/bazelbuild/bazel-skylib/tree/master/gazelle/bzl
 
 .. role:: cmd(code)
 .. role:: flag(code)
@@ -34,7 +34,8 @@ To extend Gazelle, you must do three things:
 * Write a `go_library`_ with a function named ``NewLanguage`` that provides an
   implementation of the Language_ interface. This interface provides hooks for
   generating rules, parsing configuration directives, and resolving imports
-  to Bazel labels.
+  to Bazel labels. By convention, the library's package name should match
+  the language (for example, ``proto`` or ``bzl``).
 * Write a `gazelle_binary`_ rule. Include your library in the ``languages``
   list.
 * Write a `gazelle`_ rule that points to your ``gazelle_binary``. When you run
@@ -46,8 +47,8 @@ Supported languages
 
 Some extensions have been published by the community.
 
-* `rules_sass`_ has an extension for generating ``sass_library`` and
-  ``sass_binary`` rules (currently pending in PR `#75`_).
+* `bazel-skylib`_ has an extension for generating ``bzl_library`` rules.
+  See `@bazel_skylib//gazelle/bzl`_.
 * Ecosia's `bazel_rules_nodejs_contrib`_ has an extension for generating
   ``js_library``, ``jest_node_test``, ``js_import``, and ``ts_library`` rules.
 


### PR DESCRIPTION
* Link to `@bazel_skylib//gazelle/bzl` extension.
* Remove link to rules_sass extension, since the PR was closed.
