### PR TITLE
walk: UpdateSubdirsMode

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -120,10 +120,12 @@ func (ucr *updateConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) erro
 		uc.dirs[i] = dir
 	}
 
-	if ucr.recursive {
+	if ucr.recursive && c.IndexLibraries {
 		uc.walkMode = walk.VisitAllUpdateSubdirsMode
 	} else if c.IndexLibraries {
 		uc.walkMode = walk.VisitAllUpdateDirsMode
+	} else if ucr.recursive {
+		uc.walkMode = walk.UpdateSubdirsMode
 	} else {
 		uc.walkMode = walk.UpdateDirsMode
 	}

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2392,6 +2392,83 @@ go_library(
 	})
 }
 
+// TestNoIndexRecurse checks that gazelle behaves correctly with the flags
+// -r=true -index=false. Gazelle should generate build files in directories
+// and subdirectories, but should not resolve dependencies to local libraries.
+func TestNoIndexRecurse(t *testing.T) {
+	files := []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+		{
+			Path: "foo/foo.go",
+			Content: `package foo
+
+import (
+	_ "example.com/dep/baz"
+)
+`,
+		},
+		{
+			Path:    "foo/bar/bar.go",
+			Content: "package bar",
+		}, {
+			Path: "third_party/baz/BUILD.bazel",
+			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# this should be ignored because -index=false
+go_library(
+    name = "baz",
+    srcs = ["baz.go"],
+    importpath = "example.com/dep/baz",
+    visibility = ["//visibility:public"],
+)
+`,
+		}, {
+			Path:    "third_party/baz/baz.go",
+			Content: "package baz",
+		},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	args := []string{
+		"-go_prefix=example.com/repo",
+		"-external=vendored",
+		"-r=true",
+		"-index=false",
+		"foo",
+	}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "foo/BUILD.bazel",
+			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    importpath = "example.com/repo/foo",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/example.com/dep/baz"],
+)
+`,
+		},
+		{
+			Path: "foo/bar/BUILD.bazel",
+			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "bar",
+    srcs = ["bar.go"],
+    importpath = "example.com/repo/foo/bar",
+    visibility = ["//visibility:public"],
+)
+`,
+		}})
+}
+
 // TestSubdirectoryPrefixExternal checks that directives set in subdirectories
 // may be used in dependency resolution. Verifies #412.
 func TestSubdirectoryPrefixExternal(t *testing.T) {

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -2397,8 +2397,7 @@ go_library(
 // and subdirectories, but should not resolve dependencies to local libraries.
 func TestNoIndexRecurse(t *testing.T) {
 	files := []testtools.FileSpec{
-		{Path: "WORKSPACE"},
-		{
+		{Path: "WORKSPACE"}, {
 			Path: "foo/foo.go",
 			Content: `package foo
 
@@ -2406,8 +2405,7 @@ import (
 	_ "example.com/dep/baz"
 )
 `,
-		},
-		{
+		}, {
 			Path:    "foo/bar/bar.go",
 			Content: "package bar",
 		}, {
@@ -2454,8 +2452,7 @@ go_library(
     deps = ["//vendor/example.com/dep/baz"],
 )
 `,
-		},
-		{
+		}, {
 			Path: "foo/bar/BUILD.bazel",
 			Content: `load("@io_bazel_rules_go//go:def.bzl", "go_library")
 

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -238,14 +238,14 @@ func shouldUpdate(rel string, mode Mode, updateParent bool, updateRels map[strin
 // shouldVisit returns true if Walk should visit the subdirectory rel.
 func shouldVisit(rel string, mode Mode, updateParent bool, updateRels map[string]bool) bool {
 	switch mode {
+	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
+		return true
 	case UpdateSubdirsMode:
 		_, ok := updateRels[rel]
 		return ok || updateParent
-	case UpdateDirsMode:
+	default: // UpdateDirsMode
 		_, ok := updateRels[rel]
 		return ok
-	default: // VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode
-		return true
 	}
 }
 

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -215,13 +215,14 @@ func buildUpdateRelMap(root string, dirs []string) map[string]bool {
 // shouldCall returns true if Walk should call the callback in the
 // directory rel.
 func shouldCall(rel string, mode Mode, updateParent bool, updateRels map[string]bool) bool {
-	if mode != UpdateDirsMode && mode != UpdateSubdirsMode {
+	switch mode {
+	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
 		return true
-	}
-	if mode == UpdateSubdirsMode {
+	case UpdateSubdirsMode:
 		return updateParent || updateRels[rel]
+	default: // UpdateDirsMode
+		return updateRels[rel]
 	}
-	return updateRels[rel]
 }
 
 // shouldUpdate returns true if Walk should pass true to the callback's update
@@ -236,14 +237,16 @@ func shouldUpdate(rel string, mode Mode, updateParent bool, updateRels map[strin
 
 // shouldVisit returns true if Walk should visit the subdirectory rel.
 func shouldVisit(rel string, mode Mode, updateParent bool, updateRels map[string]bool) bool {
-	if mode != UpdateDirsMode && mode != UpdateSubdirsMode {
+	switch mode {
+	case UpdateSubdirsMode:
+		_, ok := updateRels[rel]
+		return ok || updateParent
+	case UpdateDirsMode:
+		_, ok := updateRels[rel]
+		return ok
+	default: // VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode
 		return true
 	}
-	_, ok := updateRels[rel]
-	if mode == UpdateSubdirsMode {
-		return ok || updateParent
-	}
-	return ok
 }
 
 func loadBuildFile(c *config.Config, pkg, dir string, files []os.FileInfo) (*rule.File, error) {

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -51,6 +51,7 @@ func TestConfigureCallbackOrder(t *testing.T) {
 func TestUpdateDirs(t *testing.T) {
 	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
 		{Path: "update/sub/"},
+		{Path: "update/sub/sub/"},
 		{
 			Path:    "update/ignore/BUILD.bazel",
 			Content: "# gazelle:ignore",
@@ -83,6 +84,7 @@ func TestUpdateDirs(t *testing.T) {
 				{"update/error", false},
 				{"update/ignore/sub", true},
 				{"update/ignore", false},
+				{"update/sub/sub", true},
 				{"update/sub", true},
 				{"update", true},
 				{"", false},
@@ -96,6 +98,7 @@ func TestUpdateDirs(t *testing.T) {
 				{"update/error", false},
 				{"update/ignore/sub", true},
 				{"update/ignore", false},
+				{"update/sub/sub", false},
 				{"update/sub", false},
 				{"update", true},
 				{"", false},
@@ -107,6 +110,16 @@ func TestUpdateDirs(t *testing.T) {
 			want: []visitSpec{
 				{"update/ignore/sub", true},
 				{"update", true},
+			},
+		}, {
+			desc: "update_subdirs",
+			rels: []string{"update/ignore", "update/sub"},
+			mode: UpdateSubdirsMode,
+			want: []visitSpec{
+				{"update/ignore/sub", true},
+				{"update/ignore", false},
+				{"update/sub/sub", true},
+				{"update/sub", true},
 			},
 		},
 	} {


### PR DESCRIPTION
Introduces `walk.UpdateSubdirsMode` set by `fix-update` when `--index=false` and `--r=true`. 
In this mode, Gazelle only visits and updates the directories given to it and their subdirectories.
Before, with this configuration Gazelle would visit all of the directories in the repository which is
unnecessary because `--index=false`.

Fixes #945
