### PR TITLE
language/go: add golang.org/x/tools/internal/typeparams to nogo deps list

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -588,6 +588,7 @@ func isToolLibImportPath(imp string) bool {
 		"golang.org/x/tools/go/types/objectpath",
 		"golang.org/x/tools/go/types/typeutil",
 		"golang.org/x/tools/internal/analysisinternal",
+		"golang.org/x/tools/internal/typeparams",
 		"golang.org/x/tools/internal/lsp/fuzzy":
 		// Indirect dependency of nogo.
 		return true


### PR DESCRIPTION
This package was recently added as a dependency of astutil in order to
handle generics. With this change, Gazelle will generate a
go_tool_library target for this package.
