### PR TITLE
Document behaviour of extra_args with bazel run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,10 @@ The following attributes are available on the ``gazelle`` rule.
 +----------------------+---------------------+--------------------------------------+
 | :param:`extra_args`  | :type:`string_list` | :value:`[]`                          |
 +----------------------+---------------------+--------------------------------------+
-| A list of extra command line arguments passed to Gazelle.                         |
+| A list of extra command line arguments passed to Gazelle.  Note that              |
+| ``extra_args`` are suppressed by extra command line args (e.g.                    |
+| ``bazel run //:gazelle -- subdir``.                                               |  
+| See https://github.com/bazelbuild/bazel-gazelle/issues/536 for explanation.       |
 +----------------------+---------------------+--------------------------------------+
 | :param:`command`     | :type:`string`      | :value:`update`                      |
 +----------------------+---------------------+--------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -304,7 +304,7 @@ The following attributes are available on the ``gazelle`` rule.
 +----------------------+---------------------+--------------------------------------+
 | A list of extra command line arguments passed to Gazelle.  Note that              |
 | ``extra_args`` are suppressed by extra command line args (e.g.                    |
-| ``bazel run //:gazelle -- subdir``.                                               |  
+| ``bazel run //:gazelle -- subdir``).                                              |  
 | See https://github.com/bazelbuild/bazel-gazelle/issues/536 for explanation.       |
 +----------------------+---------------------+--------------------------------------+
 | :param:`command`     | :type:`string`      | :value:`update`                      |


### PR DESCRIPTION
Fixes #536
