### PR TITLE
language/go: stop generating go_tool_library rules for x/tools

### DIFF
--- a/language/go/resolve.go
+++ b/language/go/resolve.go
@@ -74,8 +74,6 @@ func (gl *goLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Remo
 	switch r.Kind() {
 	case "go_proto_library":
 		resolve = resolveProto
-	case "go_tool_library":
-		resolve = resolveGoTool
 	default:
 		resolve = ResolveGo
 	}
@@ -328,19 +326,6 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache,
 	}
 	libName := libNameByConvention(getGoConfig(c).goNamingConvention, imp, "")
 	return label.New("", rel, libName), nil
-}
-
-func resolveGoTool(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, imp string, from label.Label) (label.Label, error) {
-	if isToolLibImportPath(imp) {
-		gc := getGoConfig(c)
-		var repo string
-		if gc.prefix != "golang.org/x/tools" {
-			repo = "org_golang_x_tools"
-		}
-		pkg := strings.TrimPrefix(imp, "golang.org/x/tools/")
-		return label.Label{Repo: repo, Pkg: pkg, Name: "go_tool_library"}, nil
-	}
-	return ResolveGo(c, ix, rc, imp, from)
 }
 
 // wellKnownProtos is the set of proto sets for which we don't need to add


### PR DESCRIPTION
bazelbuild/rules_go#2374 has been fixed, so there is no more need for it.
