### PR TITLE
Expose rule.Rule as Expr

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -749,6 +749,10 @@ func (r *Rule) ShouldKeep() bool {
 	return ShouldKeep(r.expr)
 }
 
+func (r *Rule) Expr() bzl.Expr {
+	return r.expr
+}
+
 // Kind returns the kind of rule this is (for example, "go_library").
 func (r *Rule) Kind() string {
 	return r.kind


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

`rule`

**What does this PR do? Why is it needed?**

This allows for richer information gathering about existing rules in
BUILD files. In particular, it allows for calling `bzl.Walk` on an
entire `Rule`, whereas currently only individual args and attrs values
are exposed.

An example of where this is insufficient is that right now there's no
way to read the comment in this rule:

```starlark
filegroup(
    name = "fg",
    # This comment is important
    srcs = ["foo"],
)
```

because the existing API only surfaces the attr value as an Expr
(`["foo"]`), and not the `AssignExpr` (`srcs = ["foo"]`), to which this
comment  is actually attached.