### PR TITLE
Make `gazelle_generation_test` respect out suffix when generating golden files

### DIFF
--- a/testtools/files.go
+++ b/testtools/files.go
@@ -299,7 +299,7 @@ func TestGazelleGenerationOnPath(t *testing.T, args *TestGazelleGenerationArgs) 
 							}
 
 							if info.Name() == "BUILD.bazel" {
-								destFile := strings.TrimSuffix(path.Join(buildWorkspaceDirectory, path.Dir(args.TestDataPathRelative)+relativePath), ".bazel") + ".out"
+								destFile := strings.TrimSuffix(path.Join(buildWorkspaceDirectory, path.Dir(args.TestDataPathRelative)+relativePath), ".bazel") + args.BuildOutSuffix
 
 								err := copyFile(walkedPath, destFile)
 								if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

Gazelle generation tests.

**What does this PR do? Why is it needed?**

The golden file generation didn't respect the user-specified suffix for outfiles. It does now.

**Which issues(s) does this PR fix?**

According to the guidelines, small bug fixes don't need issues.
