### PR TITLE
fix(lang/proto): include imports from different targets

### DIFF
--- a/language/go/testdata/proto_package_mode/BUILD.want
+++ b/language/go/testdata/proto_package_mode/BUILD.want
@@ -17,7 +17,10 @@ proto_library(
         "foo1.proto",
         "foo2.proto",
     ],
-    _gazelle_imports = ["google/protobuf/any.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode/bar1.proto",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -31,7 +34,10 @@ go_proto_library(
 
 go_proto_library(
     name = "foo_go_proto",
-    _gazelle_imports = ["google/protobuf/any.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode/bar1.proto",
+    ],
     importpath = "example.com/repo/proto_package_mode",
     proto = ":foo_proto",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/proto_package_mode_extras/BUILD.want
+++ b/language/go/testdata/proto_package_mode_extras/BUILD.want
@@ -17,7 +17,10 @@ proto_library(
         "foo1.proto",
         "foo2.proto",
     ],
-    _gazelle_imports = ["google/protobuf/any.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode_extras/bar1.proto",
+    ],
 )
 
 go_proto_library(
@@ -29,7 +32,10 @@ go_proto_library(
 
 go_proto_library(
     name = "foo_go_proto",
-    _gazelle_imports = ["google/protobuf/any.proto"],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "proto_package_mode_extras/bar1.proto",
+    ],
     importpath = "example.com/repo/proto_package_mode_extras",
     proto = ":foo_proto",
 )

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -235,9 +235,8 @@ func generateProto(pc *ProtoConfig, rel string, pkg *Package, shouldSetVisibilit
 	r.SetPrivateAttr(PackageKey, *pkg)
 	imports := make([]string, 0, len(pkg.Imports))
 	for i := range pkg.Imports {
-		// If FileMode isn't enabled and the proto import is a self import
-		// (an import between the same package), skip it
-		if pc.Mode != FileMode && getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
+		// If the proto import is a self import (an import between the same package), skip it
+		if _, ok := pkg.Files[path.Base(i)]; ok && getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
 			delete(pkg.Imports, i)
 			continue
 		}

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -75,6 +75,7 @@ func TestGenerateRules(t *testing.T) {
 			for _, r := range res.Gen {
 				r.Insert(f)
 			}
+			convertImportsAttrs(f)
 			merger.FixLoads(f, lang.Loads())
 			f.Sync()
 			got := string(bzl.Format(f.File))
@@ -363,4 +364,16 @@ func testConfig(t *testing.T, repoRoot string) (*config.Config, language.Languag
 	})
 	cexts = append(cexts, lang)
 	return c, lang, cexts
+}
+
+// convertImportsAttrs copies private attributes to regular attributes, which
+// will later be written out to build files. This allows tests to check the
+// values of private attributes with simple string comparison.
+func convertImportsAttrs(f *rule.File) {
+	for _, r := range f.Rules {
+		v := r.PrivateAttr(config.GazelleImportsKey)
+		if v != nil {
+			r.SetAttr(config.GazelleImportsKey, v)
+		}
+	}
 }

--- a/language/proto/testdata/default_visibility/BUILD.want
+++ b/language/proto/testdata/default_visibility/BUILD.want
@@ -3,4 +3,5 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    _gazelle_imports = [],
 )

--- a/language/proto/testdata/file_mode/BUILD.want
+++ b/language/proto/testdata/file_mode/BUILD.want
@@ -3,11 +3,13 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "bar_proto",
     srcs = ["bar.proto"],
+    _gazelle_imports = ["file_mode/foo.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    _gazelle_imports = [],
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/import_prefix/BUILD.want
+++ b/language/proto/testdata/import_prefix/BUILD.want
@@ -3,6 +3,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    _gazelle_imports = [],
     import_prefix = "/bar/",
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/multiple_packages/default_mode/BUILD.want
+++ b/language/proto/testdata/multiple_packages/default_mode/BUILD.want
@@ -3,5 +3,6 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "multiple_packages_default_mode_proto",
     srcs = ["foo.proto"],
+    _gazelle_imports = [],
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/multiple_packages/package_mode/BUILD.want
+++ b/language/proto/testdata/multiple_packages/package_mode/BUILD.want
@@ -6,6 +6,7 @@ proto_library(
         "bar1.proto",
         "bar2.proto",
     ],
+    _gazelle_imports = [],
     visibility = ["//visibility:public"],
 )
 
@@ -15,5 +16,6 @@ proto_library(
         "foo1.proto",
         "foo2.proto",
     ],
+    _gazelle_imports = [],
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
+++ b/language/proto/testdata/multiple_packages/package_mode_group/BUILD.want
@@ -6,6 +6,7 @@ proto_library(
         "bar1.proto",
         "bar2.proto",
     ],
+    _gazelle_imports = [],
     visibility = ["//visibility:public"],
 )
 
@@ -15,5 +16,6 @@ proto_library(
         "foo1.proto",
         "foo2.proto",
     ],
+    _gazelle_imports = ["multiple_packages/package_mode_group/bar1.proto"],
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/multiple_packages/package_mode_group/bar1.proto
+++ b/language/proto/testdata/multiple_packages/package_mode_group/bar1.proto
@@ -1,3 +1,5 @@
 syntax = "proto3";
 
+package multiple_packages.package_mode_group;
+
 option x_package = "x/bar";

--- a/language/proto/testdata/multiple_packages/package_mode_group/bar2.proto
+++ b/language/proto/testdata/multiple_packages/package_mode_group/bar2.proto
@@ -1,3 +1,5 @@
 syntax = "proto3";
 
+package multiple_packages.package_mode_group;
+
 option x_package = "x/bar";

--- a/language/proto/testdata/multiple_packages/package_mode_group/foo1.proto
+++ b/language/proto/testdata/multiple_packages/package_mode_group/foo1.proto
@@ -1,3 +1,7 @@
 syntax = "proto3";
 
+package multiple_packages.package_mode_group;
+
 option x_package = "111@foo";
+
+import "multiple_packages/package_mode_group/bar1.proto";

--- a/language/proto/testdata/multiple_packages/package_mode_group/foo2.proto
+++ b/language/proto/testdata/multiple_packages/package_mode_group/foo2.proto
@@ -1,3 +1,5 @@
 syntax = "proto3";
 
+package multiple_packages.package_mode_group;
+
 option x_package = "111@foo";

--- a/language/proto/testdata/protos/BUILD.want
+++ b/language/proto/testdata/protos/BUILD.want
@@ -6,5 +6,9 @@ proto_library(
         "foo.proto",
         "foo_generated.proto",
     ],
+    _gazelle_imports = [
+        "google/protobuf/any.proto",
+        "protos/sub/sub.proto",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/language/proto/testdata/strip_import_prefix/BUILD.want
+++ b/language/proto/testdata/strip_import_prefix/BUILD.want
@@ -3,6 +3,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "foo_proto",
     srcs = ["foo.proto"],
+    _gazelle_imports = [],
     strip_import_prefix = "/strip_import_prefix",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/proto

**What does this PR do? Why is it needed?**

Fixes an issue where dependencies would be missed in the case where an
import was of a proto file in the same directory but from a different
target, such an when using `proto_group`. This would cause Gazelle to
generate `proto_library` and `go_proto_library` targets that could not
be built.

**Which issues(s) does this PR fix?**

Fixes #1219