### PR TITLE
Correctly propagate runfiles from gazelle_bin to gazelle

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -74,7 +74,9 @@ def _gazelle_runner_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.gazelle,
         go_tool,
-    ] + ctx.files.data)
+    ] + ctx.files.data).merge(
+        ctx.attr.gazelle[DefaultInfo].default_runfiles,
+    )
     return [DefaultInfo(
         files = depset([out_file]),
         runfiles = runfiles,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

wrapper script

**What does this PR do? Why is it needed?**

#911 previously attempted to fix #827, but did not actually do so.

In particular, the runfiles for the gazelle_bin were correctly collecting transitive runfiles for the language plugins, but the runfiles for the gazelle wrapper script were not correctly aggregating them

This small fix repairs that by merging the runfiles from the binary into the wrapper script.

**Which issues(s) does this PR fix?**

Fixes #827

**Other notes for review**
