### PR TITLE
Unwrap `go list -m -json` errors correctly

### DIFF
--- a/language/go/update_import_test.go
+++ b/language/go/update_import_test.go
@@ -313,7 +313,7 @@ definitely.doesnotexist/ever v0.1.0/go.mod h1:HI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqw
 				return []byte(`{
 "Path": "definitely.doesnotexist/ever",
 "Version": "0.1.0",
-"Error": "Did not exist"
+"Error": {"Err": "Did not exist"}
 }`), fmt.Errorf("failed to download")
 			},
 		}, {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Previously, such errors would lead to the following error message:

```
gazelle: json: cannot unmarshal object into Go struct field moduleFromList.Error of type string
```

This is fixed by changing the definition of the `Error` field to be an
object with an Err field of type string, as described at:
https://go.dev/ref/mod#go-list-m

**Other notes for review**

Follow-up to https://github.com/bazelbuild/bazel-gazelle/commit/56d35f8db086bb65ef876f96f7baa7b71516daf8

CC @illicitonion 
