### PR TITLE
Fix Gazelle with `--incompatible_disallow_empty_glob`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,3 +7,5 @@ build:ci --spawn_strategy=standalone
 build:ci --genrule_strategy=standalone
 test:ci --test_strategy=standalone
 test:ci --test_output=errors
+
+common --incompatible_disallow_empty_glob

--- a/language/proto/BUILD.bazel
+++ b/language/proto/BUILD.bazel
@@ -70,7 +70,11 @@ go_test(
         "generate_test.go",
         "resolve_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(
+        ["testdata/**"],
+        # Empty when distributed.
+        allow_empty = True,
+    ),
     embed = [":proto"],
     deps = [
         "//config",


### PR DESCRIPTION
Allows rules_go to merge https://github.com/bazelbuild/rules_go/pull/3415.