### PR TITLE
bzlmod: Add support for custom `go_proto_library` compilers

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,13 @@
 module(
     name = "gazelle",
     version = "0.27.0",
+    repo_name = "bazel_gazelle",
 )
 
 print("WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
 
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
+bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -87,6 +87,7 @@ def _go_deps_impl(module_ctx):
                     raw_version = raw_version,
                     sum = module_tag.sum,
                     build_naming_convention = module_tag.build_naming_convention,
+                    build_file_proto_mode = module_tag.build_file_proto_mode,
                 )
 
     for path, root_version in root_versions.items():
@@ -106,6 +107,7 @@ def _go_deps_impl(module_ctx):
             sum = module.sum,
             version = "v" + module.raw_version,
             build_naming_convention = module.build_naming_convention,
+            build_file_proto_mode = module.build_file_proto_mode,
         )
         for path, module in module_resolutions.items()
     ]
@@ -118,6 +120,7 @@ def _go_deps_impl(module_ctx):
         module.repo_name: [
             "importpath=" + path,
             "build_naming_convention=" + module.build_naming_convention,
+            "build_file_proto_mode=" + module_tag.build_file_proto_mode,
         ]
         for path, module in module_resolutions.items()
     }
@@ -137,7 +140,7 @@ _config_tag = tag_class(
 _from_file_tag = tag_class(
     attrs = {
         "go_mod": attr.label(mandatory = True),
-    }
+    },
 )
 
 _module_tag = tag_class(
@@ -145,7 +148,24 @@ _module_tag = tag_class(
         "path": attr.string(mandatory = True),
         "version": attr.string(mandatory = True),
         "sum": attr.string(),
-        "build_naming_convention": attr.string(default = "import_alias"),
+        "build_naming_convention": attr.string(
+            default = "import_alias",
+            values = [
+                "go_default_library",
+                "import",
+                "import_alias",
+            ],
+        ),
+        "build_file_proto_mode": attr.string(
+            default = "default",
+            values = [
+                "default",
+                "disable",
+                "disable_global",
+                "legacy",
+                "package",
+            ],
+        ),
     },
 )
 

--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -36,6 +36,7 @@ def deps_from_go_mod(module_ctx, go_mod_label):
             sum = go_sum[entry],
             direct = require.direct,
             build_naming_convention = "import_alias",
+            build_file_proto_mode = "default",
         ))
 
     return deps


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature


**What package or component does this PR mostly affect?**

bzlmod

**What does this PR do? Why is it needed?**

These changes are required to allow users of `rules_go` to use all the custom `go_proto_library` compilers defined in its `//proto` package **if they provide their own definitions of them**:
* Make `gazelle` and `protobuf` visible to `go_repository` targets under
  their legacy `WORKSPACE` names.
* Expose `build_file_proto_mode` on `go_deps.module`.

