### PR TITLE
gazelle: add -e flag for go list 1.16

### DIFF
--- a/language/go/modules.go
+++ b/language/go/modules.go
@@ -151,7 +151,7 @@ func importReposFromModules(args language.ImportReposArgs) language.ImportReposR
 
 // goListModules invokes "go list" in a directory containing a go.mod file.
 var goListModules = func(dir string) ([]byte, error) {
-	return runGoCommandForOutput(dir, "list", "-mod=readonly", "-m", "-json", "all")
+	return runGoCommandForOutput(dir, "list", "-mod=readonly", "-e", "-m", "-json", "all")
 }
 
 // goModDownload invokes "go mod download" in a directory containing a


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Starting from version 1.16, go list doesn't list all modules if sum is missing. The -e flag is required to get back the old behavior.

**Which issues(s) does this PR fix?**

Fixes #1018 
