### PR TITLE
language/go should consider default_visibility set by OtherGen (#783)

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -181,7 +181,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	g := &generator{
 		c:                   c,
 		rel:                 args.Rel,
-		shouldSetVisibility: args.File == nil || !args.File.HasDefaultVisibility(),
+		shouldSetVisibility: shouldSetVisibility(args),
 	}
 	var res language.GenerateResult
 	var rules []*rule.Rule
@@ -775,4 +775,19 @@ func escapeOption(opt string) string {
 		"$(", "$(",
 		"$", "$$",
 	).Replace(opt)
+}
+
+func shouldSetVisibility(args language.GenerateArgs) bool {
+	if args.File != nil && args.File.HasDefaultVisibility() {
+		return false
+	}
+
+	for _, r := range args.OtherGen {
+		// This is kind of the same test as *File.HasDefaultVisibility(),
+		// but for previously defined rules.
+		if r.Kind() == "package" && r.Attr("default_visibility") != nil {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Previously, the implementation of the language/go extension's GenerateRules method only considered args.File, and therefore missed scenarios where another extension (as recommended in the Issue) creates a package(default_visibility = ...)

**Which issues(s) does this PR fix?**

Fixes #783
