### PR TITLE
Label fix: properly parse external references to the main repository

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,7 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+	labelRepoRegexp = regexp.MustCompile(`^$|^[A-Za-z][A-Za-z0-9_]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
 	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
 )

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -59,7 +59,6 @@ func TestParse(t *testing.T) {
 	}{
 		{str: "", wantErr: true},
 		{str: "@//:", wantErr: true},
-		{str: "@//:a", wantErr: true},
 		{str: "@a:b", wantErr: true},
 		{str: "@//:a", want: Label{Name: "a", Relative: false}},
 		{str: "@//a:b", want: Label{Repo: "", Pkg: "a", Name: "b"}},

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -61,6 +61,8 @@ func TestParse(t *testing.T) {
 		{str: "@//:", wantErr: true},
 		{str: "@//:a", wantErr: true},
 		{str: "@a:b", wantErr: true},
+		{str: "@//:a", want: Label{Name: "a", Relative: false}},
+		{str: "@//a:b", want: Label{Repo: "", Pkg: "a", Name: "b"}},
 		{str: ":a", want: Label{Name: "a", Relative: true}},
 		{str: "a", want: Label{Name: "a", Relative: true}},
 		{str: "//:a", want: Label{Name: "a", Relative: false}},


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> go_repository

**What does this PR do? Why is it needed?**

This fix changes the variable `labelRepoRegexp` to properly parse labels starting with `@//`, which exist to reference the main repository. This is legal via [bazel_specs](https://docs.bazel.build/versions/master/build-ref.html#labels) for referencing the main repository from an external reference.

**Which issues(s) does this PR fix?**

Fixes #1001

**Other notes for review**

Test file also updated to reflect properly parsed labels