### PR TITLE
do not update files if content did not change

### DIFF
--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -291,8 +292,11 @@ func updateRepos(wd string, args []string) (err error) {
 			if f.DefName != "" {
 				uf.SortMacro()
 			}
-			if err := uf.Save(uf.Path); err != nil {
-				return err
+			newContent := f.Format()
+			if !bytes.Equal(f.Content, newContent) {
+				if err := uf.Save(uf.Path); err != nil {
+					return err
+				}
 			}
 			delete(updatedFiles, f.Path)
 		}


### PR DESCRIPTION
fixes #1065

Skip saving files if file content did not change.
This will improve the speed of analysis phase after invoking gazelle.
