### PR TITLE
Add flag to suppress non-error output.

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -83,6 +83,7 @@ func (ucr *updateConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *conf
 	fs.StringVar(&uc.patchPath, "patch", "", "when set with -mode=diff, gazelle will write to a file instead of stdout")
 	fs.Var(&gzflag.MultiFlag{Values: &ucr.knownImports}, "known_import", "import path for which external resolution is skipped (can specify multiple times)")
 	fs.StringVar(&ucr.repoConfigPath, "repo_config", "", "file where Gazelle should load repository configuration. Defaults to WORKSPACE.")
+	fs.BoolVar(&c.Quiet, "quiet", false, "when true, additional debug output during resolution is suppressed")
 }
 
 func (ucr *updateConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,10 @@ type Config struct {
 	// extensions as well. Values in here may be populated by command line
 	// arguments, directives in build files, or other mechanisms.
 	Exts map[string]interface{}
+
+	// Quiet indicates that non-error output should be suppressed; this does
+	// not change any underlying operation.
+	Quiet bool
 }
 
 // MappedKind describes a replacement to use for a built-in kind.

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -174,6 +174,8 @@ def _go_repository_impl(ctx):
             cmd.extend(["-external", ctx.attr.build_external])
         if ctx.attr.build_file_proto_mode:
             cmd.extend(["-proto", ctx.attr.build_file_proto_mode])
+        if ctx.attr.quiet:
+            cmd.append("-quiet")
         cmd.extend(ctx.attr.build_extra_args)
         cmd.append(ctx.path(""))
         result = env_execute(ctx, cmd, environment = env, timeout = _GO_REPOSITORY_TIMEOUT)
@@ -251,6 +253,9 @@ go_repository = repository_rule(
         "build_extra_args": attr.string_list(),
         "build_config": attr.label(default= "@bazel_gazelle_go_repository_config//:WORKSPACE"),
         "build_directives": attr.string_list(default = []),
+
+        # Suppress non-error output during resolution.
+        "quiet": attr.bool(),
 
         # Patches to apply after running gazelle.
         "patches": attr.label_list(),

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -89,8 +89,10 @@ func (gl *goLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remo
 		l = l.Rel(from.Repo, from.Pkg)
 		return l.String(), nil
 	})
-	for _, err := range errs {
-		log.Print(err)
+	if len(errs) > 0 && !c.Quiet {
+		for _, err := range errs {
+			log.Print(err)
+		}
 	}
 	if !deps.IsEmpty() {
 		if r.Kind() == "go_proto_library" {


### PR DESCRIPTION
**What type of PR is this?**

> Other

^^ Minor usability fix.

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

This PR adds a "quiet" option which eliminates the resolve spam. For an example of this issue, see:

https://source.cloud.google.com/results/invocations/77d52c85-2987-4701-b301-1e341c11fddd/log

**Which issues(s) does this PR fix?**

N/A - minor usability fix, can be discussed in the request.