### PR TITLE
Draft: Allow FixLoad to add loads for non-rule functions

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -234,7 +234,7 @@ func (vs byPkgRel) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }
 var genericLoads = []rule.LoadInfo{
 	{
 		Name:    "@bazel_gazelle//:def.bzl",
-		Symbols: []string{"gazelle"},
+		Symbols: []string{"gazelle", "gazelle_binary"},
 	},
 }
 

--- a/merger/BUILD.bazel
+++ b/merger/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/merger",
     visibility = ["//visibility:public"],
-    deps = ["//rule"],
+    deps = [
+        "//rule",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+    ],
 )
 
 go_test(


### PR DESCRIPTION
Not for merging - to drive discussion on #1087

We're trying to solve something similar to https://github.com/bazelbuild/bazel-gazelle/issues/1087 for our own Java implementation.

This is not something we could land as-is, but we're not really sure what the API should look like for this - this is roughly the implementation details sufficient for our Java implementation, but we'd like to work out the API we could fit this in together. There are two key parts we need to be able to do:

1. Add a call to `artifact(...)` in a deps list (similar to the `requirement` call in the linked to Python issue) - this works fine because Gazelle already accepts any `bzl.Expr` for serializing to a BUILD file.
2. Add a `load` statement for the relevant function to the file - this one is tricky because right now the Resolve interface doesn't have a way of conveying extra symbols which need loading.

We're not familiar enough with the API here to have instincts for what the API should look like, but some ideas we had:
1. The `Rule` parameter could be given some method which allows for this mutation.
2. We could add a new parameter (or return value) for conveying this information - this would be a breaking change, including breaking skylib, which feels pretty controversial.
3. Whatever else people think :)
Any of these approaches would likely need updates to `FixLoad` - it's possible we could get away with not changing much of the APIs above and instead _just_ modify `FixLoad`, but that would probably make the API look stranger.

Then on the `FixLoad` side, we could read extra data that's hidden away. Alternatively, we could add some kind of parent-child relationship to `knownLoads`/`knownKinds` so that we could detect that an `artifact` was nested inside a `java_library` call and so that particular load should be used (as I can believe these helper functions may conflict across rulesets in the future).

Would appreciate any guidance as to what this API should look like!