### PR TITLE
bzlmod: Depend on rules_proto

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ print("WARNING: The bazel_gazelle Bazel module is still highly experimental and 
 
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 


### PR DESCRIPTION
This is required to allow repositories generated for Go modules to see proto_library.

Work towards https://github.com/bazelbuild/rules_go/issues/3265
