### PR TITLE
chore: remove experimental warning from bzlmod module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,6 @@ module(
     repo_name = "bazel_gazelle",
 )
 
-print("WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
-
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.37.0", repo_name = "io_bazel_rules_go")


### PR DESCRIPTION
In practice, now that Bazel 6.0.0 has shipped, Gazelle is working about as well as any other supported languages in the ecosystem. Also, if users find bugs with it, those are important and we'll fix them.
