### PR TITLE
Correctly propagate runfiles from data dependencies to gazelle

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -74,9 +74,11 @@ def _gazelle_runner_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.gazelle,
         go_tool,
-    ] + ctx.files.data).merge(
+    ]).merge(
         ctx.attr.gazelle[DefaultInfo].default_runfiles,
     )
+    for d in ctx.attr.data:
+        runfiles = runfiles.merge(d[DefaultInfo].default_runfiles)
     return [DefaultInfo(
         files = depset([out_file]),
         runfiles = runfiles,


### PR DESCRIPTION
This is a followup to #1008 which fixed this problem for the
gazelle_binary but not for the data attribute of the gazelle rule.


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**
We are working on a python extension, where the gazelle binary will have a py_binary in its data deps.
Without this fix, the runfiles of that py_binary are absent at runtime and gazelle fails like
FileNotFoundError: [Errno 2] No such file or directory: '/home/alexeagle/.cache/bazel/_bazel_alexeagle/cdec52671ea8b1684766cfc23dcfc4be/execroot/rules_python/bazel-out/k8-fastbuild/bin/gazelle/g.runfiles/bazel_tools/tools/python/py3wrapper.sh'
