### PR TITLE
Broaden label name regex

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -64,7 +64,10 @@ var NoLabel = Label{}
 var (
 	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
-	labelNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_/.+=,@~-]*$`)
+	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
+	// Note: We've manually removed space from the regex, because though these technically parse
+	// with Bazel (and can appear in query results), they cannot actually be used in practice.
+	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_`\"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")
 )
 
 // Parse reads a label from a string.

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -78,6 +78,8 @@ func TestParse(t *testing.T) {
 		{str: "@..//b:c", want: Label{Repo: "..", Pkg: "b", Name: "c"}},
 		{str: "@--//b:c", want: Label{Repo: "--", Pkg: "b", Name: "c"}},
 		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},
+		{str: "@go_sdk//:src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt", want: Label{Repo: "go_sdk", Name: "src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt"}},
+		{str: "//:a][b", want: Label{Name: "a][b"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

label

**What does this PR do? Why is it needed?**

Broadens the accepted names in labels.
These are documented at https://docs.bazel.build/versions/main/build-ref.html#name