### PR TITLE
Change merge behavior to remove attrs instead of panicking

### DIFF
--- a/merger/merger_test.go
+++ b/merger/merger_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/language/go"
+	golang "github.com/bazelbuild/bazel-gazelle/language/go"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/merger"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -447,6 +447,34 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["foo.go"],
+)
+`,
+		expected: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+)
+`,
+	}, {
+		desc: "delete empty lists",
+		previous: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+    embed = ["deleted"],
+)
+`,
+		current: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["foo.go"],
+    embed = [],
 )
 `,
 		expected: `

--- a/rule/merge.go
+++ b/rule/merge.go
@@ -72,6 +72,8 @@ func MergeRules(src, dst *Rule, mergeable map[string]bool, filename string) {
 			if mergedValue, err := mergeExprs(srcValue, dstValue); err != nil {
 				start, end := dstValue.Span()
 				log.Printf("%s:%d.%d-%d.%d: could not merge expression", filename, start.Line, start.LineRune, end.Line, end.LineRune)
+			} else if mergedValue == nil {
+				dst.DelAttr(key)
 			} else {
 				dst.SetAttr(key, mergedValue)
 			}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

I have an optional list argument that may or may not exist on a rule, in the current configuration, `mergeExprs` can return nil if it encounters an empty destination list, which panics when passed to `SetAttr`.

I think a simple fix for this is to `DelAttr` on values that return `nil` (with no errors) in `mergeExprs`.

**Which issues(s) does this PR fix?**

Didn't make an issue for this.

**Other notes for review**
