### PR TITLE
Go: Update tests to use cmp.Diff instead of reflect.DeepEqual

### DIFF
--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//testtools",
         "//walk",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_google_go_cmp//cmp",
         "@org_golang_x_tools//go/vcs",
     ],
 )

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -18,7 +18,6 @@ package golang
 import (
 	"path"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bazelbuild/bazel-gazelle/testtools"
 	"github.com/bazelbuild/bazel-gazelle/walk"
+	"github.com/google/go-cmp/cmp"
 )
 
 func testConfig(t *testing.T, args ...string) (*config.Config, []language.Language, []config.Configurer) {
@@ -121,14 +121,15 @@ func TestDirectives(t *testing.T) {
 	if !gc.goGrpcCompilersSet {
 		t.Error("expected goGrpcCompilersSet to be set")
 	}
-	if !reflect.DeepEqual(gc.goGrpcCompilers, []string{"abc", "def"}) {
-		t.Errorf("got goGrpcCompilers %v; want [abc def]", gc.goGrpcCompilers)
+	if diff := cmp.Diff([]string{"abc", "def"}, gc.goGrpcCompilers); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
+
 	if !gc.goProtoCompilersSet {
 		t.Error("expected goProtoCompilersSet to be set")
 	}
-	if !reflect.DeepEqual(gc.goProtoCompilers, []string{"foo", "bar"}) {
-		t.Errorf("got goProtoCompilers %v; want [foo bar]", gc.goProtoCompilers)
+	if diff := cmp.Diff(gc.goProtoCompilers, []string{"foo", "bar"}); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
 
 	subContent := []byte(`
@@ -146,15 +147,17 @@ func TestDirectives(t *testing.T) {
 	if gc.goGrpcCompilersSet {
 		t.Error("expected goGrpcCompilersSet to be unset")
 	}
-	if !reflect.DeepEqual(gc.goGrpcCompilers, defaultGoGrpcCompilers) {
-		t.Errorf("got goGrpcCompilers %v; want %v", gc.goGrpcCompilers, defaultGoGrpcCompilers)
+	if diff := cmp.Diff(defaultGoGrpcCompilers, gc.goGrpcCompilers); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
+
 	if gc.goProtoCompilersSet {
 		t.Error("expected goProtoCompilersSet to be unset")
 	}
-	if !reflect.DeepEqual(gc.goProtoCompilers, defaultGoProtoCompilers) {
-		t.Errorf("got goProtoCompilers %v; want %v", gc.goProtoCompilers, defaultGoProtoCompilers)
+	if diff := cmp.Diff(defaultGoProtoCompilers, gc.goProtoCompilers); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
+
 }
 
 func TestVendorConfig(t *testing.T) {
@@ -340,8 +343,9 @@ func TestSplitValue(t *testing.T) {
 		},
 	} {
 		parts := splitValue(tc.value)
-		if !reflect.DeepEqual(tc.parts, parts) {
-			t.Errorf("want %v; got %v", tc.parts, parts)
+		if diff := cmp.Diff(tc.parts, parts); diff != "" {
+			t.Errorf("(-want, +got): %s", diff)
 		}
+
 	}
 }

--- a/language/go/fileinfo_go_test.go
+++ b/language/go/fileinfo_go_test.go
@@ -19,9 +19,18 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	fileInfoCmpOption = cmp.AllowUnexported(
+		fileInfo{},
+		fileEmbed{},
+		taggedOpts{},
+	)
 )
 
 func TestGoFileInfo(t *testing.T) {
@@ -178,9 +187,10 @@ var src string
 				got.embeds[i] = fileEmbed{path: got.embeds[i].path}
 			}
 
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+			if diff := cmp.Diff(tc.want, got, fileInfoCmpOption); diff != "" {
+				t.Errorf("(-want, +got): %s", diff)
 			}
+
 		})
 	}
 }
@@ -205,9 +215,10 @@ func TestGoFileInfoFailure(t *testing.T) {
 		goos:   "linux",
 		goarch: "amd64",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v ; want %#v", got, want)
+	if diff := cmp.Diff(want, got, fileInfoCmpOption); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
+
 }
 
 func TestCgo(t *testing.T) {
@@ -331,9 +342,10 @@ import ("C")
 				clinkopts: got.clinkopts,
 			}
 
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+			if diff := cmp.Diff(tc.want, got, fileInfoCmpOption); diff != "" {
+				t.Errorf("(-want, +got): %s", diff)
 			}
+
 		})
 	}
 }
@@ -370,6 +382,16 @@ func TestExpandSrcDir(t *testing.T) {
 		}
 	}
 }
+
+var (
+	goPackageCmpOption = cmp.AllowUnexported(
+		goPackage{},
+		goTarget{},
+		protoTarget{},
+		platformStringsBuilder{},
+		platformStringInfo{},
+	)
+)
 
 func TestExpandSrcDirRepoRelative(t *testing.T) {
 	repo, err := ioutil.TempDir(os.Getenv("TEST_TEMPDIR"), "repo")
@@ -409,9 +431,10 @@ import "C"
 	}
 	want.library.sources.addGenericString("sub.go")
 	want.library.copts.addGenericString("-Isub/..")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v ; want %#v", got, want)
+	if diff := cmp.Diff(want, got, goPackageCmpOption); diff != "" {
+		t.Errorf("(-want, +got): %s", diff)
 	}
+
 }
 
 // Copied from go/build build_test.go

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOtherFileInfo(t *testing.T) {
@@ -55,9 +57,10 @@ func TestOtherFileInfo(t *testing.T) {
 
 			// Only check that we can extract tags. Everything else is covered
 			// by other tests.
-			if !reflect.DeepEqual(got.tags, tc.wantTags) {
-				t.Errorf("got %#v; want %#v", got.tags, tc.wantTags)
+			if diff := cmp.Diff(tc.wantTags, got.tags, fileInfoCmpOption); diff != "" {
+				t.Errorf("(-want, +got): %s", diff)
 			}
+
 		})
 	}
 }
@@ -331,8 +334,8 @@ package main`,
 
 		if got, err := readTags(path); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("case %q: got %#v; want %#v", tc.desc, got, tc.want)
+		} else if diff := cmp.Diff(tc.want, got); diff != "" {
+			t.Errorf("(-want, +got): %s", diff)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.

Other

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

`reflect.DeepEqual` is a poorer chose when choosing to compare test results. For example, `DeepEqual` will only compare pointer values using their memory address, rather than the underlying value in the type.

This is a pre-factor to make #1243 easier to review (per review feedback)

**Which issues(s) does this PR fix?**

Fixes #1099 

**Other notes for review**
