### PR TITLE
Escape vars in cgo flags with an extra $

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -825,5 +825,7 @@ func escapeOption(opt string) string {
 		"\t", "\\\t",
 		"\n", "\\\n",
 		"\r", "\\\r",
+		"$(", "$(",
+		"$", "$$",
 	).Replace(opt)
 }

--- a/language/go/testdata/cgolib/BUILD.want
+++ b/language/go/testdata/cgolib/BUILD.want
@@ -15,7 +15,7 @@ go_library(
         "fmt",
     ],
     cgo = True,
-    clinkopts = ["-lweird"],
+    clinkopts = ["-lweird,-rpath,$$ORIGIN"],
     copts = [
         "-I cgolib/sub -iquote cgolib/sub",
         "-Icgolib/sub -Icgolib/othersub",

--- a/language/go/testdata/cgolib/foo.go
+++ b/language/go/testdata/cgolib/foo.go
@@ -20,7 +20,7 @@ package cgolib
 #cgo CPPFLAGS: -I/weird/include/path
 #cgo CXXFLAGS: -std=c++14
 #cgo CFLAGS: -I sub/../sub -iquote sub/../sub
-#cgo LDFLAGS: -lweird
+#cgo LDFLAGS: -lweird,-rpath,$ORIGIN
 **/
 import "C"
 import "fmt"


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

`gazelle` and `rules_go` are currently in conflict with the use of `$`-escaped variables in cgo flags. This PR should resolve the discrepancy.

**Which issues(s) does this PR fix?**

Fixes #1106 

**Other notes for review**
