### PR TITLE
Revert "Respect .bazelignore (#1022)" 

### DIFF
--- a/walk/config.go
+++ b/walk/config.go
@@ -16,13 +16,9 @@ limitations under the License.
 package walk
 
 import (
-	"bufio"
 	"flag"
-	"fmt"
 	"log"
-	"os"
 	"path"
-	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -88,10 +84,6 @@ func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	*wcCopy = *wc
 	wcCopy.ignore = false
 
-	if err := cr.loadBazelIgnore(c.RepoRoot, rel, wcCopy); err != nil {
-		log.Fatalf("loading .bazelignore failed: %v", err)
-	}
-
 	if f != nil {
 		for _, d := range f.Directives {
 			switch d.Key {
@@ -110,33 +102,6 @@ func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	}
 
 	c.Exts[walkName] = wcCopy
-}
-
-func (c *Configurer) loadBazelIgnore(repoRoot, rel string, wc *walkConfig) error {
-	file, err := os.Open(path.Join(repoRoot, ".bazelignore"))
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf(".bazelignore exists but couldn't be read: %v", err)
-	}
-	defer file.Close()
-
-	wc.excludes = append(wc.excludes, path.Join(rel, ".bazelignore"))
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		ignore := strings.TrimSpace(scanner.Text())
-		if ignore == "" || string(ignore[0]) == "#" {
-			continue
-		}
-		if err := checkPathMatchPattern(path.Join(rel, ignore)); err != nil {
-			log.Printf("the .bazelignore exclusion pattern is not valid %q: %s", path.Join(rel, ignore), err)
-			continue			
-		}
-		wc.excludes = append(wc.excludes, path.Join(rel, ignore))
-	}
-	return nil
 }
 
 func checkPathMatchPattern(pattern string) error {

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -195,16 +195,6 @@ gen(
 )
 `,
 		},
-		{
-			Path: ".bazelignore",
-			Content: `
-dir
-dir2/**
-# Random comment followed by a line
-
-a.file
-`,
-		},
 		{Path: ".dot"},       // not ignored
 		{Path: "_blank"},     // not ignored
 		{Path: "a/a.proto"},  // not ignored
@@ -220,9 +210,6 @@ a.file
 		{Path: "c/x/y/b/foo/bar"}, // ignored by 'c/**/b'
 		{Path: "ign/bad"},         // ignored by 'ign'
 		{Path: "sub/b.go"},        // ignored by 'sub/b.go'
-		{Path: "dir/contents"},    // ignored by .bazelignore 'dir'
-		{Path: "dir2/a/b"},        // ignored by .bazelignore 'dir2/**'
-		{Path: "a.file"},          // ignored by .bazelignore 'a.file'
 	})
 	defer cleanup()
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

walk

**What does this PR do? Why is it needed?**

https://github.com/bazelbuild/bazel-gazelle/commit/d1bb5647f653ae920ae368d12adc6eab0500005a Introduced breaking changes that prevent gazelle updates for existing repositories, due to issues with how .bazelignore is parsed (see https://github.com/bazelbuild/bazel-gazelle/issues/1070). Additionally, this feature should not be enabled by default, as it reduces performance.

**Which issues(s) does this PR fix?**

Fixes #1070
Fixes #1026

**Other notes for review**

This feature should be implemented in a way that is backwards compatible before being merged to master.