### PR TITLE
Make the new facts pacakge public

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -538,7 +538,7 @@ func (g *generator) generateTest(pkg *goPackage, library string) *rule.Rule {
 // maybePublishToolLib makes the given go_library rule public if needed for nogo.
 // Updating it here automatically makes it easier to upgrade org_golang_x_tools.
 func (g *generator) maybePublishToolLib(lib *rule.Rule, pkg *goPackage) {
-	if pkg.importPath == "golang.org/x/tools/go/analysis/internal/facts" {
+	if pkg.importPath == "golang.org/x/tools/go/analysis/internal/facts" || pkg.importPath == "golang.org/x/tools/internal/facts" {
 		// Imported by nogo main. We add a visibility exception.
 		lib.SetAttr("visibility", []string{"//visibility:public"})
 	}


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
golang.org/x/tools recently moved its facts package from golang.org/x/tools/go/analysis/internal/facts to golang.org/x/tools/internal/facts. We should make both of them public so Gazelle can handle new and old versions of golang.org/x/tools

