### PR TITLE
Fix: Skip default_visibility extension logic if no BUILD.bazel file present

### DIFF
--- a/language/bazel/visibility/lang.go
+++ b/language/bazel/visibility/lang.go
@@ -39,6 +39,11 @@ func (*visibilityExtension) GenerateRules(args language.GenerateArgs) language.G
 		return res
 	}
 
+	if args.File == nil {
+		// No need to create a visibility if we're not in a visible directory.
+		return res
+	}
+
 	r := rule.NewRule("package", "")
 	r.SetAttr("default_visibility", cfg.visibilityTargets)
 

--- a/language/bazel/visibility/lang_test.go
+++ b/language/bazel/visibility/lang_test.go
@@ -43,7 +43,10 @@ func Test_NoDirective(t *testing.T) {
 
 	ext := visibility.NewLanguage()
 	ext.Configure(cfg, "rel", file)
-	res := ext.GenerateRules(language.GenerateArgs{Config: cfg})
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   rule.EmptyFile("path/file", "pkg"),
+	})
 
 	if len(res.Imports) != 0 {
 		t.Fatal("expected empty array")
@@ -63,7 +66,10 @@ func Test_NewDirective(t *testing.T) {
 
 	ext := visibility.NewLanguage()
 	ext.Configure(cfg, "rel", file)
-	res := ext.GenerateRules(language.GenerateArgs{Config: cfg})
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   rule.EmptyFile("path/file", "pkg"),
+	})
 
 	if len(res.Gen) != 1 {
 		t.Fatal("expected array of length 1")
@@ -93,7 +99,10 @@ package(default_visibility = "//not-src:__subpackages__")
 
 	ext := visibility.NewLanguage()
 	ext.Configure(cfg, "rel", file)
-	res := ext.GenerateRules(language.GenerateArgs{Config: cfg})
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   rule.EmptyFile("path/file", "pkg"),
+	})
 
 	if len(res.Gen) != 1 {
 		t.Fatal("expected array of length 1")
@@ -123,7 +132,10 @@ func Test_MultipleDirectives(t *testing.T) {
 
 	ext := visibility.NewLanguage()
 	ext.Configure(cfg, "rel", file)
-	res := ext.GenerateRules(language.GenerateArgs{Config: cfg})
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   rule.EmptyFile("path/file", "pkg"),
+	})
 
 	if len(res.Gen) != 1 {
 		t.Fatal("expected array of length 1")
@@ -155,7 +167,10 @@ func Test_MultipleDefaultsSingleDirective(t *testing.T) {
 
 	ext := visibility.NewLanguage()
 	ext.Configure(cfg, "rel", file)
-	res := ext.GenerateRules(language.GenerateArgs{Config: cfg})
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   rule.EmptyFile("path/file", "pkg"),
+	})
 
 	if len(res.Gen) != 1 {
 		t.Fatal("expected array of length 1")
@@ -171,5 +186,30 @@ func Test_MultipleDefaultsSingleDirective(t *testing.T) {
 	}
 	if testVis2 != res.Gen[0].AttrStrings("default_visibility")[1] {
 		t.Fatal("expected returned visibility to match '//src2:__subpackages__'")
+	}
+}
+
+func Test_NoRuleIfNoBuildFile(t *testing.T) {
+	testVis1 := "//src:__subpackages__"
+	cfg := config.New()
+	file, err := rule.LoadData("path", "pkg", []byte(fmt.Sprintf(`
+# gazelle:default_visibility %s
+`, testVis1)))
+	if err != nil {
+		t.Fatalf("expected not nil - %+v", err)
+	}
+
+	ext := visibility.NewLanguage()
+	ext.Configure(cfg, "rel", file)
+	res := ext.GenerateRules(language.GenerateArgs{
+		Config: cfg,
+		File:   nil,
+	})
+
+	if len(res.Gen) != 0 {
+		t.Fatal("expected array of length 0, no rules generated for missing BUILD.bazel file")
+	}
+	if len(res.Imports) != 0 {
+		t.Fatal("expected array of length 0")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/bazel

**What does this PR do? Why is it needed?**

Without this change, the `default_visibility` directive will cause a BUILD.bazel file to be authored at every directory down the tree, as opposed to only those that have existing BUILD.bazel. This the notion of default visibility is only tied to rules contained within the same BUILD.bazel, this is unnecessary.
