### PR TITLE
Fix "exclude" token parsing

### DIFF
--- a/rule/BUILD.bazel
+++ b/rule/BUILD.bazel
@@ -27,9 +27,13 @@ go_test(
     srcs = [
         "directives_test.go",
         "rule_test.go",
+        "value_test.go",
     ],
     embed = [":rule"],
-    deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
+    deps = [
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_google_go_cmp//cmp",
+    ],
 )
 
 filegroup(
@@ -48,6 +52,7 @@ filegroup(
         "sort_labels.go",
         "types.go",
         "value.go",
+        "value_test.go",
     ],
     visibility = ["//visibility:public"],
 )

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -59,6 +59,10 @@ y_library(name = "bar")
 	bar := f.Rules[1]
 	bar.SetAttr("srcs", []string{"bar.y"})
 	baz := NewRule("z_library", "baz")
+	baz.SetAttr("srcs", GlobValue{
+		Patterns: []string{"**"},
+		Excludes: []string{"*.pem"},
+	})
 	baz.Insert(f)
 
 	got := strings.TrimSpace(string(f.Format()))
@@ -71,7 +75,13 @@ y_library(
     srcs = ["bar.y"],
 )
 
-z_library(name = "baz")
+z_library(
+    name = "baz",
+    srcs = glob(
+        ["**"],
+        exclude = ["*.pem"],
+    ),
+)
 `)
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)

--- a/rule/value.go
+++ b/rule/value.go
@@ -148,9 +148,10 @@ func ExprFromValue(val interface{}) bzl.Expr {
 			globArgs := []bzl.Expr{patternsValue}
 			if len(val.Excludes) > 0 {
 				excludesValue := ExprFromValue(val.Excludes)
-				globArgs = append(globArgs, &bzl.KeyValueExpr{
-					Key:   &bzl.StringExpr{Value: "excludes"},
-					Value: excludesValue,
+				globArgs = append(globArgs, &bzl.AssignExpr{
+					LHS: &bzl.LiteralExpr{Token: "exclude"},
+					Op:  "=",
+					RHS: excludesValue,
 				})
 			}
 			return &bzl.CallExpr{

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -1,0 +1,66 @@
+package rule
+
+import (
+	"testing"
+
+	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExprFromValue(t *testing.T) {
+	for name, tt := range map[string]struct {
+		val  interface{}
+		want bzl.Expr
+	}{
+		"glob value": {
+			val: GlobValue{
+				Patterns: []string{"a", "b"},
+			},
+			want: &bzl.CallExpr{
+				X: &bzl.LiteralExpr{Token: "glob"},
+				List: []bzl.Expr{
+					&bzl.ListExpr{
+						List: []bzl.Expr{
+							&bzl.StringExpr{Value: "a"},
+							&bzl.StringExpr{Value: "b"},
+						},
+					},
+				},
+			},
+		},
+		"glob value with excludes": {
+			val: GlobValue{
+				Patterns: []string{"a", "b"},
+				Excludes: []string{"c", "d"},
+			},
+			want: &bzl.CallExpr{
+				X: &bzl.LiteralExpr{Token: "glob"},
+				List: []bzl.Expr{
+					&bzl.ListExpr{
+						List: []bzl.Expr{
+							&bzl.StringExpr{Value: "a"},
+							&bzl.StringExpr{Value: "b"},
+						},
+					},
+					&bzl.AssignExpr{
+						LHS: &bzl.LiteralExpr{Token: "exclude"},
+						Op:  "=",
+						RHS: &bzl.ListExpr{
+							List: []bzl.Expr{
+								&bzl.StringExpr{Value: "c"},
+								&bzl.StringExpr{Value: "d"},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := ExprFromValue(tt.val)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ExprFromValue() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

####  What package or component does this PR mostly affect?

rule

####  What does this PR do? Why is it needed?

It fixes the marshaling of GlobValue with non empty excludes.

##### Example

```go
log.Printf("%s", bzl.FormatString(ExprFromValue(GlobValue{
	Patterns: []string{"a", "b"},
	Excludes: []string{"c", "d"},
})))
```

###### Before

Invalid, see [Functions - Glob](https://docs.bazel.build/versions/main/be/functions.html#glob).

```
glob(
    [
        "a",
        "b",
    ],
    "excludes": [
        "c",
        "d",
    ],
)
```

###### After

```
glob(
    [
        "a",
        "b",
    ],
    exclude = [
        "c",
        "d",
    ],
)
```

#### Which issues(s) does this PR fix?

I have not filed an issue.

---

#### Commits _(oldest to newest)_

f596991 Fix "exclude" token parsing


<br/>

3f0d09d test: Add e2e test


<br/>