### PR TITLE
fix: Remove gazelle_binary import collision

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,3 +88,7 @@ http_archive(
         "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
     ],
 )
+
+load("@bazel_skylib//lib:unittest.bzl", "register_unittest_toolchains")
+
+register_unittest_toolchains()

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":gazelle_binary_test.bzl", "gazelle_binary_test_suite")
 
 # gazelle:exclude *_test.go
 go_bazel_test(
@@ -14,6 +15,8 @@ go_bazel_test(
     ],
     deps = ["//testtools"],
 )
+
+gazelle_binary_test_suite()
 
 # TODO(jayconrod): test fetch_repo error cases.
 
@@ -37,6 +40,7 @@ filegroup(
         "extend_docs.bzl",
         "gazelle.bash.in",
         "gazelle_binary.bzl",
+        "gazelle_binary_test.bzl",
         "go_repository.bzl",
         "go_repository_cache.bzl",
         "go_repository_config.bzl",

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -119,10 +119,11 @@ def gazelle_binary_wrapper(**kwargs):
             fail("gazelle_binary attribute '%s' is no longer supported (https://github.com/bazelbuild/bazel-gazelle/issues/803)" % key)
     gazelle_binary(**kwargs)
 
+def _import_alias(importpath):
+    return importpath.replace("/", "_").replace(".", "_").replace("-", "_") + "_"
+
 def _format_import(importpath):
-    _, _, base = importpath.rpartition("/")
-    return '{} "{}"'.format(base + "_", importpath)
+    return '{} "{}"'.format(_import_alias(importpath), importpath)
 
 def _format_call(importpath):
-    _, _, base = importpath.rpartition("/")
-    return "{}.NewLanguage()".format(base + "_")
+    return _import_alias(importpath)+".NewLanguage()"

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -37,8 +37,8 @@ var languages = []language.Language{{
 	{lang_calls},
 }}
 """
-    lang_imports = [_format_import(d[GoArchive].data.importpath) for d in ctx.attr.languages]
-    lang_calls = [_format_call(d[GoArchive].data.importpath) for d in ctx.attr.languages]
+    lang_imports = [format_import(d[GoArchive].data.importpath) for d in ctx.attr.languages]
+    lang_calls = [format_call(d[GoArchive].data.importpath) for d in ctx.attr.languages]
     langs_content = langs_content_tpl.format(
         lang_imports = "\n\t".join(lang_imports),
         lang_calls = ",\n\t".join(lang_calls),
@@ -122,8 +122,8 @@ def gazelle_binary_wrapper(**kwargs):
 def _import_alias(importpath):
     return importpath.replace("/", "_").replace(".", "_").replace("-", "_") + "_"
 
-def _format_import(importpath):
+def format_import(importpath):
     return '{} "{}"'.format(_import_alias(importpath), importpath)
 
-def _format_call(importpath):
+def format_call(importpath):
     return _import_alias(importpath)+".NewLanguage()"

--- a/internal/gazelle_binary_test.bzl
+++ b/internal/gazelle_binary_test.bzl
@@ -1,0 +1,31 @@
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":gazelle_binary.bzl", "format_call", "format_import")
+
+def _format_call_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "github_com_bazelbuild_bazel_skylib_gazelle_.NewLanguage()",
+        format_call("github.com/bazelbuild/bazel-skylib/gazelle"),
+    )
+    return unittest.end(env)
+
+def _format_import_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "github_com_bazelbuild_bazel_skylib_gazelle_ \"github.com/bazelbuild/bazel-skylib/gazelle\"",
+        format_import("github.com/bazelbuild/bazel-skylib/gazelle"),
+    )
+    return unittest.end(env)
+
+_format_call_test = unittest.make(_format_call_test_impl)
+_format_import_test = unittest.make(_format_import_test_impl)
+
+def gazelle_binary_test_suite():
+    unittest.suite(
+        "gazelle_binary_tests",
+        partial.make(_format_call_test, size = "small"),
+        partial.make(_format_import_test, size = "small"),
+    )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

internal/gazelle_binary

**What does this PR do? Why is it needed?**

These changes make the import aliases for the generated Go code in gazelle_binary longer to avoid collisions.

Without theses changes, importing 2 gazelle extensions with the same base path would fail to build the gazelle binary:

```starlark
gazelle_binary(
    name = "gazelle_bin",
    languages = [
        # importpath = github.com/bazelbuild/bazel-skylib/gazelle
        "@bazel_skylib//gazelle/bzl",
        # importpath = github.com/bazelbuild/rules_python/gazelle
        "@rules_python//gazelle:gazelle_python_binary",
    ],
)
```

```console
$ bazel build //:gazelle_bin
[...  snip]
bazel-out/darwin-fastbuild/bin/gazelle_bin_/langs.go:10:2: gazelle_ redeclared in this block
	bazel-out/darwin-fastbuild/bin/gazelle_bin_/langs.go:9:2: other declaration of gazelle_
bazel-out/darwin-fastbuild/bin/gazelle_bin_/langs.go:10:2: imported and not used: "github.com/bazelbuild/rules_python/gazelle" as gazelle_
```

The **current** generated bazel-out/darwin-fastbuild/bin/gazelle_bin_/langs.go file:

```go
package main

import (
	"github.com/bazelbuild/bazel-gazelle/language"

	gazelle_ "github.com/bazelbuild/bazel-skylib/gazelle"
	gazelle_ "github.com/bazelbuild/rules_python/gazelle"
)

var languages = []language.Language{
	gazelle_.NewLanguage(),
	gazelle_.NewLanguage(),
}
```

With the proposed changes, this file would become:

```go
package main

import (
	"github.com/bazelbuild/bazel-gazelle/language"

	github_com_bazelbuild_bazel_skylib_gazelle_ "github.com/bazelbuild/bazel-skylib/gazelle"
	github_com_bazelbuild_rules_python_gazelle_ "github.com/bazelbuild/rules_python/gazelle"
)

var languages = []language.Language{
	github_com_bazelbuild_bazel_skylib_gazelle_.NewLanguage(),
	github_com_bazelbuild_rules_python_gazelle_.NewLanguage(),
}
```