### PR TITLE
language/proto: don't skip same-package imports in per-file mode

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -235,8 +235,9 @@ func generateProto(pc *ProtoConfig, rel string, pkg *Package, shouldSetVisibilit
 	r.SetPrivateAttr(PackageKey, *pkg)
 	imports := make([]string, 0, len(pkg.Imports))
 	for i := range pkg.Imports {
-		// If the proto import is a self import (an import between the same package), skip it
-		if getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
+		// If FileMode isn't enabled and the proto import is a self import
+		// (an import between the same package), skip it
+		if pc.Mode != FileMode && getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
 			delete(pkg.Imports, i)
 			continue
 		}

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -250,6 +250,9 @@ func TestFileModeImports(t *testing.T) {
 				},
 			},
 		},
+		// Imports should contain foo.proto. This is specific to file mode.
+		// In package mode, this import would be omitted as both foo.proto
+		// and bar.proto exist within the same package.
 		Imports: map[string]bool{
 			"file_mode/foo.proto": true,
 		},

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -386,6 +386,30 @@ proto_library(
     deps = ["//somedir:bar_proto"],
 )
 `,
+		}, {
+			desc: "test single file resolution in same package",
+			old: `
+proto_library(
+    name = "qwerty_proto",
+    srcs = ["qwerty.proto"],
+)
+
+proto_library(
+    name = "other_proto",
+    _imports = ["test/qwerty.proto"],
+)
+`,
+			want: `
+proto_library(
+    name = "qwerty_proto",
+    srcs = ["qwerty.proto"],
+)
+
+proto_library(
+    name = "other_proto",
+    deps = [":qwerty_proto"],
+)
+`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/language/proto/testdata/file_mode/bar.proto
+++ b/language/proto/testdata/file_mode/bar.proto
@@ -1,3 +1,14 @@
 syntax = "proto3";
 
 package file_mode;
+
+// Note that this import doesn't result in a dependency added to BUILD
+// when evaluated by generate_test. Dependencies are added by the resolve
+// step which is tested elsewhere.
+//
+// This import is tested by generate_test.TestFileModeImports.
+import "file_mode/foo.proto";
+
+message Bar {
+    Foo foo = 1;
+}

--- a/language/proto/testdata/file_mode/foo.proto
+++ b/language/proto/testdata/file_mode/foo.proto
@@ -1,3 +1,6 @@
 syntax = "proto3";
 
 package file_mode;
+
+message Foo {
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
language/proto

**What does this PR do? Why is it needed?**
With the recently-added per-file mode for the proto generator, imports of `.proto` files within the same package don't generate dependencies.

**Which issues(s) does this PR fix?**

Fixes #1157

**Other notes for review**
