### PR TITLE
Add `auto_use_repo` support for `go_deps`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,13 @@ module(
 
 print("WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
 
+bazel_dep(name = "auto_use_repo", version = "", dev_dependency = True)
+git_override(
+    module_name = "auto_use_repo",
+    commit = "a384d785afefcc3d656a23b6c0f3ab8a3885f05a",
+    remote = "https://github.com/fmeum/auto_use_repo",
+)
+
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.37.0", repo_name = "io_bazel_rules_go")
@@ -25,15 +32,17 @@ use_repo(
 )
 
 rules_go_non_module_deps = use_extension("@io_bazel_rules_go//go/private:extensions.bzl", "non_module_dependencies")
-use_repo(
-    rules_go_non_module_deps,
-    "go_googleapis",
-)
+use_repo(rules_go_non_module_deps, "go_googleapis")
 
 go_deps = use_extension("//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
+    # Used internally by the go_deps module extension.
+    "bazel_gazelle_go_repository_directives",
+    # Used by auto_use_repo.
+    "bazel_gazelle_auto_use_repo",
+    # Maintained by auto_use_repo.
     "com_github_bazelbuild_buildtools",
     "com_github_bmatcuk_doublestar_v4",
     "com_github_fsnotify_fsnotify",
@@ -43,6 +52,11 @@ use_repo(
     "org_golang_x_mod",
     "org_golang_x_sync",
     "org_golang_x_tools",
-    # Used internally by the go_deps module extension.
-    "bazel_gazelle_go_repository_directives",
+)
+
+auto_use_repo = use_extension("@auto_use_repo//:extensions.bzl", "auto_use_repo")
+auto_use_repo.register(
+    extension_bzl_file = "//:extensions.bzl",
+    extension_name = "go_deps",
+    repositories_json_file = "@bazel_gazelle_auto_use_repo//:repositories.json",
 )


### PR DESCRIPTION
Both maintainers and Gazelle end users can run `@auto_use_repo//:update` to keep their `use_repo(go_deps, ...)` call updated automatically.