### PR TITLE
Read .netrc in go_repository

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -14,9 +14,28 @@
 
 load("@io_bazel_rules_go//go/private:common.bzl", "env_execute", "executable_extension")
 load("@bazel_gazelle//internal:go_repository_cache.bzl", "read_cache_env")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
 
 # We can't disable timeouts on Bazel, but we can set them to large values.
 _GO_REPOSITORY_TIMEOUT = 86400
+
+
+# Copied from @bazel_tools//tools/build_defs/repo:http.bzl
+def _get_auth(ctx, urls):
+    """Given the list of URLs obtain the correct auth dict."""
+    if "HOME" in ctx.os.environ and not ctx.os.name.startswith("windows"):
+        netrcfile = "%s/.netrc" % (ctx.os.environ["HOME"])
+        if ctx.execute(["test", "-f", netrcfile]).return_code == 0:
+            netrc = read_netrc(ctx, netrcfile)
+            return use_netrc(netrc, urls, {})
+
+    if "USERPROFILE" in ctx.os.environ and ctx.os.name.startswith("windows"):
+        netrcfile = "%s/.netrc" % (ctx.os.environ["USERPROFILE"])
+        if ctx.path(netrcfile).exists:
+            netrc = read_netrc(ctx, netrcfile)
+            return use_netrc(netrc, urls, {})
+
+    return {}
 
 def _go_repository_impl(ctx):
     # TODO(#549): vcs repositories are not cached and still need to be fetched.
@@ -33,6 +52,7 @@ def _go_repository_impl(ctx):
             sha256 = ctx.attr.sha256,
             stripPrefix = ctx.attr.strip_prefix,
             type = ctx.attr.type,
+            auth = _get_auth(ctx, ctx.attr.urls)
         )
     elif ctx.attr.commit or ctx.attr.tag:
         # repository mode


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
go_repository

**What does this PR do? Why is it needed?**
The URLs that `go_repository` downloads libraries from may need authentication. We need to support the authentication tokens saved in `.netrc` similar to what `http_archive` does.

** Which issues(s) does this PR fix?
Fixes #847

** Other notes for review
This is a re-implementation of #848 by addressing @jayconrod's comments there. Besides fixes in the code, these are the responses to Jay's comments:

> Could you confirm that Bazel 1.2.0 provides these functions, and if not, what is the oldest version of Bazel that does? I'd like to make sure we're not breaking compatibility here. If these were added recently, it would be better to copy them here.

Bazel 1.2.0 provides these functions (read_netrc, use_netrc): https://github.com/bazelbuild/bazel/blob/1.2.0/tools/build_defs/repo/utils.bzl. However, the third argument to use_netrc was added in Bazel 3.1. So this pull request will require Bazel 3.1, which shouldn't be a big issue as rules_go already requires Bazel 4.0

> It looks like this will only work for HTTP mode. It also needs to work for module mode though (the ctx.attr.version branch). I think that just means making sure NETRC is set to the correct file in env_keys, but please verify.

In module mode, go_repository calls Go toolchain, which already has logic to support netrc without requiring `NETRC` environment variable.

> Please add documentation to go_repository.bzl for these attributes.

Let's not add these attributes to keep it simple and use the netrc file from default location with default auth pattern for now until some people run into a scenario where customization is needed.


