### PR TITLE
Allow tools to be built with cgo

### DIFF
--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -54,8 +54,6 @@ def _go_repository_tools_impl(ctx):
         "GO111MODULE": "off",
         # workaround: avoid the Go SDK paths from leaking into the binary
         "GOROOT_FINAL": "GOROOT",
-        # workaround: avoid cgo paths in /tmp leaking into binary
-        "CGO_ENABLED": "0",
     })
 
     if "PATH" in ctx.os.environ:


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

See the linked issue for more information. It allows Gazelle's tools to be built with cgo as builds fail when the Go SDK enforces it.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/bazel-gazelle/issues/1135

**Other notes for review**
