### PR TITLE
walk_test: switch reflect.DeepEqual to cmp.Diff

### DIFF
--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//rule",
         "//testtools",
         "@com_github_bmatcuk_doublestar//:doublestar",
+        "@com_github_google_go_cmp//cmp",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

> Test improvement

**What package or component does this PR mostly affect?**

> cmd/gazelle

**What does this PR do? Why is it needed?**

cmp.Diff outputs a much nicer error message when comparing lists. Example:

```
--- FAIL: TestExcludeSelf (0.00s)
    walk_test.go:278: Walk relative paths (-want +got):
          []string{
        -       "b/d",
        -       "b",
        -       "e",
                "",
          }
```

I found this helpful when debugging walk_test.

