### PR TITLE
Replace `cfg = "host"` with `cfg = "exec"`

### DIFF
--- a/language/go/def.bzl
+++ b/language/go/def.bzl
@@ -19,7 +19,7 @@ std_package_list = rule(
         "out": attr.output(mandatory = True),
         "_gen_std_package_list": attr.label(
             default = "//language/go/gen_std_package_list",
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_go_context_data": attr.label(


### PR DESCRIPTION
Become compatible with
`--incompatible_disable_starlark_host_transitions`, which will be flipped in Bazel 7.

https://github.com/bazelbuild/bazel/issues/17032