### PR TITLE
language/go: infer rules_go version from WORKSPACE

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3844,3 +3844,52 @@ go_test(
 		},
 	})
 }
+
+func TestFindRulesGoVersionWithWORKSPACE(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+			Content: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "7b9bbe3ea1fccb46dcfa6c3f3e29ba7ec740d8733370e21cdc8937467b4a4349",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
+    ],
+)
+`,
+		},
+		{
+			Path: "foo_illumos.go",
+			Content: `
+// illumos not supported in rules_go v0.22.4
+package foo
+`,
+		},
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:prefix example.com/foo
+`,
+		},
+	}
+
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	if err := runGazelle(dir, []string{"update"}); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:prefix example.com/foo
+`,
+		},
+	})
+}

--- a/cmd/generate_repo_config/generate_repo_config.go
+++ b/cmd/generate_repo_config/generate_repo_config.go
@@ -105,9 +105,15 @@ func generateRepoConfig(configDest, configSource string) error {
 
 	destFile := rule.EmptyFile(configDest, "")
 	for _, rsrc := range repos {
+		var rdst *rule.Rule
 		if rsrc.Kind() == "go_repository" {
-			rdst := rule.NewRule("go_repository", rsrc.Name())
+			rdst = rule.NewRule("go_repository", rsrc.Name())
 			rdst.SetAttr("importpath", rsrc.AttrString("importpath"))
+		} else if rsrc.Kind() == "http_archive" && rsrc.Name() == "io_bazel_rules_go" {
+			rdst = rule.NewRule("http_archive", "io_bazel_rules_go")
+			rdst.SetAttr("urls", rsrc.AttrStrings("urls"))
+		}
+		if rdst != nil {
 			rdst.Insert(destFile)
 		}
 	}

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -114,6 +114,7 @@ def _go_repository_impl(ctx):
         # attribute of go_repository, so we don't need to look it up.
         fetch_repo_env = dict(env)
         fetch_repo_env["GOSUMDB"] = "off"
+
         # Override external GO111MODULE, because it is needed by module mode, no-op in repository mode
         fetch_repo_env["GO111MODULE"] = "on"
 
@@ -162,7 +163,7 @@ def _go_repository_impl(ctx):
             "-repo_root",
             ctx.path(""),
             "-repo_config",
-            ctx.path(ctx.attr.build_config)
+            ctx.path(ctx.attr.build_config),
         ]
         if ctx.attr.version:
             cmd.append("-go_repository_module_mode")
@@ -259,7 +260,7 @@ go_repository = repository_rule(
             ],
         ),
         "build_extra_args": attr.string_list(),
-        "build_config": attr.label(default= "@bazel_gazelle_go_repository_config//:WORKSPACE"),
+        "build_config": attr.label(default = "@bazel_gazelle_go_repository_config//:WORKSPACE"),
         "build_directives": attr.string_list(default = []),
 
         # Patches to apply after running gazelle.

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -650,7 +650,7 @@ func rulesGoSupportsOS(v version.Version, os string) bool {
 		return true
 	}
 	if v.Compare(version.Version{0, 23, 0}) < 0 &&
-		os == "illumos" {
+		(os == "aix" || os == "illumos") {
 		return false
 	}
 	return true

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -73,9 +73,9 @@ func ListRepositories(workspace *rule.File) (repos []*rule.Rule, repoFileMap map
 	repoFileMap = make(map[string]*rule.File)
 	for _, repo := range workspace.Rules {
 		if name := repo.Name(); name != "" {
-				repos = append(repos, repo)
-				repoFileMap[name] = workspace
-				repoIndexMap[name] = len(repos) - 1
+			repos = append(repos, repo)
+			repoFileMap[name] = workspace
+			repoIndexMap[name] = len(repos) - 1
 		}
 	}
 	extraRepos, err := parseRepositoryDirectives(workspace.Directives)


### PR DESCRIPTION
We prefer to read RULES_GO_VERSION from @io_bazel_rules_go//go:def.bzl,
but that won't be available if the bazel-out symlink hasn't been
created yet.

As a fallback, look for the io_bazel_rules_go declaration in
WORKSPACE, and try to extract the version from the URLS.

Fixes #780
