### PR TITLE
Allow Label.Name to be set as the empty string

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -134,7 +134,7 @@ func (l Label) String() string {
 		repo = fmt.Sprintf("@%s", l.Repo)
 	}
 
-	if path.Base(l.Pkg) == l.Name {
+	if path.Base(l.Pkg) == l.Name || l.Name == "" {
 		return fmt.Sprintf("%s//%s", repo, l.Pkg)
 	}
 	return fmt.Sprintf("%s//%s:%s", repo, l.Pkg, l.Name)

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -29,6 +29,9 @@ func TestLabelString(t *testing.T) {
 			l:    Label{Name: "foo"},
 			want: "//:foo",
 		}, {
+			l:    Label{Pkg: "foo/bar"},
+			want: "//foo/bar",
+		}, {
 			l:    Label{Pkg: "foo/bar", Name: "baz"},
 			want: "//foo/bar:baz",
 		}, {
@@ -37,6 +40,9 @@ func TestLabelString(t *testing.T) {
 		}, {
 			l:    Label{Repo: "com_example_repo", Pkg: "foo/bar", Name: "baz"},
 			want: "@com_example_repo//foo/bar:baz",
+		}, {
+			l:    Label{Repo: "com_example_repo", Pkg: "foo/bar"},
+			want: "@com_example_repo//foo/bar",
 		}, {
 			l:    Label{Repo: "com_example_repo", Pkg: "foo/bar", Name: "bar"},
 			want: "@com_example_repo//foo/bar",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix (or Documentation-truthiness?)

**What package or component does this PR mostly affect?**

label

**What does this PR do? Why is it needed?**

Documentation for `Label.Name` is:
> Name is the name of the target the label refers to. If omitted, Name is assumed to be the same as Pkg.

However, if you use `label.New` and leave `name` empty, you get a label that ends in `:` when you stringify it, as `String()` doesn't handle an empty name. Given `Name` is technically a "public" field, the correct fix seemed like ensuring it creates the expected string label when `Name` is empty.

**Which issues(s) does this PR fix?**

There is not a filed issue, but I can make one if you want it.

**Other notes for review**
