### PR TITLE
Add note about WORKSPACE.bazel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,12 @@ should look like this:
     gazelle_dependencies()
 
 ``gazelle_dependencies`` supports optional argument ``go_env`` (dict-mapping)
-to set project specific go environment variables.
+to set project specific go environment variables. If you are using a
+`WORKSPACE.bazel` file, you will need to specify that using:
+
+.. code:: bzl
+
+    gazelle_dependencies(go_repository_default_config = "//:WORKSPACE.bazel")
 
 Add the code below to the BUILD or BUILD.bazel file in the root directory
 of your repository.


### PR DESCRIPTION
Without specifying this argument, I got a cryptic error like:
```
INFO: Repository bazel_gazelle_go_repository_config instantiated at:
  /path/to/repo/WORKSPACE.bazel:85:21: in <toplevel>
  /path/to/bazel/cache/external/bazel_gazelle/deps.bzl:80:25: in gazelle_dependencies
Repository rule go_repository_config defined at:
  /path/to/bazel/cache/external/bazel_gazelle/internal/go_repository_config.bzl:62:39: in <toplevel>

ERROR: An error occurred during the fetch of repository 'bazel_gazelle_go_repository_config':
   Traceback (most recent call last):
	File "/path/to/bazel/cache/external/bazel_gazelle/internal/go_repository_config.bzl", line 25, column 31, in _go_repository_config_impl
		config_path = ctx.path(ctx.attr.config)
Error in path: Not a regular file: /path/to/repo/WORKSPACE

ERROR: /path/to/repo/WORKSPACE.bazel:85:21: fetching go_repository_config rule //external:bazel_gazelle_go_repository_config: Traceback (most recent call last):
	File "/path/to/bazel/cache/external/bazel_gazelle/internal/go_repository_config.bzl", line 25, column 31, in _go_repository_config_impl
		config_path = ctx.path(ctx.attr.config)
Error in path: Not a regular file: /path/to/repo/WORKSPACE
```

It took me a while to notice the error did not have the .bazel extension and a bit longer to trace through the code to figure out how to set it. Hopefully this saves someone else the headache in the future.

**What type of PR is this?**
Documentation

**What package or component does this PR mostly affect?**
cmd/gazelle

**What does this PR do? Why is it needed?**
Help people avoid cryptic errors on setup.

**Which issues(s) does this PR fix?**
Missing documentation for parameter to gazelle_dependencies
