### PR TITLE
Show `go get` package time to debug output

### DIFF
--- a/repo/remote.go
+++ b/repo/remote.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -29,6 +30,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/pathtools"
@@ -420,10 +422,13 @@ func defaultModInfo(rc *RemoteCache, importPath string) (modPath string, err err
 	goTool := findGoTool()
 	env := append(os.Environ(), "GO111MODULE=on")
 
+	goGetBegin := time.Now()
 	cmd := exec.Command(goTool, "get", "-d", "--", importPath)
 	cmd.Dir = rc.tmpDir
 	cmd.Env = env
-	if _, err := cmd.Output(); err != nil {
+	_, err = cmd.Output()
+	log.Printf("lookup package %q took %s\n", importPath, time.Since(goGetBegin).Round(10*time.Millisecond))
+	if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
I was strongly confused by too long `@com_github_docker_docker` package analyzing (~20 min) after every WORKSPACE update.
Aflter some investigation I found: most time spent on `go get -d -- ...` command for not declared by `go_repostory` imports.

This PR simply adds undeclared imports logging.

In my case this messages looks like:
```
DEBUG: /home/bozaro/.cache/bazel/_bazel_bozaro/af2410e05a974acb04276ed867584966/external/bazel_gazelle/internal/go_repository.bzl:262:18: com_github_docker_cli: gazelle: package "github.com/fvbommel/sortorder" lookup tooks 770ms
gazelle: package "github.com/moby/buildkit/frontend/dockerfile/dockerignore" lookup tooks 9.45s
gazelle: package "github.com/moby/buildkit/api/services/control" lookup tooks 21.42s
gazelle: package "github.com/moby/buildkit/client" lookup tooks 24.74s
gazelle: package "github.com/moby/buildkit/session" lookup tooks 13.47s
gazelle: package "github.com/moby/buildkit/session/auth/authprovider" lookup tooks 27.84s
gazelle: package "github.com/moby/buildkit/session/filesync" lookup tooks 19.38s
gazelle: package "github.com/moby/buildkit/session/secrets/secretsprovider" lookup tooks 19.53s
gazelle: package "github.com/moby/buildkit/session/sshforward/sshprovider" lookup tooks 16.54s
gazelle: package "github.com/moby/buildkit/util/appcontext" lookup tooks 5.06s
gazelle: package "github.com/moby/buildkit/util/progress/progressui" lookup tooks 25.86s
gazelle: package "github.com/moby/buildkit/util/progress/progresswriter" lookup tooks 22.94s
...
```