### PR TITLE
update-repos: don't add repositories declared with gazelle:repository…

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -3839,6 +3839,94 @@ gazelle_dependencies()
 	})
 }
 
+func TestUpdateReposSkipsDirectiveRepo(t *testing.T) {
+	files := []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+			Content: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "2697f6bc7c529ee5e6a2d9799870b9ec9eaeb3ee7d70ed50b87a2c2c97e13d9e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.8/rules_go-v0.23.8.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.23.8/rules_go-v0.23.8.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+# gazelle:repository go_repository name=org_golang_x_mod importpath=golang.org/x/mod
+`,
+		},
+	}
+
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	args := []string{"update-repos", "golang.org/x/mod@v0.3.0"}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "WORKSPACE",
+			Content: `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "2697f6bc7c529ee5e6a2d9799870b9ec9eaeb3ee7d70ed50b87a2c2c97e13d9e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.8/rules_go-v0.23.8.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.23.8/rules_go-v0.23.8.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+# gazelle:repository go_repository name=org_golang_x_mod importpath=golang.org/x/mod
+`,
+		},
+	})
+}
+
 func TestUpdateReposOldBoilerplateNewMacro(t *testing.T) {
 	files := []testtools.FileSpec{
 		{

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -74,7 +74,8 @@ type loader struct {
 	visited      map[macroKey]struct{}
 }
 
-func isFromDirective(repo *rule.Rule) bool {
+// IsFromDirective returns true if the repo rule was defined from a directive.
+func IsFromDirective(repo *rule.Rule) bool {
 	b, ok := repo.PrivateAttr(gazelleFromDirectiveKey).(bool)
 	return ok && b
 }
@@ -82,8 +83,8 @@ func isFromDirective(repo *rule.Rule) bool {
 // add adds a repository rule to a file.
 // In the case of duplicate rules, select the rule
 // with the following prioritization:
-//  - rules that were provided as directives have precedence
-//  - rules that were provided last
+//   - rules that were provided as directives have precedence
+//   - rules that were provided last
 func (l *loader) add(file *rule.File, repo *rule.Rule) {
 	name := repo.Name()
 	if name == "" {
@@ -91,7 +92,7 @@ func (l *loader) add(file *rule.File, repo *rule.Rule) {
 	}
 
 	if i, ok := l.repoIndexMap[repo.Name()]; ok {
-		if isFromDirective(l.repos[i]) && !isFromDirective(repo) {
+		if IsFromDirective(l.repos[i]) && !IsFromDirective(repo) {
 			// We always prefer directives over non-directives
 			return
 		}
@@ -197,8 +198,9 @@ func (l *loader) loadRepositoriesFromMacro(macro *RepoMacro) error {
 // e.g. for if called on
 // load("package_name:package_dir/file.bzl", alias_name="original_def_name")
 // with defAlias = "alias_name", it will return:
-//     -> "/Path/to/package_name/package_dir/file.bzl"
-//     -> "original_def_name"
+//
+//	-> "/Path/to/package_name/package_dir/file.bzl"
+//	-> "original_def_name"
 func loadToMacroDef(l *rule.Load, repoRoot, defAlias string) *RepoMacro {
 	rel := strings.Replace(filepath.Clean(l.Name()), ":", string(filepath.Separator), 1)
 	// A loaded macro may refer to the macro by a different name (alias) in the load,


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What package or component does this PR mostly affect?**

repo
cmd/gazelle/update-repos

**What does this PR do? Why is it needed?**

Skips the generation of `go_repository` rules which are defined in a directive.

**Which issues(s) does this PR fix?**

Fixes #835

**Other notes for review**
