### PR TITLE
support dependencies on mapped kinds

### DIFF
--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/repo"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
@@ -51,11 +53,61 @@ func (mr *metaResolver) MappedKind(pkgRel string, kind config.MappedKind) {
 // Resolver returns a resolver for the given rule and package, and a bool
 // indicating whether one was found. Empty string may be passed for pkgRel,
 // which results in consulting the builtin kinds only.
-func (mr metaResolver) Resolver(r *rule.Rule, pkgRel string) resolve.Resolver {
+func (mr *metaResolver) Resolver(r *rule.Rule, pkgRel string) resolve.Resolver {
 	for _, mappedKind := range mr.mappedKinds[pkgRel] {
 		if mappedKind.KindName == r.Kind() {
-			return mr.builtins[mappedKind.FromKind]
+			fromKindResolver := mr.builtins[mappedKind.FromKind]
+			if fromKindResolver == nil {
+				return nil
+			}
+			return inverseMapKindResolver{
+				fromKind: mappedKind.FromKind,
+				delegate: fromKindResolver,
+			}
 		}
 	}
 	return mr.builtins[r.Kind()]
+}
+
+// inverseMapKindResolver applies an inverse of the map_kind
+// operations to provided rules. This enables language
+// modules to remain ignorant of mapped kinds.
+type inverseMapKindResolver struct {
+	fromKind string
+	delegate resolve.Resolver
+}
+
+var _ resolve.Resolver = inverseMapKindResolver{}
+
+func (imkr inverseMapKindResolver) Name() string {
+	return imkr.delegate.Name()
+}
+
+func (imkr inverseMapKindResolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	var imports []resolve.ImportSpec
+	imkr.inverseMapKind(r, func(r *rule.Rule) {
+		imports = imkr.delegate.Imports(c, r, f)
+	})
+	return imports
+}
+
+func (imkr inverseMapKindResolver) Embeds(r *rule.Rule, from label.Label) []label.Label {
+	var labels []label.Label
+	imkr.inverseMapKind(r, func(r *rule.Rule) {
+		labels = imkr.delegate.Embeds(r, from)
+	})
+	return labels
+}
+
+func (imkr inverseMapKindResolver) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+	imkr.inverseMapKind(r, func(r *rule.Rule) {
+		imkr.delegate.Resolve(c, ix, rc, r, imports, from)
+	})
+}
+
+func (imkr inverseMapKindResolver) inverseMapKind(r *rule.Rule, fn func(r *rule.Rule)) {
+	origKind := r.Kind()
+	r.SetKind(imkr.fromKind)
+	fn(r)
+	r.SetKind(origKind)
 }

--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -84,29 +84,22 @@ func (imkr inverseMapKindResolver) Name() string {
 }
 
 func (imkr inverseMapKindResolver) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	var imports []resolve.ImportSpec
-	imkr.inverseMapKind(r, func(r *rule.Rule) {
-		imports = imkr.delegate.Imports(c, r, f)
-	})
-	return imports
+	r = imkr.inverseMapKind(r)
+	return imkr.delegate.Imports(c, r, f)
 }
 
 func (imkr inverseMapKindResolver) Embeds(r *rule.Rule, from label.Label) []label.Label {
-	var labels []label.Label
-	imkr.inverseMapKind(r, func(r *rule.Rule) {
-		labels = imkr.delegate.Embeds(r, from)
-	})
-	return labels
+	r = imkr.inverseMapKind(r)
+	return imkr.delegate.Embeds(r, from)
 }
 
 func (imkr inverseMapKindResolver) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
-	imkr.inverseMapKind(r, func(r *rule.Rule) {
-		imkr.delegate.Resolve(c, ix, rc, r, imports, from)
-	})
+	r = imkr.inverseMapKind(r)
+	imkr.delegate.Resolve(c, ix, rc, r, imports, from)
 }
 
-func (imkr inverseMapKindResolver) inverseMapKind(r *rule.Rule, fn func(r *rule.Rule)) {
+func (imkr inverseMapKindResolver) inverseMapKind(r *rule.Rule) *rule.Rule {
 	rCopy := *r
 	rCopy.SetKind(imkr.fromKind)
-	fn(&rCopy)
+	return &rCopy
 }

--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -106,8 +106,7 @@ func (imkr inverseMapKindResolver) Resolve(c *config.Config, ix *resolve.RuleInd
 }
 
 func (imkr inverseMapKindResolver) inverseMapKind(r *rule.Rule, fn func(r *rule.Rule)) {
-	origKind := r.Kind()
-	r.SetKind(imkr.fromKind)
-	fn(r)
-	r.SetKind(origKind)
+	rCopy := *r
+	rCopy.SetKind(imkr.fromKind)
+	fn(&rCopy)
 }


### PR DESCRIPTION
Previously, rules with a mapped kind added to the RuleIndex would not
be importable.

The MetaResolver records mapped kinds generated by recorded associated
with the package. When looking up an import, we do not have the
associated package. This change addresses that by storing the language
name on the ruleRecord itself, obviating the need to look up the
Resolver.

The additional test for this scenario fails prior to this change and
succeeds as a result of it.

Fixes #943
