### PR TITLE
Have label properly resolve directives starting with "@//"

### DIFF
--- a/label/label_test.go
+++ b/label/label_test.go
@@ -43,6 +43,9 @@ func TestLabelString(t *testing.T) {
 		}, {
 			l:    Label{Relative: true, Name: "foo"},
 			want: ":foo",
+		}, {
+			l:    Label{Repo: "@", Pkg: "foo/bar", Name: "baz"},
+			want: "@//foo/bar:baz",
 		},
 	} {
 		if got, want := spec.l.String(), spec.want; got != want {
@@ -61,8 +64,8 @@ func TestParse(t *testing.T) {
 		{str: "@//:", wantErr: true},
 		{str: "@a:b", wantErr: true},
 		{str: "@a//", wantErr: true},
-		{str: "@//:a", want: Label{Name: "a", Relative: false}},
-		{str: "@//a:b", want: Label{Repo: "", Pkg: "a", Name: "b"}},
+		{str: "@//:a", want: Label{Repo: "@", Name: "a", Relative: false}},
+		{str: "@//a:b", want: Label{Repo: "@", Pkg: "a", Name: "b"}},
 		{str: ":a", want: Label{Name: "a", Relative: true}},
 		{str: "a", want: Label{Name: "a", Relative: true}},
 		{str: "//:a", want: Label{Name: "a", Relative: false}},


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

label

**What does this PR do? Why is it needed?**

Allows external references to the main repository (starting with "@//") to properly work in gazelle resolve statements:
`gazelle:resolve something @//some_path:to_something`. This scenario is legal in Bazel, and therefore is a bug that needs fixing/patches because it is not properly handled with Gazelle.


From [bazel specs](https://docs.bazel.build/versions/main/build-ref.html#labels):
> Labels starting with @// are references to the main repository, which will still work even from external repositories. Therefore @//a/b/c is different from //a/b/c when referenced from an external repository. The former refers back to the main repository, while the latter looks for //a/b/c in the external repository itself. This is especially relevant when writing rules in the main repository that refer to targets in the main repository, and will be used from external repositories.

**Which issues(s) does this PR fix?**

Fixes #1025