### PR TITLE
Added bzl_library targets for use in external repos using stardoc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
 load("//:def.bzl", "gazelle", "gazelle_binary")
 
@@ -68,6 +69,18 @@ filegroup(
         "//rule:all_files",
         "//testtools:all_files",
         "//walk:all_files",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "bzl_srcs",
+    srcs = [
+        "def.bzl",
+        "deps.bzl",
+    ],
+    deps = [
+        "//internal:bzl_srcs",
     ],
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,6 +23,22 @@ load("//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    http_archive,
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 # gazelle:repository go_repository name=org_golang_x_sync importpath=golang.org/x/sync
 # gazelle:repository go_repository name=org_golang_x_sys importpath=golang.org/x/sys
 # gazelle:repository go_repository name=org_golang_x_xerrors importpath=golang.org/x/xerrors

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
 # gazelle:exclude *_test.go
@@ -46,4 +47,18 @@ filegroup(
         "//internal/wspace:all_files",
     ],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "bzl_srcs",
+    srcs = [
+        "gazelle_binary.bzl",
+        "go_repository.bzl",
+        "go_repository_cache.bzl",
+        "go_repository_config.bzl",
+        "go_repository_tools.bzl",
+        "go_repository_tools_srcs.bzl",
+        "overlay_repository.bzl",
+    ],
+    visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

other

**What does this PR do? Why is it needed?**

This PR exposes `bzl_library` targets.

**Which issues(s) does this PR fix?**

This fixes the ability to use `stardoc` in other projects that depend on `bazel-gazelle`

**Other notes for review**
This implements the same thing as #760 but with a fix for the visibility of the top level `//:bzl_srcs` target so it can **actually** be used in other projects. 

Also, I'm unsure if https://github.com/bazelbuild/rules_go/pull/2621 can be applied to this repo as well.