### PR TITLE
Add size argument to `gazelle_generation_test`

### DIFF
--- a/extend.md
+++ b/extend.md
@@ -180,5 +180,6 @@ To update the expected files, run `UPDATE_SNAPSHOTS=true bazel run //path/to:the
 | <a id="gazelle_generation_test-build_in_suffix"></a>build_in_suffix |  The suffix for the input BUILD.bazel files. Defaults to .in. By default, will use files named BUILD.in as the BUILD files before running gazelle.   |  <code>".in"</code> |
 | <a id="gazelle_generation_test-build_out_suffix"></a>build_out_suffix |  The suffix for the expected BUILD.bazel files after running gazelle. Defaults to .out. By default, will use files named check the results of the gazelle run against files named BUILD.out.   |  <code>".out"</code> |
 | <a id="gazelle_generation_test-gazelle_timeout_seconds"></a>gazelle_timeout_seconds |  <p align="center"> - </p>   |  <code>2</code> |
+| <a id="gazelle_generation_test-size"></a>size | Specifies a test target's "heaviness": how much time/resources it needs to run.<p align="center"> - </p>   |  <code>medium</code> |
 
 

--- a/extend.md
+++ b/extend.md
@@ -145,7 +145,7 @@ proto extension stores metadata in hidden attributes of generated
 
 <pre>
 gazelle_generation_test(<a href="#gazelle_generation_test-name">name</a>, <a href="#gazelle_generation_test-gazelle_binary">gazelle_binary</a>, <a href="#gazelle_generation_test-test_data">test_data</a>, <a href="#gazelle_generation_test-build_in_suffix">build_in_suffix</a>, <a href="#gazelle_generation_test-build_out_suffix">build_out_suffix</a>,
-                        <a href="#gazelle_generation_test-gazelle_timeout_seconds">gazelle_timeout_seconds</a>)
+                        <a href="#gazelle_generation_test-gazelle_timeout_seconds">gazelle_timeout_seconds</a>, <a href="#gazelle_generation_test-size">size</a>)
 </pre>
 
     gazelle_generation_test is a macro for testing gazelle against workspaces.
@@ -180,6 +180,6 @@ To update the expected files, run `UPDATE_SNAPSHOTS=true bazel run //path/to:the
 | <a id="gazelle_generation_test-build_in_suffix"></a>build_in_suffix |  The suffix for the input BUILD.bazel files. Defaults to .in. By default, will use files named BUILD.in as the BUILD files before running gazelle.   |  <code>".in"</code> |
 | <a id="gazelle_generation_test-build_out_suffix"></a>build_out_suffix |  The suffix for the expected BUILD.bazel files after running gazelle. Defaults to .out. By default, will use files named check the results of the gazelle run against files named BUILD.out.   |  <code>".out"</code> |
 | <a id="gazelle_generation_test-gazelle_timeout_seconds"></a>gazelle_timeout_seconds |  <p align="center"> - </p>   |  <code>2</code> |
-| <a id="gazelle_generation_test-size"></a>size | Specifies a test target's "heaviness": how much time/resources it needs to run.<p align="center"> - </p>   |  <code>medium</code> |
+| <a id="gazelle_generation_test-size"></a>size |  Specifies a test target's "heaviness": how much time/resources it needs to run.   |  <code>None</code> |
 
 

--- a/internal/generationtest/generationtest.bzl
+++ b/internal/generationtest/generationtest.bzl
@@ -1,10 +1,10 @@
 """
-Test for generating rules from gazelle. 
+Test for generating rules from gazelle.
 """
 
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
-def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = ".in", build_out_suffix = ".out", gazelle_timeout_seconds = 2):
+def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = ".in", build_out_suffix = ".out", gazelle_timeout_seconds = 2, size=None):
     """
     gazelle_generation_test is a macro for testing gazelle against workspaces.
 
@@ -36,6 +36,7 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
         build_out_suffix: The suffix for the expected BUILD.bazel files after running gazelle. Defaults to .out.
             By default, will use files named check the results of the gazelle run against files named BUILD.out.
         timeout_seconds: Number of seconds to allow the gazelle process to run before killing.
+        size: Specifies a test target's "heaviness": how much time/resources it needs to run.
     """
     go_test(
         name = name,
@@ -50,6 +51,7 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
             "-build_out_suffix=%s" % build_out_suffix,
             "-timeout=%ds" % gazelle_timeout_seconds,
         ],
+        size = size,
         data = test_data + [
             gazelle_binary,
         ],


### PR DESCRIPTION


**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

`gazelle_generation_test`

**What does this PR do? Why is it needed?**
This adds the `size` argument to the test. I currently have a very small test case for my custom plugins and want to set the size to small. I could imagine that people have a larger test they want to scale up so they can schedule appropriately. 

