### PR TITLE
gazelle rule: add data attribute

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -50,7 +50,7 @@ def _gazelle_runner_impl(ctx):
         args.extend(["-go_prefix", ctx.attr.prefix])
     if ctx.attr.build_tags:
         args.extend(["-build_tags", ",".join(ctx.attr.build_tags)])
-    args.extend(ctx.attr.extra_args)
+    args.extend([ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.extra_args])
 
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     go_tool = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk.go
@@ -74,7 +74,7 @@ def _gazelle_runner_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.gazelle,
         go_tool,
-    ])
+    ] + ctx.files.data)
     return [DefaultInfo(
         files = depset([out_file]),
         runfiles = runfiles,
@@ -108,6 +108,7 @@ _gazelle_runner = rule(
         "build_tags": attr.string_list(),
         "prefix": attr.string(),
         "extra_args": attr.string_list(),
+        "data": attr.label_list(allow_files = True),
         "_template": attr.label(
             default = "@bazel_gazelle//internal:gazelle.bash.in",
             allow_single_file = True,


### PR DESCRIPTION
This enables callers to pass labels of generated files to Gazelle.

Fixes #867
