### PR TITLE
update-repos can work with a go.mod file in place

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2958,6 +2958,13 @@ require (
 )
 `,
 		},
+		{
+			Path: "go.sum",
+			Content: `
+github.com/Selvatico/go-mocket v1.0.7/go.mod h1:4gO2v+uQmsL+jzQgLANy3tyEFzaEzHlymVbZ3GP2Oes=
+github.com/selvatico/go-mocket v1.0.7/go.mod h1:7bSWzuNieCdUlanCVu3w0ppS0LvDtPAZmKBIlhoTcp8=
+`,
+		},
 	}
 	dir, cleanup := testtools.CreateFiles(t, files)
 	defer cleanup()
@@ -2990,6 +2997,12 @@ require (
 )
 
 replace github.com/selvatico/go-mocket => github.com/Selvatico/go-mocket v1.0.7
+`,
+		},
+		{
+			Path: "go.sum",
+			Content: `
+github.com/Selvatico/go-mocket v1.0.7/go.mod h1:4gO2v+uQmsL+jzQgLANy3tyEFzaEzHlymVbZ3GP2Oes=
 `,
 		},
 	}
@@ -3056,6 +3069,12 @@ require (
 )
 
 replace github.com/selvatico/go-mocket => github.com/Selvatico/go-mocket v1.0.7
+`,
+		},
+		{
+			Path: "go.sum",
+			Content: `
+github.com/Selvatico/go-mocket v1.0.7/go.mod h1:4gO2v+uQmsL+jzQgLANy3tyEFzaEzHlymVbZ3GP2Oes=
 `,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

> language/go
gazelle update-repos

**What does this PR do? Why is it needed?**

Allow update-repos to operate in-place rather than through a temp copy.  Previously, any go.mod files containing relative on-disk replace directives would completely break update-repos, since the temp copy's relative paths would all be broken.

**Which issues(s) does this PR fix?**

Fixes #650
