### PR TITLE
gazelle_binary: add extra _stdlib attr for older rules_go versions

### DIFF
--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -84,6 +84,9 @@ _gazelle_binary_kwargs = {
             allow_empty = False,
         ),
         "_go_context_data": attr.label(default = "@io_bazel_rules_go//:go_context_data"),
+        # _stdlib is needed for rules_go versions before v0.23.0. After that,
+        # _go_context_data includes a dependency on stdlib.
+        "_stdlib": attr.label(default = "@io_bazel_rules_go//:stdlib"),
         "_srcs": attr.label(
             default = "//cmd/gazelle:gazelle_lib",
         ),


### PR DESCRIPTION
Before rules_go v0.23.0, rules were required to have an _stdlib
attribute, which was usually provided via the go_rules wrapper. Now,
that dependency comes from _go_context_data. Adding an extra edge
keeps us compatible with older versions.

Fixes #896
