### PR TITLE
Allow dots and dashes at repo names in labels

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,7 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z][A-Za-z0-9_]*$`)
+	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
 	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
 )

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -75,6 +75,8 @@ func TestParse(t *testing.T) {
 		{str: "@a", want: Label{Repo: "a", Pkg: "", Name: "a"}},
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
+		{str: "@..//b:c", want: Label{Repo: "..", Pkg: "b", Name: "c"}},
+		{str: "@--//b:c", want: Label{Repo: "--", Pkg: "b", Name: "c"}},
 		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},
 	} {
 		got, err := Parse(tc.str)


### PR DESCRIPTION
Bug fix
cmd/gazelle

This PR has label.Parse accept repo names with dashes and dots. `gazelle` needs it to process bazel repositories that use these characters in repository names.

Fixes #1082