### PR TITLE
Add per-file mode for proto_library generation

### DIFF
--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -97,6 +97,9 @@ const (
 	// PackageMode generates a proto_library for each set of .proto files with
 	// the same package name in each directory.
 	PackageMode
+
+	// FileMode generates a proto_library for each .proto file.
+	FileMode
 )
 
 func ModeFromString(s string) (Mode, error) {
@@ -111,6 +114,8 @@ func ModeFromString(s string) (Mode, error) {
 		return LegacyMode, nil
 	case "package":
 		return PackageMode, nil
+	case "file":
+		return FileMode, nil
 	default:
 		return 0, fmt.Errorf("unrecognized proto mode: %q", s)
 	}
@@ -128,6 +133,8 @@ func (m Mode) String() string {
 		return "legacy"
 	case PackageMode:
 		return "package"
+	case FileMode:
+		return "file"
 	default:
 		log.Panicf("unknown mode %d", m)
 		return ""

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -126,11 +126,17 @@ func buildPackages(pc *ProtoConfig, dir, rel string, protoFiles, genFiles []stri
 					break
 				}
 			}
+		} else if pc.Mode == FileMode {
+			key = strings.TrimSuffix(name, ".proto")
 		}
+
 		if packageMap[key] == nil {
 			packageMap[key] = newPackage(info.PackageName)
 		}
 		packageMap[key].addFile(info)
+		if key != info.PackageName {
+			packageMap[key].RuleName = key
+		}
 	}
 
 	switch pc.Mode {
@@ -147,7 +153,7 @@ func buildPackages(pc *ProtoConfig, dir, rel string, protoFiles, genFiles []stri
 		}
 		return []*Package{pkg}
 
-	case PackageMode:
+	case PackageMode, FileMode:
 		pkgs := make([]*Package, 0, len(packageMap))
 		for _, pkg := range packageMap {
 			pkgs = append(pkgs, pkg)
@@ -212,7 +218,7 @@ func generateProto(pc *ProtoConfig, rel string, pkg *Package, shouldSetVisibilit
 	if pc.Mode == DefaultMode {
 		name = RuleName(goPackageName(pkg), pc.GoPrefix, rel)
 	} else {
-		name = RuleName(pkg.Options[pc.groupOption], pkg.Name, rel)
+		name = RuleName(pkg.RuleName, pkg.Name, rel)
 	}
 	r := rule.NewRule("proto_library", name)
 	srcs := make([]string, 0, len(pkg.Files))

--- a/language/proto/package.go
+++ b/language/proto/package.go
@@ -21,6 +21,7 @@ import "path/filepath"
 // same package name. This translates to a proto_library rule.
 type Package struct {
 	Name        string
+	RuleName    string // if not set, defaults to Name
 	Files       map[string]FileInfo
 	Imports     map[string]bool
 	Options     map[string]string

--- a/language/proto/testdata/file_mode/BUILD.old
+++ b/language/proto/testdata/file_mode/BUILD.old
@@ -1,0 +1,1 @@
+# gazelle:proto file

--- a/language/proto/testdata/file_mode/BUILD.want
+++ b/language/proto/testdata/file_mode/BUILD.want
@@ -1,0 +1,13 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "bar_proto",
+    srcs = ["bar.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/language/proto/testdata/file_mode/bar.proto
+++ b/language/proto/testdata/file_mode/bar.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package file_mode;

--- a/language/proto/testdata/file_mode/foo.proto
+++ b/language/proto/testdata/file_mode/foo.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package file_mode;


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> language/proto

**What does this PR do? Why is it needed?**

Allows `proto_library` rules to be instantiated per-file, which helps in situations where `package` is too coarse. Can also alleviate pain when files between two packages form import cycles when bundled at the package level instead of the file level, if you find yourself in that unfortunate situation.

**Which issues(s) does this PR fix?**

Fixes #1032

**Other notes for review**
