### PR TITLE
Label's package may contain @s

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -63,7 +63,7 @@ var NoLabel = Label{}
 
 var (
 	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
-	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._-]*$`)
+	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
 	// Note: We've manually removed space from the regex, because though these technically parse
 	// with Bazel (and can appear in query results), they cannot actually be used in practice.

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -75,6 +75,7 @@ func TestParse(t *testing.T) {
 		{str: "@a", want: Label{Repo: "a", Pkg: "", Name: "a"}},
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
+		{str: "@a//@b:c", want: Label{Repo: "a", Pkg: "@b", Name: "c"}},
 		{str: "@..//b:c", want: Label{Repo: "..", Pkg: "b", Name: "c"}},
 		{str: "@--//b:c", want: Label{Repo: "--", Pkg: "b", Name: "c"}},
 		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

label

**What does this PR do? Why is it needed?**

Label's package may contain @s

See https://github.com/bazelbuild/bazel/pull/15428 for context.

tl;dr: Bazel actually allows this, and some common rulesets (e.g.
`rules_nodejs`) rely heavily on it.