### PR TITLE
Allow setting proto_strip_import_prefix from root BUILD.bazel

### DIFF
--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -282,7 +282,7 @@ func checkStripImportPrefix(prefix, rel string) error {
 	if !strings.HasPrefix(prefix, "/") {
 		return fmt.Errorf("proto_strip_import_prefix should start with '/' for a prefix relative to the repository root")
 	}
-	if !pathtools.HasPrefix(rel, prefix[1:]) {
+	if rel != "" && !pathtools.HasPrefix(rel, prefix[1:]) {
 		return fmt.Errorf("proto_strip_import_prefix %q not in directory %s", prefix, rel)
 	}
 	return nil

--- a/language/proto/config_test.go
+++ b/language/proto/config_test.go
@@ -18,9 +18,32 @@ package proto
 import "testing"
 
 func TestCheckStripImportPrefix(t *testing.T) {
-	e := checkStripImportPrefix("/example.com/idl", "example.com")
-	wantErr := `proto_strip_import_prefix "/example.com/idl" not in directory example.com`
-	if e == nil || e.Error() != wantErr {
-		t.Errorf("got:\n%v\n\nwant:\n%s\n", e, wantErr)
+	testCases := []struct{
+		name, prefix, rel, wantErr string
+	}{
+		{
+			name: "not in directory",
+			prefix: "/example.com/idl",
+			rel: "example.com",
+			wantErr: `proto_strip_import_prefix "/example.com/idl" not in directory example.com`,
+		},
+		{
+			name: "strip prefix at root",
+			prefix: "/include",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			e := checkStripImportPrefix(tc.prefix, tc.rel)
+			if tc.wantErr == "" {
+				if e != nil {
+					t.Errorf("got:\n%v\n\nwant: nil\n", e)
+				}
+			} else {
+				if e == nil || e.Error() != tc.wantErr {
+					t.Errorf("got:\n%v\n\nwant:\n%s\n", e, tc.wantErr)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**

language/proto

**What does this PR do? Why is it needed?**
In `go_repository` rules, all Gazelle directives are at the root level BUILD.bazel. We should allow setting `proto_strip_import_prefix` at the root BUILD.bazel without warnings
