### PR TITLE
resolve: improve matching of two resolvers (#1162)

### DIFF
--- a/resolve/index.go
+++ b/resolve/index.go
@@ -189,7 +189,8 @@ func (ix *RuleIndex) collectEmbeds(r *ruleRecord) {
 			continue
 		}
 		ix.collectEmbeds(er)
-		if resolver == ix.mrslv(er.rule, er.file.Pkg) {
+		erResolver := ix.mrslv(er.rule, er.file.Pkg)
+		if resolver.Name() == erResolver.Name() {
 			er.embedded = true
 			r.embeds = append(r.embeds, er.embeds...)
 		}


### PR DESCRIPTION
A Resolver can be overriden, this is the case by example for all rules
from the map_kind operation.

This layer must be transparent while comparing two resolvers.

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

resolve

**What does this PR do? Why is it needed?**

These modifications provide an abstraction of the inverseMapKindResolver to compare two Resolver objects.

**Which issues(s) does this PR fix?**

Fixes #1162

**Other notes for review**

Thank you @blico for the test <3.