### PR TITLE
fix-update: defer construction of loads, kinds slices until after CheckFlags

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -241,6 +241,12 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		&updateConfigurer{},
 		&walk.Configurer{},
 		&resolve.Configurer{})
+
+	c, err := newFixUpdateConfiguration(wd, cmd, args, cexts)
+	if err != nil {
+		return err
+	}
+
 	mrslv := newMetaResolver()
 	kinds := make(map[string]rule.KindInfo)
 	loads := genericLoads
@@ -255,11 +261,6 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		exts = append(exts, lang)
 	}
 	ruleIndex := resolve.NewRuleIndex(mrslv.Resolver, exts...)
-
-	c, err := newFixUpdateConfiguration(wd, cmd, args, cexts)
-	if err != nil {
-		return err
-	}
 
 	if err := fixRepoFiles(c, loads); err != nil {
 		return err

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -235,12 +235,15 @@ var genericLoads = []rule.LoadInfo{
 }
 
 func runFixUpdate(wd string, cmd command, args []string) (err error) {
-	cexts := make([]config.Configurer, 0, len(languages)+3)
+	cexts := make([]config.Configurer, 0, len(languages)+4)
 	cexts = append(cexts,
 		&config.CommonConfigurer{},
 		&updateConfigurer{},
 		&walk.Configurer{},
 		&resolve.Configurer{})
+	for _, lang := range languages {
+		cexts = append(cexts, lang)
+	}
 
 	c, err := newFixUpdateConfiguration(wd, cmd, args, cexts)
 	if err != nil {
@@ -250,15 +253,14 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 	mrslv := newMetaResolver()
 	kinds := make(map[string]rule.KindInfo)
 	loads := genericLoads
-	exts := make([]interface{}, 0, len(languages))
-	for _, lang := range languages {
-		cexts = append(cexts, lang)
+	exts := make([]interface{}, len(languages))
+	for i, lang := range languages {
 		for kind, info := range lang.Kinds() {
 			mrslv.AddBuiltin(kind, lang)
 			kinds[kind] = info
 		}
 		loads = append(loads, lang.Loads()...)
-		exts = append(exts, lang)
+		exts[i] = lang
 	}
 	ruleIndex := resolve.NewRuleIndex(mrslv.Resolver, exts...)
 


### PR DESCRIPTION
> Feature
> all

**What does this PR do? Why is it needed?**

The `.RegisterFlags()` / `.CheckFlags()` API exists to allow extensions to offer custom behavior via flags.  Currently, there is no way that these flags may influence the return value(s) of the `.Loads()` and/or `.Kinds()` due to the fact that `.CheckFlags` is called after `.Loads()` and `.Kinds()`.  However, this is an arbitrary limitation based on the original code that decided to initialize the metaresolver, loads slice, and kinds slice early in `runFixUpdate`.  Fortunately, this is otherwise independent of initialization of the update configuration.

This PR simply moves `newFixUpdateConfiguration` before `.Loads` and `Kinds()` is called.

**Which issues(s) does this PR fix?**

Fixes #1275
