### PR TITLE
bzlmod: Fix canonical label literal after Bazel change

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -16,7 +16,7 @@ def deps_from_go_mod(module_ctx, go_mod_label):
     # We go through a Label so that the module extension is restarted if go.sum
     # changes. We have to use a canonical label as we may not have visibility
     # into the module that provides the go.sum.
-    go_sum_label = Label("@{}//{}:{}".format(
+    go_sum_label = Label("@@{}//{}:{}".format(
         go_mod_label.workspace_name,
         go_mod_label.package,
         "go.sum",

--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -42,7 +42,14 @@ def _go_repository_config_impl(ctx):
             for f in result.stdout.splitlines():
                 f = f.lstrip()
                 if len(f) > 0:
-                    macro_label = Label("@" + ctx.attr.config.workspace_name + "//:" + f)
+                    macro_label_str = "@" + ctx.attr.config.workspace_name + "//:" + f
+                    if "~" in ctx.attr.config.workspace_name:
+                        # The workspace name is a Bzlmod canonical repository
+                        # name that we don't have visibility into directly.
+                        # Instead, use a canonical label literal (starting with
+                        # "@@") to bypass visibility checks.
+                        macro_label_str = "@" + macro_label_str
+                    macro_label = Label(macro_label_str)
                     ctx.path(macro_label)
 
     else:

--- a/tests/bcr/.bazelversion
+++ b/tests/bcr/.bazelversion
@@ -1,1 +1,1 @@
-4e439689db73a12b9c8a1f9f1a5f8023e09d40b0
+last_green


### PR DESCRIPTION
Necessary after https://github.com/bazelbuild/bazel/commit/7f9de9e6f8bd3ede758ec7f11ed76b63dab15384
