### PR TITLE
use forward slashes during embed discovery

### DIFF
--- a/language/go/embed.go
+++ b/language/go/embed.go
@@ -170,11 +170,12 @@ func (er *embedResolver) resolve(embed fileEmbed) (list []string, err error) {
 	// would not include "a/.e".
 	var visit func(*embeddableNode, bool)
 	visit = func(f *embeddableNode, add bool) {
-		match, _ := path.Match(embed.path, f.path)
+		convertedPath := filepath.ToSlash(f.path)
+		match, _ := path.Match(embed.path, convertedPath)
 		add = match || (add && !f.isHidden())
 		if !f.isDir() {
 			if add {
-				list = append(list, f.path)
+				list = append(list, convertedPath)
 			}
 			return
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix.

**What package or component does this PR mostly affect?**

`language/go`

**What does this PR do? Why is it needed?**

On Windows, `//go:embed` directives with a folder (e.g. `foo/*.ext`) will not generate any `embedsrcs` due to using `\\` path separators during directory walks instead of `/` which is expected when matching paths.

This PR converts those double slashes during traversal, and forwards the fixed path to the later steps. This fixed our issues when compiling [this embed directive](https://github.com/cloudspannerecosystem/yo/blob/master/v2/module/builtin/module.go#L31).

**Which issues(s) does this PR fix?**

No relevant issue (e.g., subdirectory embeds on Windows) found.
