### PR TITLE
bzlmod: Update deps and Bazel pin

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,9 +13,9 @@ tasks:
   ubuntu1804_bcr_tests:
     name: BCR test module
     platform: ubuntu1804
-    # Includes https://github.com/bazelbuild/bazel/commit/4e439689db73a12b9c8a1f9f1a5f8023e09d40b0,
+    # Includes https://github.com/bazelbuild/bazel/commit/3f92232c17bf4aad51880c811c291ba4b5b42721,
     # which will eventually be released in Bazel 5.3.0.
-    bazel_version: 4e439689db73a12b9c8a1f9f1a5f8023e09d40b0
+    bazel_version: 3f92232c17bf4aad51880c811c291ba4b5b42721
     working_directory: tests/bcr
     build_targets:
       - "//..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,9 +6,9 @@ module(
 
 print("WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
 
-bazel_dep(name = "bazel_skylib", version = "1.2.0")
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.35.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/tests/bcr/.bazelversion
+++ b/tests/bcr/.bazelversion
@@ -1,1 +1,1 @@
-last_green
+3f92232c17bf4aad51880c811c291ba4b5b42721

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -8,7 +8,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_go", version = "0.33.0")
+bazel_dep(name = "rules_go", version = "0.35.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 


### PR DESCRIPTION
Also pin Bazel in `.bazelversion`, which appears to override the `bazel_version` specified in the CI script.
