### PR TITLE
autogazelle can build on windows

### DIFF
--- a/cmd/autogazelle/BUILD.bazel
+++ b/cmd/autogazelle/BUILD.bazel
@@ -37,6 +37,9 @@ go_library(
         "@io_bazel_rules_go//go/platform:solaris": [
             "@com_github_fsnotify_fsnotify//:fsnotify",
         ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "@com_github_fsnotify_fsnotify//:fsnotify",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/cmd/autogazelle/client_unix.go
+++ b/cmd/autogazelle/client_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
 
 /* Copyright 2018 The Bazel Authors. All rights reserved.
 

--- a/cmd/autogazelle/server_unix.go
+++ b/cmd/autogazelle/server_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
 
 /* Copyright 2018 The Bazel Authors. All rights reserved.
 


### PR DESCRIPTION
I don't know for sure why this was disabled, but the initial commit and
the change to golang to support AF_UNIX on windows were at roughly the
same time in 2018, so that might be the reason.

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

cmd/autogazelle

**What does this PR do? Why is it needed?**

This makes 'bazel test //...' work on windows. Currently it dies to a build error, which appears to be unnecessary.