### PR TITLE
Look in call args for loadable symbols

### DIFF
--- a/merger/fix.go
+++ b/merger/fix.go
@@ -65,20 +65,30 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 			return
 		}
 
-		id, ok := ce.X.(*bzl.Ident)
+		functionIdent, ok := ce.X.(*bzl.Ident)
 		if !ok {
 			return
 		}
 
-		file, ok := knownSymbols[id.Name]
-		if !ok || otherLoadedKinds[id.Name] {
-			return
+		idents := []*bzl.Ident{functionIdent}
+
+		for _, arg := range ce.List {
+			if argIdent, ok := arg.(*bzl.Ident); ok {
+				idents = append(idents, argIdent)
+			}
 		}
 
-		if usedSymbols[file] == nil {
-			usedSymbols[file] = make(map[string]bool)
+		for _, id := range idents {
+			file, ok := knownSymbols[id.Name]
+			if !ok || otherLoadedKinds[id.Name] {
+				continue
+			}
+
+			if usedSymbols[file] == nil {
+				usedSymbols[file] = make(map[string]bool)
+			}
+			usedSymbols[file][id.Name] = true
 		}
-		usedSymbols[file][id.Name] = true
 	})
 
 	// Fix the load statements. The order is important, so we iterate over

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -41,6 +41,12 @@ func TestFixLoads(t *testing.T) {
 				"foo_test",
 			},
 		},
+		{
+			Name: "@bazel_tools//tools/build_defs/repo:utils.bzl",
+			Symbols: []string{
+				"maybe",
+			},
+		},
 	}
 
 	type testCase struct {
@@ -153,6 +159,21 @@ foo_library(name = "a_lib")
 foo_binary(name = "a")
 
 foo_library(name = "a_lib")
+`,
+		},
+		"missing wrapper and wrapped kind load symbol": {
+			input: `maybe(
+    foo_binary,
+    name = "a",
+)
+`,
+			want: `load("@foo", "foo_binary")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    foo_binary,
+    name = "a",
+)
 `,
 		},
 		"unused kind load symbol": {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`merger`

**What does this PR do? Why is it needed?**

Since https://github.com/bazelbuild/bazel-gazelle/pull/1310 we can add
arguments to rules - this PR allows symbols to be loaded for these
arguments.