### PR TITLE
Migrate Gazelle to Go import_alias naming convention

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,9 +16,9 @@ gazelle(
 gazelle_binary(
     name = "gazelle_local",
     languages = [
-        "//language/proto:go_default_library",
-        "//language/go:go_default_library",
-        "//internal/language/test_filegroup:go_default_library",
+        "//language/proto",
+        "//language/go",
+        "//internal/language/test_filegroup",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,7 @@ load("//:def.bzl", "gazelle", "gazelle_binary")
 # gazelle:exclude third_party
 # gazelle:exclude .bazelci
 # gazelle:exclude .github
+# gazelle:go_naming_convention import_alias
 gazelle(
     name = "gazelle",
     command = "fix",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,3 +22,13 @@ go_register_toolchains(nogo = "@bazel_gazelle//:nogo")
 load("//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
+
+# gazelle:repository go_repository name=org_golang_x_sync importpath=golang.org/x/sync
+# gazelle:repository go_repository name=org_golang_x_sys importpath=golang.org/x/sys
+# gazelle:repository go_repository name=org_golang_x_xerrors importpath=golang.org/x/xerrors
+# gazelle:repository go_repository name=com_github_bazelbuild_buildtools importpath=github.com/bazelbuild/buildtools build_naming_convention=go_default_library
+# gazelle:repository go_repository name=com_github_fsnotify_fsnotify importpath=github.com/fsnotify/fsnotify
+# gazelle:repository go_repository name=com_github_pelletier_go_toml importpath=github.com/pelletier/go-toml
+# gazelle:repository go_repository name=com_github_pmezard_go_difflib importpath=github.com/pmezard/go-difflib
+# gazelle:repository go_repository name=com_github_bmatcuk_doublestar importpath=github.com/bmatcuk/doublestar
+# gazelle:repository go_repository name=com_github_google_go_cmp importpath=github.com/google/go-cmp

--- a/cmd/autogazelle/BUILD.bazel
+++ b/cmd/autogazelle/BUILD.bazel
@@ -11,34 +11,34 @@ go_library(
     visibility = ["//visibility:private"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
-            "@com_github_fsnotify_fsnotify//:go_default_library",
+            "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
         "//conditions:default": [],
     }),

--- a/cmd/autogazelle/BUILD.bazel
+++ b/cmd/autogazelle/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "autogazelle_lib",
     srcs = [
         "autogazelle.go",
         "client_unix.go",
@@ -46,7 +46,7 @@ go_library(
 
 go_binary(
     name = "autogazelle",
-    embed = [":go_default_library"],
+    embed = [":autogazelle_lib"],
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/fetch_repo/BUILD.bazel
+++ b/cmd/fetch_repo/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "fetch_repo_lib",
     srcs = [
         "fetch_repo.go",
         "module.go",
@@ -14,14 +14,14 @@ go_library(
 
 go_binary(
     name = "fetch_repo",
-    embed = [":go_default_library"],
+    embed = [":fetch_repo_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "fetch_repo_test",
     srcs = ["fetch_repo_test.go"],
-    embed = [":go_default_library"],
+    embed = [":fetch_repo_lib"],
     deps = ["@org_golang_x_tools//go/vcs:go_default_library"],
 )
 

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -23,7 +23,7 @@ gazelle_binary(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "gazelle_lib",
     # keep
     srcs = [
         "diff.go",
@@ -38,25 +38,25 @@ go_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//flag:go_default_library",
-        "//internal/wspace:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//language/go:go_default_library",
-        "//language/proto:go_default_library",
-        "//merger:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
-        "//walk:go_default_library",
+        "//config",
+        "//flag",
+        "//internal/wspace",
+        "//label",
+        "//language",
+        "//language/go",
+        "//language/proto",
+        "//merger",
+        "//repo",
+        "//resolve",
+        "//rule",
+        "//walk",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_pmezard_go_difflib//difflib:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "gazelle_test",
     size = "small",
     srcs = [
         "diff_test.go",
@@ -66,11 +66,11 @@ go_test(
     ],
     args = ["-go_sdk=go_sdk"],
     data = ["@go_sdk//:files"],
-    embed = [":go_default_library"],
+    embed = [":gazelle_lib"],
     deps = [
-        "//config:go_default_library",
-        "//internal/wspace:go_default_library",
-        "//testtools:go_default_library",
+        "//config",
+        "//internal/wspace",
+        "//testtools",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -51,7 +51,7 @@ go_library(
         "//rule",
         "//walk",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
-        "@com_github_pmezard_go_difflib//difflib:go_default_library",
+        "@com_github_pmezard_go_difflib//difflib",
     ],
 )
 

--- a/cmd/generate_repo_config/BUILD.bazel
+++ b/cmd/generate_repo_config/BUILD.bazel
@@ -1,27 +1,27 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "generate_repo_config_lib",
     srcs = ["generate_repo_config.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/cmd/generate_repo_config",
     visibility = ["//visibility:private"],
     deps = [
-        "//repo:go_default_library",
-        "//rule:go_default_library",
+        "//repo",
+        "//rule",
     ],
 )
 
 go_binary(
     name = "generate_repo_config",
-    embed = [":go_default_library"],
+    embed = [":generate_repo_config_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "generate_repo_config_test",
     srcs = ["generate_repo_config_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//testtools:go_default_library"],
+    embed = [":generate_repo_config_lib"],
+    deps = ["//testtools"],
 )
 
 filegroup(

--- a/cmd/move_labels/BUILD.bazel
+++ b/cmd/move_labels/BUILD.bazel
@@ -1,29 +1,29 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "move_labels_lib",
     srcs = ["move_labels.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/cmd/move_labels",
     visibility = ["//visibility:private"],
     deps = [
-        "//internal/wspace:go_default_library",
-        "//label:go_default_library",
-        "//pathtools:go_default_library",
+        "//internal/wspace",
+        "//label",
+        "//pathtools",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
 )
 
 go_binary(
     name = "move_labels",
-    embed = [":go_default_library"],
+    embed = [":move_labels_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "move_labels_test",
     srcs = ["move_labels_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//testtools:go_default_library"],
+    embed = [":move_labels_lib"],
+    deps = ["//testtools"],
 )
 
 filegroup(

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "config",
     srcs = [
         "config.go",
         "constants.go",
@@ -9,16 +9,16 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/wspace:go_default_library",
-        "//rule:go_default_library",
+        "//internal/wspace",
+        "//rule",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "config_test",
     srcs = ["config_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//rule:go_default_library"],
+    embed = [":config"],
+    deps = ["//rule"],
 )
 
 filegroup(
@@ -30,5 +30,11 @@ filegroup(
         "config_test.go",
         "constants.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":config",
     visibility = ["//visibility:public"],
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -29,13 +29,6 @@ load(
     "go_repository_config",
 )
 load(
-    "@bazel_gazelle//internal:overlay_repository.bzl",
-    # Load overlay git_repository and http_archive in order to re-export.
-    # These may be removed at some point in the future.
-    "git_repository",
-    "http_archive",
-)
-load(
     "@bazel_tools//tools/build_defs/repo:git.bzl",
     _tools_git_repository = "git_repository",
 )
@@ -152,7 +145,7 @@ def gazelle_dependencies(
 
     _maybe(
         go_repository,
-        name = "com_github_google_go_cmp",
+        name = "org_golang_x_xerrors",
         importpath = "golang.org/x/xerrors",
         sum = "h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=",
         version = "v0.0.0-20191204190536-9bdfabe68543",

--- a/flag/BUILD.bazel
+++ b/flag/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "flag",
     srcs = ["flag.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/flag",
     visibility = ["//visibility:public"],
@@ -14,5 +14,11 @@ filegroup(
         "BUILD.bazel",
         "flag.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":flag",
     visibility = ["//visibility:public"],
 )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -4,11 +4,11 @@ load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 go_bazel_test(
     name = "go_repository_test",
     srcs = ["go_repository_test.go"],
-    deps = ["//testtools:go_default_library"],
     rule_files = [
         "@bazel_gazelle//:all_files",
         "@io_bazel_rules_go//:all_files",
     ],
+    deps = ["//testtools:go_default_library"],
 )
 
 # TODO(jayconrod): test fetch_repo error cases.

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -8,7 +8,7 @@ go_bazel_test(
         "@bazel_gazelle//:all_files",
         "@io_bazel_rules_go//:all_files",
     ],
-    deps = ["//testtools:go_default_library"],
+    deps = ["//testtools"],
 )
 
 # TODO(jayconrod): test fetch_repo error cases.

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -18,11 +18,6 @@ load(
     "go_context",
 )
 load(
-    "@io_bazel_rules_go//go/platform:list.bzl",
-    "GOARCH",
-    "GOOS",
-)
-load(
     "@io_bazel_rules_go//go/private:rules/transition.bzl",
     "go_transition_rule",
     "go_transition_wrapper",
@@ -95,7 +90,7 @@ _gazelle_binary_kwargs = {
         ),
         "_go_context_data": attr.label(default = "@io_bazel_rules_go//:go_context_data"),
         "_srcs": attr.label(
-            default = "//cmd/gazelle:go_default_library",
+            default = "//cmd/gazelle:gazelle_lib",
         ),
     },
     "executable": True,

--- a/internal/gazellebinarytest/BUILD.bazel
+++ b/internal/gazellebinarytest/BUILD.bazel
@@ -11,28 +11,28 @@ gazelle_binary(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "gazellebinarytest",
     srcs = ["xlang.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/gazellebinarytest",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//label",
+        "//language",
+        "//repo",
+        "//resolve",
+        "//rule",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "gazellebinarytest_test",
     srcs = ["gazellebinary_test.go"],
     data = [":gazelle_go_x"],
-    embed = [":go_default_library"],
+    embed = [":gazellebinarytest"],
     rundir = ".",
     deps = [
-        "//testtools:go_default_library",
+        "//testtools",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
@@ -46,4 +46,10 @@ filegroup(
         "xlang.go",
     ],
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":gazellebinarytest",
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/gazellebinarytest/BUILD.bazel
+++ b/internal/gazellebinarytest/BUILD.bazel
@@ -5,8 +5,8 @@ gazelle_binary(
     name = "gazelle_go_x",
     # keep
     languages = [
-        "//language/go:go_default_library",
-        ":go_default_library",
+        "//language/go",
+        ":gazellebinarytest",
     ],
 )
 

--- a/internal/language/test_filegroup/BUILD.bazel
+++ b/internal/language/test_filegroup/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "test_filegroup",
     srcs = ["lang.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/language/test_filegroup",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//label",
+        "//language",
+        "//repo",
+        "//resolve",
+        "//rule",
     ],
 )
 
@@ -23,4 +23,10 @@ filegroup(
         "lang.go",
     ],
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":test_filegroup",
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/version/BUILD.bazel
+++ b/internal/version/BUILD.bazel
@@ -1,16 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "version",
     srcs = ["version.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/version",
     visibility = ["//:__subpackages__"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "version_test",
     srcs = ["version_test.go"],
-    embed = [":go_default_library"],
+    embed = [":version"],
 )
 
 filegroup(
@@ -22,4 +22,10 @@ filegroup(
         "version_test.go",
     ],
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":version",
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/wspace/BUILD.bazel
+++ b/internal/wspace/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "wspace",
     srcs = ["finder.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/wspace",
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "wspace_test",
     size = "small",
     srcs = ["finder_test.go"],
-    embed = [":go_default_library"],
+    embed = [":wspace"],
 )
 
 filegroup(
@@ -23,4 +23,10 @@ filegroup(
         "finder_test.go",
     ],
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":wspace",
+    visibility = ["//:__subpackages__"],
 )

--- a/label/BUILD.bazel
+++ b/label/BUILD.bazel
@@ -1,17 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "label",
     srcs = ["label.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/label",
     visibility = ["//visibility:public"],
-    deps = ["//pathtools:go_default_library"],
+    deps = ["//pathtools"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "label_test",
     srcs = ["label_test.go"],
-    embed = [":go_default_library"],
+    embed = [":label"],
 )
 
 filegroup(
@@ -22,5 +22,11 @@ filegroup(
         "label.go",
         "label_test.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":label",
     visibility = ["//visibility:public"],
 )

--- a/language/BUILD.bazel
+++ b/language/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "language",
     srcs = [
         "lang.go",
         "update.go",
@@ -9,10 +9,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/language",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//repo",
+        "//resolve",
+        "//rule",
     ],
 )
 
@@ -26,5 +26,11 @@ filegroup(
         "//language/go:all_files",
         "//language/proto:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":language",
     visibility = ["//visibility:public"],
 )

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -12,7 +12,7 @@ std_package_list(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "go",
     srcs = [
         "config.go",
         "constants.go",
@@ -32,16 +32,16 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/language/go",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//flag:go_default_library",
-        "//internal/version:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//language/proto:go_default_library",
-        "//pathtools:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//flag",
+        "//internal/version",
+        "//label",
+        "//language",
+        "//language/proto",
+        "//pathtools",
+        "//repo",
+        "//resolve",
+        "//rule",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_pelletier_go_toml//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
@@ -49,7 +49,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "go_test",
     srcs = [
         "config_test.go",
         "fileinfo_go_test.go",
@@ -61,19 +61,19 @@ go_test(
         "update_import_test.go",
     ],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":go"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//language/proto:go_default_library",
-        "//merger:go_default_library",
-        "//pathtools:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
-        "//testtools:go_default_library",
-        "//walk:go_default_library",
+        "//config",
+        "//label",
+        "//language",
+        "//language/proto",
+        "//merger",
+        "//pathtools",
+        "//repo",
+        "//resolve",
+        "//rule",
+        "//testtools",
+        "//walk",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
@@ -109,5 +109,11 @@ filegroup(
         "update_import_test.go",
         "//language/go/gen_std_package_list:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":go",
     visibility = ["//visibility:public"],
 )

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -43,8 +43,8 @@ go_library(
         "//resolve",
         "//rule",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
-        "@com_github_pelletier_go_toml//:go_default_library",
-        "@org_golang_x_sync//errgroup:go_default_library",
+        "@com_github_pelletier_go_toml//:go-toml",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/language/go/gen_std_package_list/BUILD.bazel
+++ b/language/go/gen_std_package_list/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "gen_std_package_list",
-    embed = [":go_default_library"],
+    embed = [":gen_std_package_list_lib"],
     # TODO(bazelbuild/rules_go#2302): needs to be public in order to use as
     # a default value in std_package_list, which is defined with go_rule.
     # std_package_list should not be defined with go_rule.
@@ -10,7 +10,7 @@ go_binary(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "gen_std_package_list_lib",
     srcs = ["gen_std_package_list.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/language/go/gen_std_package_list",
     visibility = ["//visibility:private"],

--- a/language/proto/BUILD.bazel
+++ b/language/proto/BUILD.bazel
@@ -34,7 +34,7 @@ known_imports(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "proto",
     srcs = [
         "config.go",
         "constants.go",
@@ -42,8 +42,8 @@ go_library(
         "fix.go",
         "generate.go",
         "kinds.go",
-        "known_imports.go",
         "known_go_imports.go",
+        "known_imports.go",
         "known_proto_imports.go",
         "lang.go",
         "package.go",
@@ -52,18 +52,18 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/language/proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//pathtools:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//label",
+        "//language",
+        "//pathtools",
+        "//repo",
+        "//resolve",
+        "//rule",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "proto_test",
     srcs = [
         "config_test.go",
         "fileinfo_test.go",
@@ -71,17 +71,17 @@ go_test(
         "resolve_test.go",
     ],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":proto"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//language:go_default_library",
-        "//merger:go_default_library",
-        "//repo:go_default_library",
-        "//resolve:go_default_library",
-        "//rule:go_default_library",
-        "//testtools:go_default_library",
-        "//walk:go_default_library",
+        "//config",
+        "//label",
+        "//language",
+        "//merger",
+        "//repo",
+        "//resolve",
+        "//rule",
+        "//testtools",
+        "//walk",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
     ],
 )
@@ -102,8 +102,8 @@ filegroup(
         "generate.go",
         "generate_test.go",
         "kinds.go",
-        "known_imports.go",
         "known_go_imports.go",
+        "known_imports.go",
         "known_proto_imports.go",
         "lang.go",
         "package.go",
@@ -112,5 +112,11 @@ filegroup(
         "resolve_test.go",
         "//language/proto/gen:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":proto",
     visibility = ["//visibility:public"],
 )

--- a/language/proto/gen/BUILD.bazel
+++ b/language/proto/gen/BUILD.bazel
@@ -1,16 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "gen_lib",
     srcs = ["gen_known_imports.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/language/proto/gen",
     visibility = ["//visibility:private"],
-    deps = ["//label:go_default_library"],
+    deps = ["//label"],
 )
 
 go_binary(
     name = "gen_known_imports",
-    embed = [":go_default_library"],
+    embed = [":gen_lib"],
     visibility = ["//:__subpackages__"],
 )
 

--- a/merger/BUILD.bazel
+++ b/merger/BUILD.bazel
@@ -1,26 +1,26 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "merger",
     srcs = [
         "fix.go",
         "merger.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/merger",
     visibility = ["//visibility:public"],
-    deps = ["//rule:go_default_library"],
+    deps = ["//rule"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "merger_test",
     size = "small",
     srcs = ["merger_test.go"],
-    embed = [":go_default_library"],
+    embed = [":merger"],
     deps = [
-        "//language:go_default_library",
-        "//language/go:go_default_library",
-        "//language/proto:go_default_library",
-        "//rule:go_default_library",
+        "//language",
+        "//language/go",
+        "//language/proto",
+        "//rule",
     ],
 )
 
@@ -33,5 +33,11 @@ filegroup(
         "merger.go",
         "merger_test.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":merger",
     visibility = ["//visibility:public"],
 )

--- a/pathtools/BUILD.bazel
+++ b/pathtools/BUILD.bazel
@@ -1,16 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "pathtools",
     srcs = ["path.go"],
     importpath = "github.com/bazelbuild/bazel-gazelle/pathtools",
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "pathtools_test",
     srcs = ["path_test.go"],
-    embed = [":go_default_library"],
+    embed = [":pathtools"],
 )
 
 filegroup(
@@ -21,5 +21,11 @@ filegroup(
         "path.go",
         "path_test.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":pathtools",
     visibility = ["//visibility:public"],
 )

--- a/repo/BUILD.bazel
+++ b/repo/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "repo",
     srcs = [
         "remote.go",
         "repo.go",
@@ -9,25 +9,25 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/repo",
     visibility = ["//visibility:public"],
     deps = [
-        "//label:go_default_library",
-        "//pathtools:go_default_library",
-        "//rule:go_default_library",
+        "//label",
+        "//pathtools",
+        "//rule",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "repo_test",
     srcs = [
         "remote_test.go",
         "repo_test.go",
         "stubs_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":repo"],
     deps = [
-        "//pathtools:go_default_library",
-        "//rule:go_default_library",
-        "//testtools:go_default_library",
+        "//pathtools",
+        "//rule",
+        "//testtools",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],
 )
@@ -43,5 +43,11 @@ filegroup(
         "repo_test.go",
         "stubs_test.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":repo",
     visibility = ["//visibility:public"],
 )

--- a/resolve/BUILD.bazel
+++ b/resolve/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "resolve",
     srcs = [
         "config.go",
         "index.go",
@@ -9,10 +9,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/resolve",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//label:go_default_library",
-        "//repo:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//label",
+        "//repo",
+        "//rule",
     ],
 )
 
@@ -24,5 +24,11 @@ filegroup(
         "config.go",
         "index.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":resolve",
     visibility = ["//visibility:public"],
 )

--- a/rule/BUILD.bazel
+++ b/rule/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "rule",
     srcs = [
         "directives.go",
         "expr.go",
@@ -16,19 +16,19 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/rule",
     visibility = ["//visibility:public"],
     deps = [
-        "//label:go_default_library",
+        "//label",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_bazelbuild_buildtools//tables:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "rule_test",
     srcs = [
         "directives_test.go",
         "rule_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":rule"],
     deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
 )
 
@@ -49,5 +49,11 @@ filegroup(
         "types.go",
         "value.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":rule",
     visibility = ["//visibility:public"],
 )

--- a/testtools/BUILD.bazel
+++ b/testtools/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "testtools",
     testonly = True,
     srcs = [
         "config.go",
@@ -10,8 +10,8 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/testtools",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//language:go_default_library",
+        "//config",
+        "//language",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )
@@ -24,5 +24,11 @@ filegroup(
         "config.go",
         "files.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":testtools",
     visibility = ["//visibility:public"],
 )

--- a/testtools/BUILD.bazel
+++ b/testtools/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     deps = [
         "//config",
         "//language",
-        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp",
     ],
 )
 

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "walk",
     srcs = [
         "config.go",
         "walk.go",
@@ -9,25 +9,25 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/walk",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//flag:go_default_library",
-        "//pathtools:go_default_library",
-        "//rule:go_default_library",
+        "//config",
+        "//flag",
+        "//pathtools",
+        "//rule",
         "@com_github_bmatcuk_doublestar//:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "walk_test",
     srcs = [
         "config_test.go",
         "walk_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":walk"],
     deps = [
-        "//config:go_default_library",
-        "//rule:go_default_library",
-        "//testtools:go_default_library",
+        "//config",
+        "//rule",
+        "//testtools",
         "@com_github_bmatcuk_doublestar//:go_default_library",
     ],
 )
@@ -42,5 +42,11 @@ filegroup(
         "walk.go",
         "walk_test.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":walk",
     visibility = ["//visibility:public"],
 )

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "//flag",
         "//pathtools",
         "//rule",
-        "@com_github_bmatcuk_doublestar//:go_default_library",
+        "@com_github_bmatcuk_doublestar//:doublestar",
     ],
 )
 
@@ -28,7 +28,7 @@ go_test(
         "//config",
         "//rule",
         "//testtools",
-        "@com_github_bmatcuk_doublestar//:go_default_library",
+        "@com_github_bmatcuk_doublestar//:doublestar",
     ],
 )
 


### PR DESCRIPTION
* Set naming convention in main build file.
* Add gazelle:repository declarations in WORKSPACE for repos in gazelle_dependencies.
* Run 'gazelle fix'.
* Manual fixes for manually written targets.