### PR TITLE
language/go: fix "extra" target for protoc-gen-go/generator

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -573,7 +573,7 @@ func (g *generator) maybeGenerateExtraLib(lib *rule.Rule, pkg *goPackage) *rule.
 		r.SetAttr("actual", ":go_default_library")
 		r.SetAttr("visibility", []string{"//visibility:public"})
 
-	case "github.com/golang/protobuf/generator":
+	case "github.com/golang/protobuf/protoc-gen-go/generator":
 		r = rule.NewRule("go_library", "go_default_library_gen")
 		r.SetAttr("srcs", pkg.library.sources.buildFlat())
 		r.SetAttr("importpath", pkg.importPath)

--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -363,7 +363,7 @@ func isExtraLibrary(r *rule.Rule) bool {
 	}
 	switch r.AttrString("importpath") {
 	case "github.com/golang/protobuf/descriptor",
-		"github.com/golang/protobuf/generator",
+		"github.com/golang/protobuf/protoc-gen-go/generator",
 		"github.com/golang/protobuf/ptypes":
 		return true
 	default:


### PR DESCRIPTION
The target was generated for github.com/golang/protobuf/generator.
It should be github.com/golang/protobuf/protoc-gen-go/generator.

Fixes #872