### PR TITLE
Update to install@latest command for builds via Go tooling (cmd/gazelle)

### DIFF
--- a/Design.rst
+++ b/Design.rst
@@ -441,7 +441,7 @@ Bazel, using the regular Go SDK.
 
 .. code:: bash
 
-  $ go get -u github.com/bazelbuild/bazel-gazelle/cmd/gazelle
+  $ go install github.com/bazelbuild/bazel-gazelle/cmd/gazelle@latest
   $ gazelle -go_prefix example.com/project
 
 We lightly discourage this method of running Gazelle. All developers on a

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ command below:
 
 .. code::
 
-  go get github.com/bazelbuild/bazel-gazelle/cmd/gazelle
+  go install github.com/bazelbuild/bazel-gazelle/cmd/gazelle@latest
 
 Make sure to re-run this command to upgrade Gazelle whenever you upgrade
 rules_go in your repository.


### PR DESCRIPTION
Documentation
cmd/gazelle

Revises doc language for installing cmd/gazelle via Go tooling as `go install pkg@version` has replaced now-deprecated `go get ...` when building and installing executables in module mode.