### PR TITLE
language: add BaseLang

### DIFF
--- a/internal/go_repository_tools_srcs.bzl
+++ b/internal/go_repository_tools_srcs.bzl
@@ -45,6 +45,7 @@ GO_REPOSITORY_TOOLS_SRCS = [
 	Label("//label:BUILD.bazel"),
 	Label("//label:label.go"),
 	Label("//language:BUILD.bazel"),
+	Label("//language:base.go"),
 	Label("//language/go:BUILD.bazel"),
 	Label("//language/go:config.go"),
 	Label("//language/go:constants.go"),

--- a/internal/language/test_filegroup/BUILD.bazel
+++ b/internal/language/test_filegroup/BUILD.bazel
@@ -6,11 +6,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/language/test_filegroup",
     visibility = ["//visibility:public"],
     deps = [
-        "//config",
-        "//label",
         "//language",
-        "//repo",
-        "//resolve",
         "//rule",
     ],
 )

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -24,20 +24,17 @@ limitations under the License.
 package test_filegroup
 
 import (
-	"flag"
 	"path"
 
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/repo"
-	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 const testFilegroupName = "test_filegroup"
 
-type testFilegroupLang struct{}
+type testFilegroupLang struct {
+	language.BaseLang
+}
 
 func NewLanguage() language.Language {
 	return &testFilegroupLang{}
@@ -45,29 +42,8 @@ func NewLanguage() language.Language {
 
 func (*testFilegroupLang) Name() string { return testFilegroupName }
 
-func (*testFilegroupLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
-
-func (*testFilegroupLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
-
-func (*testFilegroupLang) KnownDirectives() []string { return nil }
-
-func (*testFilegroupLang) Configure(c *config.Config, rel string, f *rule.File) {}
-
 func (*testFilegroupLang) Kinds() map[string]rule.KindInfo {
 	return kinds
-}
-
-func (*testFilegroupLang) Loads() []rule.LoadInfo { return nil }
-
-func (*testFilegroupLang) Fix(c *config.Config, f *rule.File) {}
-
-func (*testFilegroupLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	return nil
-}
-
-func (*testFilegroupLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
-
-func (*testFilegroupLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
 }
 
 var kinds = map[string]rule.KindInfo{

--- a/language/BUILD.bazel
+++ b/language/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "language",
     srcs = [
+        "base.go",
         "lang.go",
         "update.go",
     ],
@@ -10,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//config",
+        "//label",
         "//repo",
         "//resolve",
         "//rule",
@@ -21,6 +23,7 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
+        "base.go",
         "lang.go",
         "update.go",
         "//language/go:all_files",

--- a/language/base.go
+++ b/language/base.go
@@ -1,0 +1,70 @@
+package language
+
+import (
+	"flag"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// BaseLang implements the minimum of language.Language interface.
+// This is not meant to be used directly by Gazelle, but to be used by
+// a downstream struct through composition. End users could use this to
+// write an extensions iteratively without having to implement every
+// functions in the interface right away.
+//
+// Example usage:
+//
+//	type MyLang struct {
+//		language.BaseLang
+//	}
+//
+//	func NewLanguage() language.Language {
+//		return &MyLang{}
+//	}
+//
+type BaseLang struct{}
+
+func (b *BaseLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
+
+func (b *BaseLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
+	return nil
+}
+
+func (b *BaseLang) KnownDirectives() []string {
+	return nil
+}
+
+func (b *BaseLang) Configure(c *config.Config, rel string, f *rule.File) {}
+
+func (b *BaseLang) Name() string {
+	return "BaseLang"
+}
+
+func (b *BaseLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	return nil
+}
+
+func (b *BaseLang) Embeds(r *rule.Rule, from label.Label) []label.Label {
+	return nil
+}
+
+func (b *BaseLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+}
+
+func (b *BaseLang) Kinds() map[string]rule.KindInfo {
+	return nil
+}
+
+func (b *BaseLang) Loads() []rule.LoadInfo {
+	return nil
+}
+
+func (b *BaseLang) GenerateRules(args GenerateArgs) GenerateResult {
+	return GenerateResult{}
+}
+
+func (b *BaseLang) Fix(c *config.Config, f *rule.File) {}


### PR DESCRIPTION
In order to help folks extend Gazelle quicker and easier, provide a base
implementation of the language.Language interface where everything is
no-ops.

End users then can simply compose their downstream struct with this
to have a valid implementation to iterate upon.