### PR TITLE
bug: Allow user-specified tags on gazelle rule

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -96,7 +96,7 @@ _gazelle_runner = rule(
         "gazelle": attr.label(
             default = "//cmd/gazelle",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "command": attr.string(
             values = [
@@ -135,14 +135,18 @@ def gazelle(name, **kwargs):
             fail("{}: both args and extra_args were provided".format(name))
         kwargs["extra_args"] = kwargs["args"]
         kwargs.pop("args")
+
+    tags_set = {t: "" for t in kwargs.pop("tags", [])}
+    tags_set["manual"] = ""
+    tags = [k for k in tags_set.keys()]
     runner_name = name + "-runner"
     _gazelle_runner(
         name = runner_name,
-        tags = ["manual"],
+        tags = tags,
         **kwargs
     )
     native.sh_binary(
         name = name,
         srcs = [runner_name],
-        tags = ["manual"],
+        tags = tags,
     )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`gazelle` rule

**What does this PR do? Why is it needed?**

This PR allows user-specified tags on `gazelle` rule instances.

**Which issues(s) does this PR fix?**

Currently if a user specifies their own tags on a `gazelle` rule
```starlark
gazelle(
    name = "gazelle.go.update",
    command = "fix",
    prefix = "<REDACTED>",
    tags = ["ci"],
)
```

this results in an error:
```text
 -> bazel run //:gazelle
ERROR: Traceback (most recent call last):
	File "/Users/dvamstel/<REDACTED>/BUILD.bazel", line 86, column 8, in <toplevel>
		gazelle(
	File "/private/var/tmp/_bazel_dvamstel/1ae6969914f9a102dcd06aac0525d313/external/bazel_gazelle/def.bzl", line 139, column 20, in gazelle
		_gazelle_runner(
Error in _gazelle_runner: rule(...) got multiple values for parameter 'tags'
ERROR: error loading package '': Package '' contains errors
INFO: Elapsed time: 7.348s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (1 packages loaded)
FAILED: Build did NOT complete successfully (1 packages loaded)
```

With the changes in this PR the errors no longer appear and the user-tags are appropriately detected.

```text
 -> bazel run //:gazelle.go.update
INFO: Analyzed target //:gazelle.go.update (136 packages loaded, 10093 targets configured).
INFO: Found 1 target...
Target //:gazelle.go.update up-to-date:
  bazel-bin/gazelle.go.update-runner.bash
  bazel-bin/gazelle.go.update
INFO: Elapsed time: 55.315s, Critical Path: 27.29s
INFO: 35 processes: 4 internal, 31 darwin-sandbox.
INFO: Build completed successfully, 35 total actions
INFO: Build completed successfully, 35 total actions

 -> bazel query 'attr("tags", "[\[,]manual[\],]", //...)'
//:gazelle.go.update
//:gazelle.go.update-runner
Loading: 1 packages loaded

 -> bazel query 'attr("tags", "[\[,]ci[\],]", //...)'
//:gazelle.go.deps.update
//:gazelle.go.deps.update-runner
Loading: 0 packages loaded
```

**Other notes for review**

The move from `cfg = "host"` to `cfg = "exec"` is a drive-by change suggested by Buildifier. To the best of my knowledge the move to use `exec` dates back to Bazel 3.x (the documentation moves from `host` to `exec` [on 3.6](https://docs.bazel.build/versions/3.6.0/skylark/rules.html#configurations)). Given that `gazelle` depends on `rules_go >= 0.29.0` and that `rules_go@0.29.0` depends on `bazel >= 4.2.0` this change should not be an issue.

I can revert this if necessary, just let me know.