### PR TITLE
Merge private attrs in MergeRules

### DIFF
--- a/rule/merge.go
+++ b/rule/merge.go
@@ -46,6 +46,20 @@ func MergeRules(src, dst *Rule, mergeable map[string]bool, filename string) {
 		return
 	}
 
+	// If src has private attrs, copy them into dst
+	for k, v := range src.private {
+		dst.private[k] = v
+	}
+
+	// Merge the private attrs from src into dest
+	for k, v := range src.private {
+		if _, ok := dst.private[k]; ok {
+			start, _ := dst.expr.Span()
+			log.Printf("%s:%d: Private attribute \"%s\" overridden during merge", filename, start.Line, k)
+		}
+		dst.private[k] = v
+	}
+
 	// Process attributes that are in dst but not in src.
 	for key, dstAttr := range dst.attrs {
 		if _, ok := src.attrs[key]; ok || !mergeable[key] || ShouldKeep(dstAttr) {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

rule.MergeRules

**What does this PR do? Why is it needed?**

I am working on a custom language extension, and was trying to use SetPrivateAttr(...) to pass data between the Generate and Resolve functions. In this particular case, Resolve needs information about the parsed contents of the source file that is not apparent from just the generated rule, and we want to avoid paying the cost of parsing the files twice.

This works fine for rules that are newly-generated by this invocation of Bazel, but when there is an existing rule in the BUILD file with the same name, it inexplicably fails due to MergeRules not propagating private attributes.

**Which issues(s) does this PR fix?**

This seemed small enough to not need a dedicated issue, but I'm happy to open one if more discussion is needed.

**Other notes for review**
