### PR TITLE
gazelle_binary: remove mode attributes

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -4,21 +4,6 @@ load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle_binary")
 gazelle_binary(
     name = "gazelle",
     languages = DEFAULT_LANGUAGES,
-    msan = "off",
-    pure = "off",
-    race = "off",
-    static = "off",
-    visibility = ["//visibility:public"],
-)
-
-gazelle_binary(
-    name = "gazelle_pure",
-    languages = DEFAULT_LANGUAGES,
-    msan = "off",
-    pure = "on",
-    race = "off",
-    static = "off",
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -17,11 +17,6 @@ load(
     "GoArchive",
     "go_context",
 )
-load(
-    "@io_bazel_rules_go//go/private:rules/transition.bzl",
-    "go_transition_rule",
-    "go_transition_wrapper",
-)
 
 def _gazelle_binary_impl(ctx):
     go = go_context(ctx)
@@ -99,13 +94,11 @@ _gazelle_binary_kwargs = {
 
 gazelle_binary = rule(**_gazelle_binary_kwargs)
 
-# DEPRECATED(#803): go_transition_rule and go_transition_wrapper are internal
-# to rules_go and should not be used. The mode attributes supported by this
-# are deprecated, and support for them should be dropped after v0.22.0.
-gazelle_transition_binary = go_transition_rule(**_gazelle_binary_kwargs)
-
-def gazelle_binary_wrapper(name, **kwargs):
-    go_transition_wrapper(gazelle_binary, gazelle_transition_binary, name = name, **kwargs)
+def gazelle_binary_wrapper(**kwargs):
+    for key in ("goos", "goarch", "static", "msan", "race", "pure", "strip", "debug", "linkmode", "gotags"):
+        if key in kwargs:
+            fail("gazelle_binary attribute '%s' is no longer supported (https://github.com/bazelbuild/bazel-gazelle/issues/803)" % key)
+    gazelle_binary(**kwargs)
 
 def _format_import(importpath):
     _, _, base = importpath.rpartition("/")


### PR DESCRIPTION
This PR removes mode attributes (goos, goarch, race, etc.) from the
gazelle_binary rule. These attributes were implemented using private
files in rules_go, so supporting them is blocking changes in the
rules_go implementation.

These attributes should probably never be used. gazelle_binary should
generally be built for the host configuration (by 'bazel run' or
'bazel build' without configuration flags). If a binary is still
needed in a different configuration, that may still be accomplished
with command-line flags like --platforms or
--@io_bazel_rules_go//go/config:race.

Fixes #803
