### PR TITLE
Support canonical_id for go_repository

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -50,6 +50,7 @@ def _go_repository_impl(ctx):
         ctx.download_and_extract(
             url = ctx.attr.urls,
             sha256 = ctx.attr.sha256,
+            canonical_id = ctx.attr.canonical_id,
             stripPrefix = ctx.attr.strip_prefix,
             type = ctx.attr.type,
             auth = _get_auth(ctx, ctx.attr.urls),
@@ -62,7 +63,7 @@ def _go_repository_impl(ctx):
         elif ctx.attr.tag:
             rev = ctx.attr.tag
             rev_key = "tag"
-        for key in ("urls", "strip_prefix", "type", "sha256", "version", "sum", "replace"):
+        for key in ("urls", "strip_prefix", "type", "sha256", "version", "sum", "replace", "canonical_id"):
             if getattr(ctx.attr, key):
                 fail("cannot specify both %s and %s" % (rev_key, key), key)
 
@@ -237,6 +238,7 @@ go_repository = repository_rule(
         "strip_prefix": attr.string(),
         "type": attr.string(),
         "sha256": attr.string(),
+        "canonical_id": attr.string(),
 
         # Attributes for a module that should be downloaded with the Go toolchain.
         "version": attr.string(),

--- a/repository.rst
+++ b/repository.rst
@@ -214,6 +214,11 @@ returned by ``go env GOPATH``.
 | can cause differences in file order, alignment, and compression that break                                                |
 | SHA-256 sums.                                                                                                             |
 +------------------------------------+----------------------+---------------------------------------------------------------+
+| :param:`canonical_id`              | :type:`string`       | :value:`""`                                                   |
++------------------------------------+----------------------+---------------------------------------------------------------+
+| If the repository is downloaded via HTTP (``urls`` is set) and this is set, restrict cache hits to those cases where the  |
+| repository was added to the cache with the same canonical id.                                                             |
++------------------------------------+----------------------+---------------------------------------------------------------+
 | :param:`build_file_generation`     | :type:`string`       | :value:`"auto"`                                               |
 +------------------------------------+----------------------+---------------------------------------------------------------+
 | One of ``"auto"``, ``"on"``, ``"off"``.                                                                                   |


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

This supports `canonical_id` for `go_repository`, like for `http_archive`. This can be used to force redownloading, when for example the URLs are updated but the `sha256` is unchanged.

**Which issues(s) does this PR fix?**

Fixes #1119