### PR TITLE
Export bzl files with bzl_library to be able to use stardoc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,7 +22,7 @@ gazelle_binary(
         "//language/proto",
         "//language/go",
         "//internal/language/test_filegroup",
-        "@bazel_skylib//gazelle/bzl"
+        "@bazel_skylib//gazelle/bzl",
     ],
 )
 
@@ -74,9 +74,27 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# needed for stardoc
 bzl_library(
-    name = "lib",
-    srcs = glob(["*.bzl"]),
+    name = "def",
+    srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//internal:gazelle_binary",
+        "//internal:go_repository",
+        "//internal:overlay_repository",
+        "@bazel_skylib//lib:shell",
+    ],
+)
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_gazelle//internal:go_repository",
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_gazelle//internal:go_repository_config",
+        "@bazel_gazelle//internal:go_repository_tools",
+        "@bazel_tools//tools/build_defs/repo:git.bzl",
+    ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//:def.bzl", "gazelle", "gazelle_binary")
 
 # gazelle:prefix github.com/bazelbuild/bazel-gazelle
@@ -69,5 +70,12 @@ filegroup(
         "//testtools:all_files",
         "//walk:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# needed for stardoc
+bzl_library(
+    name = "lib",
+    srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ gazelle_binary(
         "//language/proto",
         "//language/go",
         "//internal/language/test_filegroup",
+        "@bazel_skylib//gazelle/bzl"
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,16 @@
 workspace(name = "bazel_gazelle")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+    name = "bazel_skylib",
+    commit = "df3c9e2735f02a7fe8cd80db4db00fec8e13d25f",  # `master` as of 2021-08-19
+    remote = "https://github.com/bazelbuild/bazel-skylib",
+)
 
 http_archive(
     name = "io_bazel_rules_go",

--- a/deps.bzl
+++ b/deps.bzl
@@ -79,7 +79,7 @@ def gazelle_dependencies(
         _tools_git_repository,
         name = "bazel_skylib",
         remote = "https://github.com/bazelbuild/bazel-skylib",
-        commit = "3fea8cb680f4a53a129f7ebace1a5a4d1e035914",  # 0.5.0 as of 2018-11-01
+        tag = "1.0.3"
     )
 
     _maybe(

--- a/deps.bzl
+++ b/deps.bzl
@@ -76,13 +76,6 @@ def gazelle_dependencies(
     )
 
     _maybe(
-        _tools_git_repository,
-        name = "bazel_skylib",
-        remote = "https://github.com/bazelbuild/bazel-skylib",
-        tag = "1.0.3"
-    )
-
-    _maybe(
         go_repository,
         name = "com_github_bazelbuild_buildtools",
         importpath = "github.com/bazelbuild/buildtools",

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -63,7 +63,6 @@ bzl_library(
     deps = [
         "@bazel_gazelle//internal:go_repository_cache",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
-        "@io_bazel_rules_go//go/private:common",
     ],
 )
 
@@ -71,7 +70,7 @@ bzl_library(
     name = "go_repository_cache",
     srcs = ["go_repository_cache.bzl"],
     visibility = ["//:__subpackages__"],
-    deps = ["@io_bazel_rules_go//go/private:common"],
+    deps = [],
 )
 
 bzl_library(
@@ -80,7 +79,6 @@ bzl_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "@bazel_gazelle//internal:go_repository_cache",
-        "@io_bazel_rules_go//go/private:common",
     ],
 )
 
@@ -91,7 +89,6 @@ bzl_library(
     deps = [
         "@bazel_gazelle//internal:go_repository_cache",
         "@bazel_gazelle//internal:go_repository_tools_srcs",
-        "@io_bazel_rules_go//go/private:common",
     ],
 )
 

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -49,9 +49,60 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# needed for stardoc
 bzl_library(
-    name = "internal",
-    srcs = glob(["*.bzl"]),
-    visibility = ["//visibility:public"],
+    name = "gazelle_binary",
+    srcs = ["gazelle_binary.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@io_bazel_rules_go//go:def"],
+)
+
+bzl_library(
+    name = "go_repository",
+    srcs = ["go_repository.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+        "@io_bazel_rules_go//go/private:common",
+    ],
+)
+
+bzl_library(
+    name = "go_repository_cache",
+    srcs = ["go_repository_cache.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@io_bazel_rules_go//go/private:common"],
+)
+
+bzl_library(
+    name = "go_repository_config",
+    srcs = ["go_repository_config.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@io_bazel_rules_go//go/private:common",
+    ],
+)
+
+bzl_library(
+    name = "go_repository_tools",
+    srcs = ["go_repository_tools.bzl"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@bazel_gazelle//internal:go_repository_cache",
+        "@bazel_gazelle//internal:go_repository_tools_srcs",
+        "@io_bazel_rules_go//go/private:common",
+    ],
+)
+
+bzl_library(
+    name = "go_repository_tools_srcs",
+    srcs = ["go_repository_tools_srcs.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "overlay_repository",
+    srcs = ["overlay_repository.bzl"],
+    visibility = ["//:__subpackages__"],
 )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 # gazelle:exclude *_test.go
 go_bazel_test(
@@ -45,5 +46,12 @@ filegroup(
         "//internal/version:all_files",
         "//internal/wspace:all_files",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# needed for stardoc
+bzl_library(
+    name = "internal",
+    srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
 )

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load(":def.bzl", "std_package_list")
 
@@ -119,4 +120,11 @@ alias(
     name = "go_default_library",
     actual = ":go",
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@io_bazel_rules_go//go:def"],
 )

--- a/language/proto/gen/BUILD.bazel
+++ b/language/proto/gen/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -23,5 +24,11 @@ filegroup(
         "gen_known_imports.go",
         "update_proto_csv.go",
     ],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Stardoc is a documentation tool for Bazel rules/macros/etc. We need to group the bzl files of bazel-gazelle into bzl_library targets so that stardoc can pick them up.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>


Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
