### PR TITLE
Allow GO env vars to be specified via update-repos

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -194,7 +194,7 @@ def _go_repository_impl(ctx):
         fail("one of urls, commit, tag, or importpath must be specified")
 
     env = read_cache_env(ctx, go_env_cache)
-    env_keys = [
+    go_env_keys = [
         # Respect user proxy and sumdb settings for privacy.
         # TODO(jayconrod): gazelle in go_repository mode should probably
         # not go out to the network at all. This means *the build*
@@ -205,7 +205,8 @@ def _go_repository_impl(ctx):
         "GOPRIVATE",
         "GOSUMDB",
         "GONOSUMDB",
-
+    ]
+    env_keys = go_env_keys + [
         # PATH is needed to locate git and other vcs tools.
         "PATH",
 
@@ -229,6 +230,7 @@ def _go_repository_impl(ctx):
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 
     if fetch_repo_args:
+        env.update({ k: ctx.attr.go_env[k] for k in go_env_keys if k in ctx.attr.go_env })
         # Disable sumdb in fetch_repo. In module mode, the sum is a mandatory
         # attribute of go_repository, so we don't need to look it up.
         fetch_repo_env = dict(env)
@@ -415,6 +417,32 @@ go_repository = repository_rule(
             NOTE: There is no `go_repository` equivalent to file path `replace`
             directives. Use `local_repository` instead.""",
         ),
+        "go_env": attr.string_dict(
+            doc = """A dictionary of GO environment variables to set when running `go mod download`.
+            Values will also be read from your shell's environment.
+
+            Valid keys are:
+                GOPROXY
+                GONOPROXY
+                GOPRIVATE
+                GOSUMDB
+                GONOSUMDB
+            """,
+        ),
+        "go_env": attr.string_dict(
+            doc = """A dictionary of GO environment variables to set when running `go mod download`.
+            Values will also be read from your shell's environment.
+
+            Valid keys are:
+                GOPROXY
+                GONOPROXY
+                GOPRIVATE
+                GOSUMDB
+                GONOSUMDB
+            """,
+        ),
+
+
 
         # Attributes for a repository that needs automatic build file generation
         "build_external": attr.string(

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -125,6 +125,19 @@ type goConfig struct {
 	// buildTagsAttr are attributes for go_repository rules, set on the command
 	// line.
 	buildDirectivesAttr, buildExternalAttr, buildExtraArgsAttr, buildFileGenerationAttr, buildFileNamesAttr, buildFileProtoModeAttr, buildTagsAttr string
+
+	// goEnv attributes for go_repository rules, set on the command line.
+	goEnv
+}
+
+// goEnv attributes for go_repository rules, set on the command line.
+type goEnv struct {
+	// GoProxy, GoNoProxy, GoPrivate, GoSumDb, and GoNoSumDb
+	// used to specify GO env vars for the go_repository rule.
+	GoProxy, GoNoProxy, GoPrivate, GoSumDb, GoNoSumDb goEnvKey
+}
+type goEnvKey struct {
+	key, value string
 }
 
 var (
@@ -137,6 +150,13 @@ func newGoConfig() *goConfig {
 		goProtoCompilers: defaultGoProtoCompilers,
 		goGrpcCompilers:  defaultGoGrpcCompilers,
 		goGenerateProto:  true,
+		goEnv: goEnv{
+			GoProxy:   goEnvKey{key: "GOPROXY"},
+			GoNoProxy: goEnvKey{key: "GONOPROXY"},
+			GoPrivate: goEnvKey{key: "GOPRIVATE"},
+			GoSumDb:   goEnvKey{key: "GOSUMDB"},
+			GoNoSumDb: goEnvKey{key: "GONOSUMDB"},
+		},
 	}
 	gc.preprocessTags()
 	return gc
@@ -420,6 +440,26 @@ func (*goLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 			"build_tags",
 			"",
 			"Sets the build_tags attribute for the generated go_repository rule(s).")
+		fs.StringVar(&gc.goEnv.GoProxy.value,
+			"env_goproxy",
+			"",
+			"Sets the go_env.GOPROXY attribute for the generated go_repository rule(s).")
+		fs.StringVar(&gc.goEnv.GoNoProxy.value,
+			"env_gonoproxy",
+			"",
+			"Sets the go_env.GONOPROXY attribute for the generated go_repository rule(s).")
+		fs.StringVar(&gc.goEnv.GoPrivate.value,
+			"env_goprivate",
+			"",
+			"Sets the go_env.GOPRIVATE attribute for the generated go_repository rule(s).")
+		fs.StringVar(&gc.goEnv.GoSumDb.value,
+			"env_gosumdb",
+			"",
+			"Sets the go_env.GOSUMDB attribute for the generated go_repository rule(s).")
+		fs.StringVar(&gc.goEnv.GoNoSumDb.value,
+			"env_gonosumdb",
+			"",
+			"Sets the go_env.GONOSUMDB attribute for the generated go_repository rule(s).")
 	}
 	c.Exts[goName] = gc
 }

--- a/language/go/update.go
+++ b/language/go/update.go
@@ -17,6 +17,7 @@ package golang
 
 import (
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -113,6 +114,23 @@ func setBuildAttrs(gc *goConfig, r *rule.Rule) {
 	if gc.buildTagsAttr != "" {
 		buildTags := strings.Split(gc.buildTagsAttr, ",")
 		r.SetAttr("build_tags", buildTags)
+	}
+	env := make(map[string]string)
+
+	// Iterate of the goEnv struct using the `key` and `value` field with reflect
+	// tbh, this is a very silly quirk of go and I wish I could just iterate over a struct
+	t := reflect.TypeOf(gc.goEnv)
+	v := reflect.ValueOf(gc.goEnv)
+	num := t.NumField()
+	for i := 0; i < num; i++ {
+		ek := v.Field(i).Interface().(goEnvKey)
+		if ek.value != "" {
+			env[ek.key] = ek.value
+		}
+	}
+
+	if len(env) > 0 {
+		r.SetAttr("go_env", env)
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> * go_repository
> * update-repos

**What does this PR do? Why is it needed?**
Short of being able to specify the `GOPROXY` and other vars via the workspace (which would be ideal), I needed the ability to specify an internal proxy as we're not allowed to hit public Go proxies at work.

This PR adds the `go_env` attr on `go_repository` and correctly feeds it into `fetch_repo`. Additionally it allows setting these env vars when calling `update-repos`.

**Which issues(s) does this PR fix?**

Related to #579

**Other notes for review**
I'm mostly leaving this for others to use until a proper solution to configuring via WORKSPACE is put forth. Internally we're using this via a bazel patch.

Also I'm not a day-to-day Go programmer so very open to feedback on the implementation.