### PR TITLE
Include reference to proto_import_prefix Gazelle directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,11 +423,12 @@ The following flags are accepted:
 | Determines the proto option Gazelle uses to group .proto files into rules                             |
 | when in ``package`` mode. See details in `Directives`_ below.                                         |
 +--------------------------------------------------------------+----------------------------------------+
-| :flag:`-proto_import_prefix repo`                            |                                        |
+| :flag:`-proto_import_prefix path`                            |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | Sets the `import_prefix`_ attribute of generated ``proto_library`` rules.                             |
 | This adds a prefix to the string used to import ``.proto`` files listed in                            |
-| the ``srcs`` attribute of generated rules.                                                            |
+| the ``srcs`` attribute of generated rules. Equivalent to the                                          |
+| ``# gazelle:proto_import_prefix`` directive. See details in `Directives`_ below.                      |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-repo_root dir`                                       |                                        |
 +--------------------------------------------------------------+----------------------------------------+


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
It includes a reference to the Gazelle directive documentation in `proto_import_prefix` flag description, because there is more explanation of `proto_import_prefix` in the directives section.