### PR TITLE
go_repository: avoid unnecessary fetches in HTTP mode

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -98,6 +98,8 @@ def _go_repository_impl(ctx):
     # Declare Label dependencies at the top of function to avoid unnecessary fetching:
     # https://docs.bazel.build/versions/main/skylark/repository_rules.html#when-is-the-implementation-function-executed
     go_env_cache = str(ctx.path(Label("@bazel_gazelle_go_repository_cache//:go.env")))
+    if not ctx.attr.urls:
+        fetch_repo = str(ctx.path(Label("@bazel_gazelle_go_repository_tools//:bin/fetch_repo{}".format(executable_extension(ctx)))))
     generate = ctx.attr.build_file_generation == "on"
     _gazelle = "@bazel_gazelle_go_repository_tools//:bin/gazelle{}".format(executable_extension(ctx))
     if generate:
@@ -200,7 +202,6 @@ def _go_repository_impl(ctx):
         # Override external GO111MODULE, because it is needed by module mode, no-op in repository mode
         fetch_repo_env["GO111MODULE"] = "on"
 
-        fetch_repo = str(ctx.path(Label("@bazel_gazelle_go_repository_tools//:bin/fetch_repo{}".format(executable_extension(ctx)))))
         result = env_execute(
             ctx,
             [fetch_repo] + fetch_repo_args,


### PR DESCRIPTION
Currently, if a `go_repository` rule is in HTTP mode and has `build_file_generation = on` it can result in unnecessary calls to `download_and_extract` while the `@bazel_gazelle_go_repository_tools` and `@bazel_gazelle_go_repository_cache` labels are still not available. Note that redundant fetches can be unavoidable when in HTTP mode and `build_file_generation = auto` because the rule needs to fetch and examine the repo to determine if it requires `@bazel_gazelle_go_repository_tools`.

For more info about repository rule restarting see:
https://docs.bazel.build/versions/5.0.0/skylark/repository_rules.html#when-is-the-implementation-function-executed 

Resolve #1175
