### PR TITLE
Stop inferring import path for empty packages

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -404,9 +404,8 @@ func emptyPackage(c *config.Config, dir, rel string, f *rule.File) *goPackage {
 		dir:  dir,
 		rel:  rel,
 	}
-	if err := pkg.inferImportPath(c); err != nil {
-		log.Printf("could not infer import path: %v", err)
-	}
+	// It's fine if it fails to infer import path
+	_ = pkg.inferImportPath(c)
 
 	return pkg
 }

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -151,7 +151,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 					protoName = name
 					break
 				}
-			} else if len(protoPackages) > 1 {
+			} else {
 				pkg = emptyPackage(c, args.Dir, args.Rel, args.File)
 			}
 		} else {
@@ -403,9 +403,6 @@ func emptyPackage(c *config.Config, dir, rel string, f *rule.File) *goPackage {
 		name: pkgName,
 		dir:  dir,
 		rel:  rel,
-	}
-	if err := pkg.inferImportPath(c); err != nil {
-		log.Printf("could not infer import path: %v", err)
 	}
 
 	return pkg

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -151,7 +151,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 					protoName = name
 					break
 				}
-			} else {
+			} else if len(protoPackages) > 1 {
 				pkg = emptyPackage(c, args.Dir, args.Rel, args.File)
 			}
 		} else {
@@ -404,8 +404,9 @@ func emptyPackage(c *config.Config, dir, rel string, f *rule.File) *goPackage {
 		dir:  dir,
 		rel:  rel,
 	}
-	// It's fine if it fails to infer import path
-	_ = pkg.inferImportPath(c)
+	if err := pkg.inferImportPath(c); err != nil {
+		log.Printf("could not infer import path: %v", err)
+	}
 
 	return pkg
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**
After #1197, Gazelle prints out the following warning every time it visits a directory without any `gazelle:prefix`, even the directory has no Go files:

```
gazelle: could not infer import path: /foo/bar: go prefix is not set, so importpath can't be determined for rules. Set a prefix with a '# gazelle:prefix' comment or with -go_prefix on the command line
```

The root cause is Gazelle tries to generate package and infer import path even when there is no Go or proto package. The error to infer import path was ignored before #1197. However, we should not infer import path for empty package because it will be inferred later when there is Go files: https://github.com/bazelbuild/bazel-gazelle/blob/32dab97bac88b1a35653d33a034b38e55d757983/language/go/generate.go#L165
