### PR TITLE
Add link to BenchSci's rules_nodejs_gazelle extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Gazelle can generate Bazel BUILD files for many languages:
 
 * JavaScript / TypeScript
 
-  BencSci's `rules_nodejs_gazelle`_ supports generating `ts_project`, `js_library`, `jest_test`,
+  BenchSci's `rules_nodejs_gazelle`_ supports generating `ts_project`, `js_library`, `jest_test`,
   and `web_asset` rules, and is able to support module bundlers like Webpack and Next.js
 
 * Protocol Buffers

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Gazelle build file generator
 .. _rules_python: https://github.com/bazelbuild/rules_python
 .. _rules_r: https://github.com/grailbio/rules_r
 .. _rules_haskell: https://github.com/tweag/rules_haskell
-.. _bazel_rules_nodejs_contrib: https://github.com/ecosia/bazel_rules_nodejs_contrib#build-file-generation
+.. _rules_nodejs_gazelle: https://github.com/benchsci/rules_nodejs_gazelle
 .. _bazel-skylib: https://github.com/bazelbuild/bazel-skylib
 .. _bazel_skylib/gazelle/bzl: https://github.com/bazelbuild/bazel-skylib/tree/master/gazelle/bzl
 .. _gazelle_cabal: https://github.com/tweag/gazelle_cabal
@@ -99,8 +99,8 @@ Gazelle can generate Bazel BUILD files for many languages:
 
 * JavaScript / TypeScript
 
-  Ecosia's `bazel_rules_nodejs_contrib`_ has an extension for generating
-  ``js_library``, ``jest_node_test``, ``js_import``, and ``ts_library`` rules.
+  BencSci's `rules_nodejs_gazelle`_ supports generating `ts_project`, `js_library`, `jest_test`,
+  and `web_asset` rules, and is able to support module bundlers like Webpack and Next.js
 
 * Protocol Buffers
 


### PR DESCRIPTION
Ecosia's repo is marked as archived, so I've removed the link to it. BenchSci's extension was originally a fork of Ecosia's extension.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Documentation

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Update link to nodejs suggestion from archived Ecosia repo to active BenchSci repo
