### PR TITLE
diff: make a non-existing file match an empty generation

### DIFF
--- a/cmd/gazelle/diff.go
+++ b/cmd/gazelle/diff.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -42,22 +43,30 @@ func diffFile(c *config.Config, f *rule.File) error {
 		ToDate:   date,
 	}
 
-	if len(f.Content) == 0 {
-		diff.FromFile = "/dev/null"
-	} else {
-		diff.A = difflib.SplitLines(string(f.Content))
-		if c.ReadBuildFilesDir == "" {
-			path, err := filepath.Rel(c.RepoRoot, f.Path)
-			if err != nil {
-				return fmt.Errorf("error getting old path for file %q: %v", f.Path, err)
-			}
-			diff.FromFile = filepath.ToSlash(path)
-		} else {
-			diff.FromFile = f.Path
-		}
+	newContent := f.Format()
+	if bytes.Equal(newContent, f.Content) {
+		// No change.
+		return nil
 	}
 
-	newContent := f.Format()
+	if _, err := os.Stat(f.Path); os.IsNotExist(err) {
+		diff.FromFile = "/dev/null"
+	} else if err != nil {
+		return fmt.Errorf("error reading original file: %v", err)
+	} else if c.ReadBuildFilesDir == "" {
+		path, err := filepath.Rel(c.RepoRoot, f.Path)
+		if err != nil {
+			return fmt.Errorf("error getting old path for file %q: %v", f.Path, err)
+		}
+		diff.FromFile = filepath.ToSlash(path)
+	} else {
+		diff.FromFile = f.Path
+	}
+
+	if len(f.Content) != 0 {
+    		diff.A = difflib.SplitLines(string(f.Content))
+	}
+
 	diff.B = difflib.SplitLines(string(newContent))
 	outPath := findOutputPath(c, f)
 	if c.WriteBuildFilesDir == "" {

--- a/cmd/gazelle/diff_test.go
+++ b/cmd/gazelle/diff_test.go
@@ -102,6 +102,33 @@ func TestDiffNew(t *testing.T) {
 	testtools.CheckFiles(t, dir, want)
 }
 
+func TestDiffMissingAndNoChange(t *testing.T) {
+	files := []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	if err := runGazelle(dir, []string{"-go_prefix=example.com/hello", "-mode=diff", "-patch=p"}); err != nil {
+		t.Error("Expected no diff, but got a diff.")
+	}
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{{Path: "p"}})
+}
+
+func TestDiffEmptyAndNoChange(t *testing.T) {
+	files := []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+		{Path: "BUILD.bazel"},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	if err := runGazelle(dir, []string{"-go_prefix=example.com/hello", "-mode=diff", "-patch=p"}); err != nil {
+		t.Error("Expected no diff, but got a diff.")
+	}
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{{Path: "p"}})
+}
+
 func TestDiffReadWriteDir(t *testing.T) {
 	files := []testtools.FileSpec{
 		{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

`-mode=diff` doesn't handle the generation of empty files the same way as `-mode=fix` does.
Fix won't actually print out empty files, but diff says the empty file should contain a single newline (due to how `difflib.SplitLines` handles the empty string).

**Which issues(s) does this PR fix?**

#925

**Other notes for review**

The test I added actually passes without this change, so it's not actually helpful. I'd love assistance turning it into something which requires this change to pass, and would fail otherwise.