### PR TITLE
Fix indentation error in README setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ should look like this:
         sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.27.0/bazel-gazelle-v0.28.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
         ],
     )
 

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ should look like this:
 
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-     http_archive(
+    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "56d8c5a5c91e1af73eca71a6fab2ced959b67c86d12ba37feedb0a2dfea441a6",
         urls = [


### PR DESCRIPTION
An extra space causes indentation errors when one copy/pastes from the README setup instructions.

Also noticed a typo in one of the URLs for the bazel_gazelle http_archive.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.

Documentation

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
