### PR TITLE
Updated documentation of go_prefix flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -381,9 +381,9 @@ The following flags are accepted:
 | :flag:`-go_prefix example.com/repo`                          |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | A prefix of import paths for libraries in the repository that corresponds to                          |
-| the repository root. Equivalent to the ``# gazelle:prefix`` directive and the                         |
-| ``prefix`` attribute of the gazelle rule. If neither of those are set, this                           |
-| option is mandatory.                                                                                  |
+| the repository root. Equivalent to setting the ``# gazelle:prefix`` directive                         |
+| in the root BUILD.bazel file or the ``prefix`` attribute of the gazelle rule. If                      |
+| neither of those are set, this option is mandatory.                                                   |
 |                                                                                                       |
 | This prefix is used to determine whether an import path refers to a library                           |
 | in the current repository or an external dependency.                                                  |

--- a/README.rst
+++ b/README.rst
@@ -381,9 +381,9 @@ The following flags are accepted:
 | :flag:`-go_prefix example.com/repo`                          |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | A prefix of import paths for libraries in the repository that corresponds to                          |
-| the repository root. Gazelle infers this from the ``# gazelle:prefix`` directive                      |
-| in the root BUILD.bazel file, if it exists, or from the ``prefix`` attribute of                       |
-| the gazelle rule. If neither of those exist, this option is mandatory.                                |
+| the repository root. Equivalent to the ``# gazelle:prefix`` directive and the                         |
+| ``prefix`` attribute of the gazelle rule. If neither of those are set, this                           |
+| option is mandatory.                                                                                  |
 |                                                                                                       |
 | This prefix is used to determine whether an import path refers to a library                           |
 | in the current repository or an external dependency.                                                  |

--- a/README.rst
+++ b/README.rst
@@ -382,7 +382,7 @@ The following flags are accepted:
 +--------------------------------------------------------------+----------------------------------------+
 | A prefix of import paths for libraries in the repository that corresponds to                          |
 | the repository root. Equivalent to setting the ``# gazelle:prefix`` directive                         |
-| in the root BUILD.bazel file or the ``prefix`` attribute of the gazelle rule. If                      |
+| in the root BUILD.bazel file or the ``prefix`` attribute of the ``gazelle`` rule. If                  |
 | neither of those are set, this option is mandatory.                                                   |
 |                                                                                                       |
 | This prefix is used to determine whether an import path refers to a library                           |

--- a/README.rst
+++ b/README.rst
@@ -381,8 +381,9 @@ The following flags are accepted:
 | :flag:`-go_prefix example.com/repo`                          |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | A prefix of import paths for libraries in the repository that corresponds to                          |
-| the repository root. Gazelle infers this from the ``go_prefix`` rule in the                           |
-| root BUILD.bazel file, if it exists. If not, this option is mandatory.                                |
+| the repository root. Gazelle infers this from the ``# gazelle:prefix`` directive                      |
+| in the root BUILD.bazel file, if it exists, or from the ``prefix`` attribute of                       |
+| the gazelle rule. If neither of those exist, this option is mandatory.                                |
 |                                                                                                       |
 | This prefix is used to determine whether an import path refers to a library                           |
 | in the current repository or an external dependency.                                                  |


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
It updates the description of the `go_prefix` flag, since the [go_prefix rule no longer exists](https://github.com/bazelbuild/rules_go/issues/721).  Hopefully my understanding is correct.