### PR TITLE
go_repository: set build_external default to external

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -375,12 +375,12 @@ go_repository = repository_rule(
             `replace` will be downloaded at `version` and verified with `sum`.
 
             NOTE: There is no `go_repository` equivalent to file path `replace`
-            directives. Use `local_repository` instead."""
+            directives. Use `local_repository` instead.""",
         ),
 
         # Attributes for a repository that needs automatic build file generation
         "build_external": attr.string(
-            default = "static",
+            default = "external",
             doc = """One of `"external"`, `"static"` or `"vendored"`.
 
             This sets Gazelle's `-external` command line flag. In `"static"` mode,
@@ -498,7 +498,7 @@ go_repository = repository_rule(
             so this defaults to `False`. However, setting to `True` can be useful for debugging build failures and
             unexpected behavior for the given rule.
             """,
-        )
+        ),
     },
 )
 """See repository.md#go-repository for full documentation."""


### PR DESCRIPTION
Previously in 9c475138e6c118b55309a55dbf28de77bcf77621 we introduce the
new static dep resolution mode to improve performance of gazelle when
running over a big go_repository archive.

However this introduced several regression issues, especially where the
default user experience starting from v0.25.0 is not able to compile
gazelle binary from scratch.

Let's reverse the default value of this flag for now.  Those who wish to
gain performance from 'static' deps resolution mode may opt-in to this
flag specifically or try to resolve the reported issue in #1217.

Close #1217 