### PR TITLE
FixLoad loads helper functions, not just rules

### DIFF
--- a/merger/BUILD.bazel
+++ b/merger/BUILD.bazel
@@ -8,19 +8,27 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/merger",
     visibility = ["//visibility:public"],
-    deps = ["//rule"],
+    deps = [
+        "//rule",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+    ],
 )
 
 go_test(
     name = "merger_test",
     size = "small",
-    srcs = ["merger_test.go"],
+    srcs = [
+        "fix_test.go",
+        "merger_test.go",
+    ],
     deps = [
         ":merger",
         "//language",
         "//language/go",
         "//language/proto",
         "//rule",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_google_go_cmp//cmp",
     ],
 )
 
@@ -30,6 +38,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "fix.go",
+        "fix_test.go",
         "merger.go",
         "merger_test.go",
     ],

--- a/merger/fix.go
+++ b/merger/fix.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 // FixLoads removes loads of unused go rules and adds loads of newly used rules.
@@ -29,11 +30,11 @@ import (
 // This function calls File.Sync before processing loads.
 func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 	knownFiles := make(map[string]bool)
-	knownKinds := make(map[string]string)
+	knownSymbols := make(map[string]string)
 	for _, l := range knownLoads {
 		knownFiles[l.Name] = true
 		for _, k := range l.Symbols {
-			knownKinds[k] = l.Name
+			knownSymbols[k] = l.Name
 		}
 	}
 
@@ -57,16 +58,28 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 	}
 
 	// Make a map of all the symbols from known files used in this file.
-	usedKinds := make(map[string]map[string]bool)
-	for _, r := range f.Rules {
-		kind := r.Kind()
-		if file, ok := knownKinds[kind]; ok && !otherLoadedKinds[kind] {
-			if usedKinds[file] == nil {
-				usedKinds[file] = make(map[string]bool)
-			}
-			usedKinds[file][kind] = true
-		}
-	}
+	usedSymbols := make(map[string]map[string]bool)
+	bzl.Walk(f.File, func(x bzl.Expr, stk []bzl.Expr) {
+        ce, ok := x.(*bzl.CallExpr)
+        if !ok {
+            return
+        }
+
+        id, ok := ce.X.(*bzl.Ident)
+        if !ok {
+            return
+        }
+
+        file, ok := knownSymbols[id.Name]
+        if !ok || otherLoadedKinds[id.Name] {
+            return
+        }
+
+        if usedSymbols[file] == nil {
+            usedSymbols[file] = make(map[string]bool)
+        }
+        usedSymbols[file][id.Name] = true
+    })
 
 	// Fix the load statements. The order is important, so we iterate over
 	// knownLoads instead of knownFiles.
@@ -78,17 +91,17 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 				continue
 			}
 			if first {
-				fixLoad(l, file, usedKinds[file], knownKinds)
+				fixLoad(l, file, usedSymbols[file], knownSymbols)
 				first = false
 			} else {
-				fixLoad(l, file, nil, knownKinds)
+				fixLoad(l, file, nil, knownSymbols)
 			}
 			if l.IsEmpty() {
 				l.Delete()
 			}
 		}
 		if first {
-			load := fixLoad(nil, file, usedKinds[file], knownKinds)
+			load := fixLoad(nil, file, usedSymbols[file], knownSymbols)
 			if load != nil {
 				index := newLoadIndex(f, known.After)
 				load.Insert(f, index)
@@ -98,26 +111,27 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 }
 
 // fixLoad updates a load statement with the given symbols. If load is nil,
-// a new load may be created and returned. Symbols in kinds will be added
-// to the load if they're not already present. Known symbols not in kinds
+// a new load may be created and returned. Symbols in symbols will be added
+// to the load if they're not already present. Known symbols not in symbols
 // will be removed if present. Other symbols will be preserved. If load is
 // empty, nil is returned.
-func fixLoad(load *rule.Load, file string, kinds map[string]bool, knownKinds map[string]string) *rule.Load {
+func fixLoad(load *rule.Load, file string, symbols map[string]bool, knownSymbols map[string]string) *rule.Load {
 	if load == nil {
-		if len(kinds) == 0 {
+		if len(symbols) == 0 {
 			return nil
 		}
 		load = rule.NewLoad(file)
 	}
 
-	for k := range kinds {
+	for k := range symbols {
 		load.Add(k)
 	}
 	for _, k := range load.Symbols() {
-		if knownKinds[k] != "" && !kinds[k] {
+		if knownSymbols[k] != "" && !symbols[k] {
 			load.Remove(k)
 		}
 	}
+
 	return load
 }
 

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -1,0 +1,189 @@
+/* Copyright 2022 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merger_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/merger"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFixLoads(t *testing.T) {
+	knownLoads := []rule.LoadInfo{
+		{
+			Name: "@bar",
+			Symbols: []string{
+				"magic",
+			},
+		},
+		{
+			Name: "@foo",
+			Symbols: []string{
+				"foo_binary",
+				"foo_library",
+				"foo_test",
+			},
+		},
+	}
+
+	type testCase struct {
+		input string
+		want  string
+	}
+
+	for name, tc := range map[string]testCase{
+		"correct": {
+			input: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+			want: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+		},
+		"correct with macro": {
+			input: `load("@bar", "magic")
+load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(
+	name = "a_lib",
+	deps = [
+		"//a/b:c",
+		magic("baz"),
+	],
+)
+		`,
+			want: `load("@bar", "magic")
+load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(
+    name = "a_lib",
+    deps = [
+        "//a/b:c",
+        magic("baz"),
+    ],
+)
+`,
+		},
+		"missing macro load": {
+			input: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(
+    name = "a_lib",
+    deps = [
+        "//a/b:c",
+        magic("baz"),
+    ],
+)
+`,
+			want: `load("@bar", "magic")
+load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(
+    name = "a_lib",
+    deps = [
+        "//a/b:c",
+        magic("baz"),
+    ],
+)
+`,
+		},
+		"unused macro": {
+			input: `load("@bar", "magic")
+			load("@foo", "foo_binary")
+	
+foo_binary(name = "a")
+`,
+			want: `load("@foo", "foo_binary")
+
+foo_binary(name = "a")
+`,
+		},
+		"missing kind load symbol": {
+			input: `load("@foo", "foo_binary")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+			want: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+		},
+		"missing kind load": {
+			input: `foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+			want: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+		},
+		"unused kind load symbol": {
+			input: `load("@foo", "foo_binary", "foo_library", "foo_test")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+			want: `load("@foo", "foo_binary", "foo_library")
+
+foo_binary(name = "a")
+
+foo_library(name = "a_lib")
+`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f, err := rule.LoadData("", "", []byte(tc.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			merger.FixLoads(f, knownLoads)
+			f.Sync()
+
+			want := strings.TrimSpace(tc.want)
+			got := strings.TrimSpace(string(bzl.Format(f.File)))
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("FixLoads() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

`merger`

**What does this PR do? Why is it needed?**

Some language implementations may try to add helper functions as
`CallExpr`s, e.g. in rules_python the `requirement` function, or in
rules_jvm_external the `artifact` function. This allows for parsing
these out and adding `load` statements for them.

**Which issues(s) does this PR fix?**

See also: #981, #978, #1087 (but does not fully fix them).

**Other notes for review**

This approach was suggested in [this comment](https://github.com/bazelbuild/bazel-gazelle/issues/978#issuecomment-755431161).