### PR TITLE
Add deprecation notice to aliases generated with import_alias naming convention

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1196,6 +1196,7 @@ go_library(
 alias(
     name = "go_default_library",
     actual = ":foo",
+    deprecation = "Use :foo instead of :go_default_library.  Details about the new naming convention: https://github.com/bazelbuild/bazel-gazelle/pull/863",
     visibility = ["//visibility:public"],
 )
 `,

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -501,6 +501,7 @@ func (g *generator) maybeGenerateAlias(pkg *goPackage, libName string) *rule.Rul
 	alias.SetAttr("visibility", g.commonVisibility(pkg.importPath))
 	if gc.goNamingConvention == importAliasNamingConvention {
 		alias.SetAttr("actual", ":"+libName)
+		alias.SetAttr("deprecation", "Use new naming convention rather than go_default_library.")
 	}
 	return alias
 }

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -501,7 +501,7 @@ func (g *generator) maybeGenerateAlias(pkg *goPackage, libName string) *rule.Rul
 	alias.SetAttr("visibility", g.commonVisibility(pkg.importPath))
 	if gc.goNamingConvention == importAliasNamingConvention {
 		alias.SetAttr("actual", ":"+libName)
-		alias.SetAttr("deprecation", "Use "+libName+" instead of go_default_library.  Details about the new naming convention here: https://github.com/bazelbuild/bazel-gazelle/pull/863")
+		alias.SetAttr("deprecation", "Use :"+libName+" instead of :go_default_library.  Details about the new naming convention here: https://github.com/bazelbuild/bazel-gazelle/pull/863")
 	}
 	return alias
 }

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -501,7 +501,7 @@ func (g *generator) maybeGenerateAlias(pkg *goPackage, libName string) *rule.Rul
 	alias.SetAttr("visibility", g.commonVisibility(pkg.importPath))
 	if gc.goNamingConvention == importAliasNamingConvention {
 		alias.SetAttr("actual", ":"+libName)
-		alias.SetAttr("deprecation", "Use :"+libName+" instead of :go_default_library.  Details about the new naming convention here: https://github.com/bazelbuild/bazel-gazelle/pull/863")
+		alias.SetAttr("deprecation", "Use :"+libName+" instead of :go_default_library.  Details about the new naming convention: https://github.com/bazelbuild/bazel-gazelle/pull/863")
 	}
 	return alias
 }

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -501,7 +501,7 @@ func (g *generator) maybeGenerateAlias(pkg *goPackage, libName string) *rule.Rul
 	alias.SetAttr("visibility", g.commonVisibility(pkg.importPath))
 	if gc.goNamingConvention == importAliasNamingConvention {
 		alias.SetAttr("actual", ":"+libName)
-		alias.SetAttr("deprecation", "Use new naming convention rather than go_default_library.")
+		alias.SetAttr("deprecation", "Use "+libName+" instead of go_default_library.  Details about the new naming convention here: https://github.com/bazelbuild/bazel-gazelle/pull/863")
 	}
 	return alias
 }

--- a/language/go/testdata/naming_convention/import_alias/lib/BUILD.want
+++ b/language/go/testdata/naming_convention/import_alias/lib/BUILD.want
@@ -11,6 +11,7 @@ go_library(
 alias(
     name = "go_default_library",
     actual = ":lib",
+    deprecation = "Use :lib instead of :go_default_library.  Details about the new naming convention: https://github.com/bazelbuild/bazel-gazelle/pull/863",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
It adds a deprecation notice to aliases named `go_default_library` generated with the `import_alias` naming convention.

**Which issues(s) does this PR fix?**
Fixes #1048