### PR TITLE
Avoid embedding go_library when there is no internal test

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3807,7 +3807,7 @@ go_library(
 go_test(
     name = "foo_test",
     srcs = ["foo_test.go"],
-	embed = [":foo"],
+    embed = [":foo"],
 )`,
 		},
 	}

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3772,3 +3772,59 @@ gazelle_dependencies()
 		},
 	})
 }
+
+func TestExternalOnly(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+		},
+		{
+			Path: "foo/foo.go",
+			Content: `package foo
+import _ "golang.org/x/baz"
+`,
+		},
+		{
+			Path: "foo/foo_test.go",
+			Content: `package foo_test
+import _ "golang.org/x/baz"
+import _ "example.com/foo"
+`,
+		},
+		{
+			Path:    "BUILD.bazel",
+			Content: "# gazelle:prefix example.com",
+		},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	var args []string
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "foo/BUILD.bazel",
+			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_baz//:go_default_library"],
+)
+
+go_test(
+    name = "foo_test",
+    srcs = ["foo_test.go"],
+    deps = [
+        ":foo",
+        "@org_golang_x_baz//:go_default_library",
+    ],
+)`,
+		},
+	})
+}

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3792,8 +3792,23 @@ import _ "example.com/foo"
 `,
 		},
 		{
-			Path:    "BUILD.bazel",
-			Content: "# gazelle:prefix example.com",
+			Path: "foo/BUILD.bazel",
+			Content: `# gazelle:prefix example.com/foo
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_baz//:go_default_library"],
+)
+
+go_test(
+    name = "foo_test",
+    srcs = ["foo_test.go"],
+	embed = [":foo"],
+)`,
 		},
 	}
 	dir, cleanup := testtools.CreateFiles(t, files)
@@ -3807,7 +3822,8 @@ import _ "example.com/foo"
 	testtools.CheckFiles(t, dir, []testtools.FileSpec{
 		{
 			Path: "foo/BUILD.bazel",
-			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+			Content: `# gazelle:prefix example.com/foo
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "foo",

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -62,6 +62,10 @@ type fileInfo struct {
 	// ends with "_test.go". This is never true for non-Go files.
 	isTest bool
 
+	// isExternalTest is true when the file isTest and the original package
+	// name ends with "_test"
+	isExternalTest bool
+
 	// imports is a list of packages imported by a file. It does not include
 	// "C" or anything from the standard library.
 	imports []string
@@ -285,6 +289,7 @@ func goFileInfo(path, rel string) fileInfo {
 	info.packageName = pf.Name.Name
 	if info.isTest && strings.HasSuffix(info.packageName, "_test") {
 		info.packageName = info.packageName[:len(info.packageName)-len("_test")]
+		info.isExternalTest = true
 	}
 
 	for _, decl := range pf.Decls {

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -18,8 +18,6 @@ package golang
 import (
 	"fmt"
 	"go/build"
-	"go/parser"
-	"go/token"
 	"log"
 	"path"
 	"path/filepath"
@@ -520,13 +518,8 @@ func (g *generator) generateTest(pkg *goPackage, library string) *rule.Rule {
 		return goTest // empty
 	}
 	var embed string
-	for src := range pkg.test.sources.strs {
-		f, err := parser.ParseFile(token.NewFileSet(), filepath.Join(pkg.dir, src), nil, parser.PackageClauseOnly)
-		if err == nil && !strings.HasSuffix(f.Name.Name, "_test") {
-			// there are internal tests
-			embed = library
-			break
-		}
+	if pkg.test.hasInternalTest {
+		embed = library
 	}
 	g.setCommonAttrs(goTest, pkg.rel, nil, pkg.test, embed)
 	if pkg.hasTestdata {

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -43,7 +43,7 @@ type goPackage struct {
 // (library, binary, or test).
 type goTarget struct {
 	sources, imports, copts, clinkopts platformStringsBuilder
-	cgo                                bool
+	cgo, hasInternalTest               bool
 }
 
 // protoTarget contains information used to generate a go_proto_library rule.
@@ -108,6 +108,9 @@ func (pkg *goPackage) addFile(c *config.Config, info fileInfo, cgo bool) error {
 			return fmt.Errorf("%s: use of cgo in test not supported", info.path)
 		}
 		pkg.test.addFile(c, info)
+		if !info.isExternalTest {
+			pkg.test.hasInternalTest = true
+		}
 	default:
 		pkg.library.addFile(c, info)
 	}

--- a/language/go/testdata/platforms/BUILD.want
+++ b/language/go/testdata/platforms/BUILD.want
@@ -57,6 +57,5 @@ go_test(
         "generic_test.go",
         "suffix_linux_test.go",
     ],
-    _gazelle_imports = [],
-    embed = [":platforms"],
+    _gazelle_imports = ["example.com/repo/platforms"],
 )

--- a/language/go/testdata/platforms/generic_test.go
+++ b/language/go/testdata/platforms/generic_test.go
@@ -1,1 +1,3 @@
 package platforms_test
+
+import _ "example.com/repo/platforms"

--- a/language/go/testdata/platforms/suffix_linux_test.go
+++ b/language/go/testdata/platforms/suffix_linux_test.go
@@ -1,1 +1,3 @@
 package platforms_test
+
+import _ "example.com/repo/platforms"


### PR DESCRIPTION

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**
`go_test` may [recompile](https://github.com/bazelbuild/rules_go/blob/c69d159acddfeb3a6849e105ec7a57542cac8987/go/private/rules/test.bzl#L245) external test archive where there embedded libraries. For packages with only external tests, this is not necessary and may slow down the build. This PR parse the test files to see if there are any internal tests. If not, the generated `go_test` will not embed `go_default_library`.