### PR TITLE
Allow FixLoads to fix any CallExpr and support requirement("name") style dependencies

### DIFF
--- a/merger/BUILD.bazel
+++ b/merger/BUILD.bazel
@@ -8,15 +8,18 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/merger",
     visibility = ["//visibility:public"],
-    deps = ["//rule"],
+    deps = [
+        "//rule",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+    ],
 )
 
 go_test(
     name = "merger_test",
     size = "small",
     srcs = ["merger_test.go"],
-    embed = [":merger"],
     deps = [
+        ":merger",
         "//language",
         "//language/go",
         "//language/proto",

--- a/merger/fix.go
+++ b/merger/fix.go
@@ -58,7 +58,7 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 	}
 
 	// Make a map of all the symbols from known files used in this file.
-	// We walk the whole AST to find every call expression that LHS is an
+	// We walk the whole AST to find every call expression where LHS is an
 	// identifier.
 	usedKinds := make(map[string]map[string]bool)
 	bzl.WalkPointers(f.File, func(x *bzl.Expr, _ []bzl.Expr) {

--- a/merger/fix.go
+++ b/merger/fix.go
@@ -59,12 +59,13 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 	// Make a map of all the symbols from known files used in this file.
 	usedKinds := make(map[string]map[string]bool)
 	for _, r := range f.Rules {
-		kind := r.Kind()
-		if file, ok := knownKinds[kind]; ok && !otherLoadedKinds[kind] {
-			if usedKinds[file] == nil {
-				usedKinds[file] = make(map[string]bool)
+		for _, symbol := range r.CalledSymbols() {
+			if file, ok := knownKinds[symbol]; ok && !otherLoadedKinds[symbol] {
+				if usedKinds[file] == nil {
+					usedKinds[file] = make(map[string]bool)
+				}
+				usedKinds[file][symbol] = true
 			}
-			usedKinds[file][kind] = true
 		}
 	}
 

--- a/merger/merger_test.go
+++ b/merger/merger_test.go
@@ -867,7 +867,7 @@ go_proto_library(
 )
 `,
 	}, {
-		desc: "allow single argument macros",
+		desc: "allow single string argument macros",
 		previous: `
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
 
@@ -903,7 +903,7 @@ go_library(
     srcs = [
         "lex.go",
         "print.go",
-        go_binary("asdf"),
+        go_binary("fake_macro_expansion"),
     ],
 )
 
@@ -924,7 +924,7 @@ go_library(
     srcs = [
         "lex.go",  # comment about this line
         "print.go",
-        go_binary("asdf"),
+        go_binary("fake_macro_expansion"),
         # go_binary isn't valid here, we are testing the loading and sorting
         # of single argument macros. e.g. requirement("package_name")
         go_binary("keep"),  # keep

--- a/merger/merger_test.go
+++ b/merger/merger_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/language/go"
+	golang "github.com/bazelbuild/bazel-gazelle/language/go"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/merger"
 	"github.com/bazelbuild/bazel-gazelle/rule"

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -189,21 +189,21 @@ func dictEntryKeyValue(e bzl.Expr) (string, *bzl.ListExpr, error) {
 	return k.Value, v, nil
 }
 
-// simpleValue is a string or a call expression with a single string argument
-// e.g. "string" or call_expression("string")
+// simpleValue encapsulates information about a string or a call expression
+// with a single string argument. e.g. "string" or call_expression("string")
 // Some bazel language rules (e.g. rules_python) use macro expansions of this
 // nature to hide mangled labels that might change from version to version.
 type simpleValue struct {
 	symbol, str string
 }
 
-// parses `identifier("string")`
+// simpleValueFromExpr tries to create a simpleValue from an unknown bzl.Expr.
 func simpleValueFromExpr(e bzl.Expr) (simpleValue, error) {
 	switch expr := e.(type) {
 	case *bzl.StringExpr:
 		return simpleValue{str: expr.Value}, nil
 	case *bzl.CallExpr:
-		// is calling an identifier and only one argument which is a string
+		// Check if calling an identifier with one string argument.
 		if id, ok := expr.X.(*bzl.Ident); ok && len(expr.List) == 1 {
 			if arg, ok := expr.List[0].(*bzl.StringExpr); ok {
 				return simpleValue{id.Name, arg.Value}, nil

--- a/rule/merge.go
+++ b/rule/merge.go
@@ -433,15 +433,16 @@ func squashDict(x, y *bzl.DictExpr) (*bzl.DictExpr, error) {
 	return &squashed, nil
 }
 
-// listSquasher builds a sorted, deduplicated list of string expressions. If
-// a string expression is added multiple times, comments are consolidated.
+// listSquasher builds a sorted, deduplicated list of simpleValues (string
+// expressions and single string argument call expressions).
+// If a simpleValue is added multiple times, comments are consolidated.
 // The original expressions are not modified.
 type listSquasher struct {
 	unique       map[simpleValue]uniqueExpr // track unique expressions
 	seenComments map[elemComment]bool       // track unique comments on expressions
 }
 
-// uniqueExpr tracks unique expressions and has a reference to their comments
+// uniqueExpr tracks unique expressions and has a reference to their comments.
 type uniqueExpr struct {
 	expr     bzl.Expr
 	comments *bzl.Comments

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -691,6 +691,20 @@ func NewRule(kind, name string) *Rule {
 	return r
 }
 
+// CalledSymbols returns a list of every identifier called in the rule, including the rule's name
+func (r *Rule) CalledSymbols() (symbols []string) {
+	symbols = append(symbols, r.kind)
+	bzl.WalkOnce(r.expr, func(x *bzl.Expr) {
+		if call, ok := (*x).(*bzl.CallExpr); ok {
+			if symbol, ok := call.X.(*bzl.Ident); ok {
+				symbols = append(symbols, symbol.Name)
+			}
+		}
+	})
+
+	return
+}
+
 func ruleFromExpr(index int, expr bzl.Expr) *Rule {
 	call, ok := expr.(*bzl.CallExpr)
 	if !ok {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -691,20 +691,6 @@ func NewRule(kind, name string) *Rule {
 	return r
 }
 
-// CalledSymbols returns a list of every identifier called in the rule, including the rule's name
-func (r *Rule) CalledSymbols() (symbols []string) {
-	symbols = append(symbols, r.kind)
-	bzl.WalkOnce(r.expr, func(x *bzl.Expr) {
-		if call, ok := (*x).(*bzl.CallExpr); ok {
-			if symbol, ok := call.X.(*bzl.Ident); ok {
-				symbols = append(symbols, symbol.Name)
-			}
-		}
-	})
-
-	return
-}
-
 func ruleFromExpr(index int, expr bzl.Expr) *Rule {
 	call, ok := expr.(*bzl.CallExpr)
 	if !ok {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

This PR allows gazelle to merge, sort, and identify loads from "simple call expressions", i.e. starlark call expressions with a single string argument.

For example, rules_python uses a macro to expand a string to a full (but mangled) label, the mangling algorithm might change from rules_python version to version. I'm attempting to write a gazelle plugin for Python, and ran into a roadblock here. It felt like a much better idea to emit the macro than to have a moving target of emitting mangled names, mostly for git diff and developer readability reasons.

A simple example of a build file that a Python gazelle plugin might try to sync:

```
load("@rules_python//python:defs.bzl", "py_library")
load("@pip3//:requirements.bzl", "requirement")

py_library(
    name = "mylibrary",
    srcs = [
        "__init__.py",
        "fun.py",
    ],
    visibility = ["//visibility:public"],
    deps = [
        "//other/label",
        requirement("numpy"),
    ],
)
```

Currently gazelle allows for the rule syntax above to be emitted, but the macro won't be automatically loaded, and if being merged with an existing build file, the existing list gets clobbered, as gazelle can't handle lists of strings + other things. The change adds the ability for gazelle to reason about very simple call expressions, specifically ones with a single string argument, and allows those to be included in lists of strings.

**Which issues(s) does this PR fix?**

Fixes #978

**Other notes for review**

This review ended up being fairly invasive as I wanted to support these [simpleValue](https://github.com/wolfd/bazel-gazelle/blob/a1020867fa059d6020ed70471c22b40f9b9931d6/rule/expr.go#L192-L198) expressions in a number of places. The `requirement("pypi_name")` pattern is common to a few different Python related rules, [the official rules](https://github.com/bazelbuild/rules_python/blob/bbe0712276ee2c9cd216323783fbdbfa15da7c99/examples/pip_install/BUILD#L34) and [a popular alternative way of using pip with the official rules](https://github.com/ali5h/rules_pip/blob/0559f4dfb1bfce200dc8db5d8f1c011d1eb1aaff/examples/src/BUILD#L9), but at a cursory glance, it seems somewhat unique to Python.

So, I'd be happy to discuss whether this method seems reasonable to you, and if need be, come up with alternatives.

Also, I think I'd want to add a test case to test the squash behavior, but wanted to get your opinion first on the rest of this.