### PR TITLE
language/go: support embedding subdirs containing buildable subdirs

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -110,7 +110,8 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	var hasTestdata bool
 	for _, sub := range args.Subdirs {
 		if sub == "testdata" {
-			hasTestdata = !gl.goPkgRels[path.Join(args.Rel, "testdata")]
+			_, ok := gl.goPkgRels[path.Join(args.Rel, "testdata")]
+			hasTestdata = !ok
 			break
 		}
 	}
@@ -300,7 +301,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	} else {
 		for _, sub := range args.Subdirs {
 			if gl.goPkgRels[path.Join(args.Rel, sub)] {
-				gl.goPkgRels[args.Rel] = true
+				gl.goPkgRels[args.Rel] = false
 				break
 			}
 		}

--- a/language/go/lang.go
+++ b/language/go/lang.go
@@ -59,7 +59,8 @@ const goName = "go"
 
 type goLang struct {
 	// goPkgDirs is a set of relative paths to directories containing buildable
-	// Go code, including in subdirectories.
+	// Go code. If the value is false, it means the directory does not contain 
+	// buildable Go code, but it has a subdir which does.
 	goPkgRels map[string]bool
 }
 

--- a/language/go/testdata/embedsrcs/m_dir/o_go/o.go
+++ b/language/go/testdata/embedsrcs/m_dir/o_go/o.go
@@ -1,0 +1,5 @@
+// m_dir/o_go/o.go should not be embedded because Gazelle will generate a build file
+// for this directory, and we can't reliably embed files across Bazel
+// packages.
+
+package o


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**
Fixes a bug where Gazelle was failing to embed files of a subdir, if it contained buildable subdirs.

For example, Gazelle would not find `bar.txt` for `//go:embed foo/bar.txt` if `foo` also contained a package `baz` which had go files.

`goPkgRels` is currently being used to determine if a directory is embeddable and if a `testdata` directory can be added as a `data` attribute. These two cases are the same unless a subdir contains buildable subdirs, in which the directory should still be embeddable but if it is `testdata` it should not be added as a `data` attribute.

The fix is to ensure `goPkgRels` correctly reflects whether a dir is a go package or not. To ensure `testdata` still conforms to the old logic, rather than checking for the value of `goPkgRels` we check if a value exists for the given dir.

**Which issues(s) does this PR fix?**

Fixes #1192
