### PR TITLE
gazelle rule: simplify runner script

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,4 +27,4 @@ platforms:
     # It requires UNIX domain sockets.
     - "-//cmd/autogazelle/..."
     # Fails to execute, apparently due to command-line length limit.
-    - "-//internal:go_repository_test"
+    - "-//internal:bazel_test"

--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -117,7 +117,7 @@ func TestCreateFile(t *testing.T) {
 	}
 
 	// Check that Gazelle creates a new file named "BUILD.bazel".
-	run(defaultArgs(dir))
+	run(dir, defaultArgs(dir))
 
 	buildFile := filepath.Join(dir, "BUILD.bazel")
 	if _, err = os.Stat(buildFile); err != nil {
@@ -145,7 +145,7 @@ func TestUpdateFile(t *testing.T) {
 	}
 
 	// Check that Gazelle updates the BUILD file in place.
-	run(defaultArgs(dir))
+	run(dir, defaultArgs(dir))
 	if st, err := os.Stat(buildFile); err != nil {
 		t.Errorf("could not stat BUILD: %v", err)
 	} else if st.Size() == 0 {
@@ -196,7 +196,7 @@ go_binary(
 	modTime := st.ModTime()
 
 	// Ensure that Gazelle does not write to the BUILD file.
-	run(defaultArgs(dir))
+	run(dir, defaultArgs(dir))
 	if st, err := os.Stat(buildFile); err != nil {
 		t.Errorf("could not stat BUILD: %v", err)
 	} else if !modTime.Equal(st.ModTime()) {
@@ -350,7 +350,7 @@ go_library(
 				}
 				tc.args[i] = replacer.Replace(tc.args[i])
 			}
-			if err := run(tc.args); err != nil {
+			if err := run(dir, tc.args); err != nil {
 				t.Error(err)
 			}
 			testtools.CheckFiles(t, dir, tc.want)
@@ -388,7 +388,7 @@ go_library(
 	defer cleanup()
 
 	// Check that Gazelle does not update the BUILD file, due to lang filter.
-	run([]string{
+	run(dir, []string{
 		"-repo_root", dir,
 		"-go_prefix", "example.com/repo",
 		"-lang=proto",

--- a/cmd/gazelle/gazelle.go
+++ b/cmd/gazelle/gazelle.go
@@ -59,7 +59,17 @@ func main() {
 	log.SetPrefix("gazelle: ")
 	log.SetFlags(0) // don't print timestamps
 
-	if err := run(os.Args[1:]); err != nil && err != flag.ErrHelp {
+	var wd string
+	if wsDir := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); wsDir != "" {
+		wd = wsDir
+	} else {
+		var err error
+		if wd, err = os.Getwd(); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if err := run(wd, os.Args[1:]); err != nil && err != flag.ErrHelp {
 		if err == exitError {
 			os.Exit(1)
 		} else {
@@ -68,7 +78,7 @@ func main() {
 	}
 }
 
-func run(args []string) error {
+func run(wd string, args []string) error {
 	cmd := updateCmd
 	if len(args) == 1 && (args[0] == "-h" || args[0] == "-help" || args[0] == "--help") {
 		cmd = helpCmd
@@ -82,11 +92,11 @@ func run(args []string) error {
 
 	switch cmd {
 	case fixCmd, updateCmd:
-		return runFixUpdate(cmd, args)
+		return runFixUpdate(wd, cmd, args)
 	case helpCmd:
 		return help()
 	case updateReposCmd:
-		return updateRepos(args)
+		return updateRepos(wd, args)
 	default:
 		log.Panicf("unknown command: %v", cmd)
 	}

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -46,16 +46,7 @@ func skipIfWorkspaceVisible(t *testing.T, dir string) {
 }
 
 func runGazelle(wd string, args []string) error {
-	oldWd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if err := os.Chdir(wd); err != nil {
-		return err
-	}
-	defer os.Chdir(oldWd)
-
-	return run(args)
+	return run(wd, args)
 }
 
 // TestHelp checks that help commands do not panic due to nil flag values.

--- a/def.bzl
+++ b/def.bzl
@@ -132,6 +132,5 @@ def gazelle(name, **kwargs):
     native.sh_binary(
         name = name,
         srcs = [runner_name],
-        args = ["-bazel_run"],
         tags = ["manual"],
     )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,9 +1,12 @@
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
-# gazelle:exclude go_repository_test.go
+# gazelle:exclude *_test.go
 go_bazel_test(
-    name = "go_repository_test",
-    srcs = ["go_repository_test.go"],
+    name = "bazel_test",
+    srcs = [
+        "go_repository_test.go",
+        "runner_test.go",
+    ],
     rule_files = [
         "@bazel_gazelle//:all_files",
         "@io_bazel_rules_go//:all_files",

--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 @@GENERATED_MESSAGE@@
 
 set -euo pipefail
@@ -41,16 +40,6 @@ function find_runfile {
   # printing nothing indicates failure
 }
 
-# bazel_build_get_path builds a given target and prints the absolute path
-# to the generated binary. This only works for rules that produce a single file.
-function bazel_build_get_path {
-  local build_log=$(mktemp gazelle_build.XXXX.json --tmpdir)
-  bazel build --build_event_json_file="$build_log" "$1"
-  grep "^{\"id\":{\"targetCompleted\":{\"label\":\"$1\"" "$build_log" | \
-    sed -e 's!^.*file://\([^"]*\).*$!\1!'
-  rm -f "$build_log"
-}
-
 # set_goroot attempts to set GOROOT to the SDK used by rules_go. gazelle
 # invokes tools inside the Go SDK for dependency management. It's good to
 # use the SDK used by the workspace in case the Go SDK is not installed
@@ -68,14 +57,6 @@ function set_goroot {
   fi
 }
 
-# Check whether the script was executed by Bazel. The gazelle macro prepends
-# an argument that tells us this.
-is_bazel_run=false
-if [ "${1-}" = "-bazel_run" ]; then
-  is_bazel_run=true
-  shift
-fi
-
 # If arguments were provided on the command line, either replace or augment
 # the generated args.
 if [ "${1-}" = "-args" ]; then
@@ -85,35 +66,18 @@ elif [ $# -ne 0 ]; then
   ARGS=("$@")
 fi
 
-if [ "$is_bazel_run" = true ]; then
-  # If the script was invoked by "bazel run", jump out of the execroot, into
-  # the workspace before running Gazelle.
-  # TODO(jayconrod): detect when a command can't be run this way.
-  set_goroot
-  gazelle_short_path=$(find_runfile "$GAZELLE_SHORT_PATH")
-  if [ -z "$gazelle_short_path" ]; then
-    echo "error: could not locate gazelle binary" >&2
-    exit 1
-  fi
-  if [ -z "${BUILD_WORKSPACE_DIRECTORY-}" ]; then
-    echo "error: BUILD_WORKSPACE_DIRECOTRY not set" >&2
-    exit 1
-  fi
-  cd "$BUILD_WORKSPACE_DIRECTORY"
-  "$gazelle_short_path" "${ARGS[@]}"
-else
-  # If the script was invoked directly, check whether the script is out of
-  # date before proceeding.
-  new_runner_script=$(bazel_build_get_path "$RUNNER_LABEL")
-  if ! diff "$new_runner_script" "$0" &>/dev/null; then
-    cat - >&2 <<EOF
-error: $0: script is out of date. Refresh it with the command:
-  bazel build $RUNNER_LABEL && cp -fv "$new_runner_script" "$0"
-EOF
-    exit 1
-  fi
-
-  # Rebuild and run Gazelle.
-  gazelle_exe=$(bazel_build_get_path "$GAZELLE_LABEL")
-  "$gazelle_exe" "${ARGS[@]}"
+# Invoke Gazelle.
+# Note that we don't change directories first; if we did, Gazelle wouldn't be
+# able to find runfiles, and some extensions rely on that. Gazelle can use
+# BUILD_WORKSPACE_DIRECTORY to interpret relative paths on the command line.
+set_goroot
+gazelle_short_path=$(find_runfile "$GAZELLE_SHORT_PATH")
+if [ -z "$gazelle_short_path" ]; then
+  echo "error: could not locate gazelle binary" >&2
+  exit 1
 fi
+if [ -z "${BUILD_WORKSPACE_DIRECTORY-}" ]; then
+  echo "error: BUILD_WORKSPACE_DIRECTORY not set" >&2
+  exit 1
+fi
+"$gazelle_short_path" "${ARGS[@]}"

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package go_repository_test
+package bazel_test
 
 import (
 	"bytes"
@@ -30,6 +30,20 @@ import (
 var testArgs = bazel_testing.Args{
 	Main: `
 -- BUILD.bazel --
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix example.com/m
+
+gazelle(name = "gazelle")
+
+-- go.mod --
+module example.com/m
+
+go 1.15
+-- hello.go --
+package main
+
+func main() {}
 `,
 	WorkspaceSuffix: `
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

--- a/internal/runner_test.go
+++ b/internal/runner_test.go
@@ -1,0 +1,70 @@
+/* Copyright 2020 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bazel_test
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestRunner(t *testing.T) {
+	origBuildData, err := ioutil.ReadFile("BUILD.bazel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("BUILD.bazel", origBuildData, 0666); err != nil {
+			t.Fatalf("restoring build file: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel("run", "//:gazelle"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := bazel_testing.BazelOutput("query", "//:all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool)
+	for _, target := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		got[target] = true
+	}
+	want := []string{"//:m", "//:m_lib"}
+	for _, target := range want {
+		if !got[target] {
+			t.Errorf("target missing from query output: %s", target)
+		}
+	}
+}
+
+func TestRunnerUpdateReposFromGoMod(t *testing.T) {
+	origWorkspaceData, err := ioutil.ReadFile("WORKSPACE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ioutil.WriteFile("WORKSPACE", origWorkspaceData, 0666); err != nil {
+			t.Fatalf("restoring WORKSPACE: %v", err)
+		}
+	}()
+
+	if err := bazel_testing.RunBazel("run", "//:gazelle", "--", "update-repos", "-from_file=go.mod"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This reverts commit 024ada3b0a179ea03ddb8b8b979b4f27194e0834,
rolling forward PR #830, reverted in #844.

The runner script no longer changes directories before invoking
Gazelle. It also no longer supports being invoked without Bazel (to my
knowledge, no one does that).

Instead, Gazelle uses BUILD_WORKSPACE_DIRECTORY (if set) to resolve
relative paths on the command line. The effective working directory is
saved in config.Config, so extensions may access it. That should be
used instead of os.Getwd.

This is needed so that extensions may look up runfiles.

Fixes #827
