### PR TITLE
Add reference to bazel-skylib Gazelle plugin

### DIFF
--- a/extend.rst
+++ b/extend.rst
@@ -13,8 +13,7 @@ Extending Gazelle
 .. _proto.GetProtoConfig: https://godoc.org/github.com/bazelbuild/bazel-gazelle/language/proto#GetProtoConfig
 .. _proto.Package: https://godoc.org/github.com/bazelbuild/bazel-gazelle/language/proto#Package
 .. _rules_r: https://github.com/grailbio/rules_r
-.. _rules_sass: https://github.com/bazelbuild/rules_sass
-.. _#75: https://github.com/bazelbuild/rules_sass/pull/75
+.. _bazel-skylib: https://github.com/bazelbuild/bazel-skylib/tree/main/gazelle/bzl
 .. _bazel_rules_nodejs_contrib: https://github.com/ecosia/bazel_rules_nodejs_contrib#build-file-generation
 .. _#803: https://github.com/bazelbuild/bazel-gazelle/issues/803
 
@@ -47,8 +46,7 @@ Supported languages
 
 Some extensions have been published by the community.
 
-* `rules_sass`_ has an extension for generating ``sass_library`` and
-  ``sass_binary`` rules (currently pending in PR `#75`_).
+* `bazel-skylib`_ has an extension for generating ``bzl_library``.
 * `rules_r`_ has an extension for generating rules for R package builds and
   tests.
 * Ecosia's `bazel_rules_nodejs_contrib`_ has an extension for generating


### PR DESCRIPTION
Also removes reference to abandoned `rules_sass` plugin.