### PR TITLE
Include links to go_naming_convention directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,7 +370,8 @@ The following flags are accepted:
 | :flag:`-go_naming_convention`                                |                                        |
 +--------------------------------------------------------------+----------------------------------------+
 | Controls the names of generated Go targets. Equivalent to the                                         |
-| ``# gazelle:go_naming_convention`` directive.                                                         |
+| ``# gazelle:go_naming_convention`` directive. See details in                                          |
+| `Directives`_ below.                                                                                  |
 +--------------------------------------------------------------+----------------------------------------+
 | :flag:`-go_naming_convention_external`                       |                                        |
 +--------------------------------------------------------------+----------------------------------------+

--- a/repository.rst
+++ b/repository.rst
@@ -149,7 +149,7 @@ returned by ``go env GOPATH``.
 | repository. If unset, the convention from the external workspace is used.                                                 |
 | Legal values are ``go_default_library``, ``import``, and ``import_alias``.                                                |
 |                                                                                                                           |
-| See ``-go_naming_convention`` for more information.                                                                       |
+| See the ``gazelle:go_naming_convention`` directive in Directives_ for more information.                                   |
 +------------------------------------+----------------------+---------------------------------------------------------------+
 | :param:`replace`                   | :type:`string`       | :value:`""`                                                   |
 +------------------------------------+----------------------+---------------------------------------------------------------+


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
It includes a reference to the Gazelle directive documentation in the `build_naming_convention` attribute of the `go_repository` rule and the `go_naming_convention` flag description, because there is more explanation of `go_naming_convention` in the directives section.