### PR TITLE
gazelle_dependencies: add support to set project specific go env variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,9 @@ should look like this:
 
     gazelle_dependencies()
 
+``gazelle_dependencies`` supports optional argument ``go_env`` (dict-mapping)
+to set project specific go environment variables.
+
 Add the code below to the BUILD or BUILD.bazel file in the root directory
 of your repository. 
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -38,11 +38,13 @@ go_repository = _go_repository
 
 def gazelle_dependencies(
         go_sdk = "",
-        go_repository_default_config = "@//:WORKSPACE"):
+        go_repository_default_config = "@//:WORKSPACE",
+        go_env = {}):
     if go_sdk:
         go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_name = go_sdk,
+            go_env = go_env,
         )
     else:
         go_sdk_info = {}
@@ -60,6 +62,7 @@ def gazelle_dependencies(
         go_repository_cache(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_info = go_sdk_info,
+            go_env = go_env,
         )
 
     go_repository_tools(


### PR DESCRIPTION
* add parameter `go_env` to rule `gazelle_dependencies`

* add documentation describing new parameter `go_env` in README.rst

* add unit test for inclusion of values in `external/bazel_gazelle_go_repository_cache/go.env`

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**Which issues(s) does this PR fix?**

Fixes #966 


Open questions:
1. Use a blacklist for GOROOT / GOPATH / GOCACHE or use same whitelist as in go_repository.bzl? ( see line 68 in internal/go_repository_cache.bzl )
2. How to test black/whitelist which will need different WORKSPACE for each test?