### PR TITLE
doc: fix flag and directive names for go_naming_convention_external [skip ci]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,11 +339,11 @@ The following flags are accepted:
 | Controls the names of generated Go targets. Equivalent to the                                         |
 | ``# gazelle:go_naming_convention`` directive.                                                         |
 +--------------------------------------------------------------+----------------------------------------+
-| :flag:`-go_naming_convention_extern`                         |                                        |
+| :flag:`-go_naming_convention_external`                       |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | Controls the default naming convention used when resolving libraries in                               |
 | external repositories with unknown naming conventions. Equivalent to the                              |
-| ``# gazelle:go_naming_convention_extern`` directive.                                                  |
+| ``# gazelle:go_naming_convention_external`` directive.                                                |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-go_prefix example.com/repo`                          |                                        |
 +--------------------------------------------------------------+----------------------------------------+
@@ -607,7 +607,7 @@ The following directives are recognized:
 | * ``import_alias``: Same as ``import``, but an ``alias`` target is generated named         |
 |   ``go_default_library`` to ensure backwards compatibility.                                |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:go_naming_convention_extern`    | n/a                                    |
+| :direc:`# gazelle:go_naming_convention_external`  | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
 | Controls the default naming convention used when resolving libraries in                    |
 | external repositories with unknown naming conventions. Accepts the same values             |


### PR DESCRIPTION
Fixes #886
