### PR TITLE
Don't exclude spaces from the label name regex

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -65,9 +65,7 @@ var (
 	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
-	// Note: We've manually removed space from the regex, because though these technically parse
-	// with Bazel (and can appear in query results), they cannot actually be used in practice.
-	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_`\"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")
+	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_` \"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")
 )
 
 // Parse reads a label from a string.

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -81,6 +81,7 @@ func TestParse(t *testing.T) {
 		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},
 		{str: "@go_sdk//:src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt", want: Label{Repo: "go_sdk", Name: "src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt"}},
 		{str: "//:a][b", want: Label{Name: "a][b"}},
+		{str: "//:a b", want: Label{Name: "a b"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

label

**What does this PR do? Why is it needed?**

Don't exclude spaces from the label name regex

In parsing the output of `bazel query`, we found that some files with
spaces in their names are included in the output.

It seems reasonable that all labels that come out of a `bazel query`
should be parsable by this `Label` type; let's just use the raw regex
from the Bazel documentation.