### PR TITLE
bzlmod: Add missing `strip_prefix` field to `source.template.json`

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,4 +1,5 @@
 {
   "integrity": "",
+  "strip_prefix": "",  
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }


### PR DESCRIPTION
This field is required even if its value is empty.