### PR TITLE
language/go: add go_naming_convention_extern flag and directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,12 @@ The following flags are accepted:
 | Controls the names of generated Go targets. Equivalent to the                                         |
 | ``# gazelle:go_naming_convention`` directive.                                                         |
 +--------------------------------------------------------------+----------------------------------------+
+| :flag:`-go_naming_convention_extern`                         |                                        |
++--------------------------------------------------------------+----------------------------------------+
+| Controls the default naming convention used when resolving libraries in                               |
+| external repositories with unknown naming conventions. Equivalent to the                              |
+| ``# gazelle:go_naming_convention_extern`` directive.                                                  |
++--------------------------------------------------------------+----------------------------------------+
 | :flag:`-go_prefix example.com/repo`                          |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | A prefix of import paths for libraries in the repository that corresponds to                          |
@@ -601,6 +607,12 @@ The following directives are recognized:
 |   ``foobin_test``.                                                                         |
 | * ``import_alias``: Same as ``import``, but an ``alias`` target is generated named         |
 |   ``go_default_library`` to ensure backwards compatibility.                                |
++---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:go_naming_convention_extern`    | n/a                                    |
++---------------------------------------------------+----------------------------------------+
+| Controls the default naming convention used when resolving libraries in                    |
+| external repositories with unknown naming conventions. Accepts the same values             |
+| as ``go_naming_convention``.                                                               |
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:go_proto_compilers`             | ``@io_bazel_rules_go//proto:go_proto`` |
 +---------------------------------------------------+----------------------------------------+

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -271,15 +271,24 @@ func resolveExternal(c *config.Config, rc *repo.RemoteCache, imp string) (label.
 
 	// Determine what naming convention is used by the repository.
 	// If there is no known repository, it's probably declared in an http_archive
-	// somewhere like go_rules_dependencies. Use the old naming convention.
-	nc, ok := gc.repoNamingConvention[repo]
-	if !ok {
-		nc = goDefaultLibraryNamingConvention
-	}
-	if nc == importAliasNamingConvention {
-		// If the repository is compatible with either naming convention, use
-		// whichever is preferred in this directory to avoid churn.
-		nc = gc.goNamingConvention
+	// somewhere like go_rules_dependencies, so use the old naming convention,
+	// unless the user has explicitly told us otherwise.
+	// If the repository uses the import_alias convention (default for
+	// go_repository), use the convention from the current directory unless the
+	// user has told us otherwise.
+	nc := gc.repoNamingConvention[repo]
+	if nc == unknownNamingConvention {
+		if gc.goNamingConventionExtern != unknownNamingConvention {
+			nc = gc.goNamingConventionExtern
+		} else {
+			nc = goDefaultLibraryNamingConvention
+		}
+	} else if nc == importAliasNamingConvention {
+		if gc.goNamingConventionExtern != unknownNamingConvention {
+			nc = gc.goNamingConventionExtern
+		} else {
+			nc = gc.goNamingConvention
+		}
 	}
 
 	name := libNameByConvention(nc, imp, "")

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -1084,12 +1084,13 @@ func TestResolveExternal(t *testing.T) {
 	ix.Finish()
 	gl := langs[1].(*goLang)
 	for _, tc := range []struct {
-		desc, importpath     string
-		repos                []repo.Repo
-		moduleMode           bool
-		namingConvention     namingConvention
-		repoNamingConvention map[string]namingConvention
-		want                 string
+		desc, importpath       string
+		repos                  []repo.Repo
+		moduleMode             bool
+		namingConvention       namingConvention
+		namingConventionExtern namingConvention
+		repoNamingConvention   map[string]namingConvention
+		want                   string
 	}{
 		{
 			desc:       "top",
@@ -1142,6 +1143,24 @@ func TestResolveExternal(t *testing.T) {
 			},
 			importpath: "example.com/repo/lib",
 			want:       "@custom_repo_name//lib",
+		}, {
+			desc: "custom_repo_naming_convention_extern_import",
+			repos: []repo.Repo{{
+				Name:     "custom_repo_name",
+				GoPrefix: "example.com/repo",
+			}},
+			namingConventionExtern: importNamingConvention,
+			importpath:             "example.com/repo/lib",
+			want:                   "@custom_repo_name//lib",
+		}, {
+			desc: "custom_repo_naming_convention_extern_default",
+			repos: []repo.Repo{{
+				Name:     "custom_repo_name",
+				GoPrefix: "example.com/repo",
+			}},
+			namingConventionExtern: goDefaultLibraryNamingConvention,
+			importpath:             "example.com/repo/lib",
+			want:                   "@custom_repo_name//lib:go_default_library",
 		}, {
 			desc:       "qualified",
 			importpath: "example.com/repo.git/lib",
@@ -1200,6 +1219,7 @@ func TestResolveExternal(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			gc.moduleMode = tc.moduleMode
 			gc.goNamingConvention = tc.namingConvention
+			gc.goNamingConventionExtern = tc.namingConventionExtern
 			gc.repoNamingConvention = tc.repoNamingConvention
 			rc := testRemoteCache(tc.repos)
 			r := rule.NewRule("go_library", "x")


### PR DESCRIPTION
Allows the user to set the default Go naming convention used when
resolving imports of packages in external repositories with unknown
naming conventions.

For #5
