### PR TITLE
Limit Gazelle's walk to -universe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -443,6 +443,12 @@ The following flags are accepted:
 | should use the index to resolve dependencies. If this is switched off, Gazelle would rely on               |
 | ``# gazelle:prefix`` directive or ``-go_prefix`` flag to resolve dependencies.                             |
 +-------------------------------------------------------------------+----------------------------------------+
+| :flag:`-universe dir1,dir2`                                       |                                        |
++-------------------------------------------------------------------+----------------------------------------+
+| List of directories that Gazelle should visit recursively. They are relative paths to `-repo_root`, so the |
+| default empty string means `-repo_root`. Gazelle will not read/index or write any Bazel rules outside the  |
+| universe.                                                                                                  |
++-------------------------------------------------------------------+----------------------------------------+
 | :flag:`-go_grpc_compiler`                                         | ``@io_bazel_rules_go//proto:go_grpc``  |
 +-------------------------------------------------------------------+----------------------------------------+
 | The protocol buffers compiler to use for building go bindings for gRPC. May be repeated.                   |

--- a/config/config.go
+++ b/config/config.go
@@ -321,7 +321,7 @@ func (cc *CommonConfigurer) removeSubDirs(dirs []string) []string {
 	for dir := range dirSet {
 		parent := filepath.Dir(dir)
 		var isSubDir = false
-		for parent != "." && parent != "" {
+		for parent != "." && parent != "/" {
 			if _, ok := dirSet[parent]; ok {
 				isSubDir = true
 				break

--- a/config/config.go
+++ b/config/config.go
@@ -321,7 +321,7 @@ func (cc *CommonConfigurer) removeSubDirs(dirs []string) []string {
 	for dir := range dirSet {
 		parent := filepath.Dir(dir)
 		var isSubDir = false
-		for parent != "." && parent != "/" {
+		for parent != "." && parent != string(filepath.Separator) {
 			if _, ok := dirSet[parent]; ok {
 				isSubDir = true
 				break

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,6 +90,7 @@ func TestCommonConfigurerDirectives(t *testing.T) {
 }
 
 func TestRemoveSubDirs(t *testing.T) {
+	repoRoot := filepath.Join(os.TempDir(), "root")
 	tests := []struct {
 		desc          string
 		given, expect []string
@@ -101,12 +102,12 @@ func TestRemoveSubDirs(t *testing.T) {
 		},
 		{
 			desc:   "ignore absolute paths outside root",
-			given:  []string{"/tmp/dir1", "dir2"},
+			given:  []string{filepath.Join(os.TempDir(), "dir1"), "dir2"},
 			expect: []string{"dir2"},
 		},
 		{
 			desc:   "convert absolute paths under root",
-			given:  []string{"/root/dir1"},
+			given:  []string{filepath.Join(repoRoot, "dir1")},
 			expect: []string{"dir1"},
 		},
 		{
@@ -121,7 +122,7 @@ func TestRemoveSubDirs(t *testing.T) {
 		},
 	}
 	cc := &CommonConfigurer{
-		repoRoot: "/root",
+		repoRoot: repoRoot,
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,6 +66,11 @@ func TestCommonConfigurerFlags(t *testing.T) {
 	if !reflect.DeepEqual(c.Langs, wantLangs) {
 		t.Errorf("for Langs, got %#v, want %#v", c.Langs, wantLangs)
 	}
+
+	wantUniverse := []string{""}
+	if !reflect.DeepEqual(c.Universe, wantUniverse) {
+		t.Errorf("for universe, got %#v, want %#v", c.Universe, wantUniverse)
+	}
 }
 
 func TestCommonConfigurerDirectives(t *testing.T) {

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -174,7 +174,10 @@ func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode,
 			wf(dir, rel, c, update, f, subdirs, regularFiles, genFiles)
 		}
 	}
-	visit(c, c.RepoRoot, "", false)
+
+	for _, rootRel := range c.Universe {
+		visit(c, c.RepoRoot, rootRel, false)
+	}
 }
 
 // buildUpdateRelMap builds a table of prefixes, used to determine which


### PR DESCRIPTION
**What type of PR is this?**
Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

* config
* walk

**What does this PR do? Why is it needed?**
Gazelle now takes a `-universe` parameter, which contains a list of directories. Instead of walking from the repo root, it walks from each directories in the `-universe`. This is needed to speed up traversal in large repositories, where we know some part of the repository is not relevant to Gazelle.

**Which issues(s) does this PR fix?**

Fixes #1180 

**Other notes for review**
