### PR TITLE
bzlmod: Add macro to convert import paths to Bazel labels

### DIFF
--- a/internal/bzlmod/BUILD.bazel
+++ b/internal/bzlmod/BUILD.bazel
@@ -6,6 +6,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "go_deps.bzl",
+        "go_helper.bzl",
         "go_mod.bzl",
         "non_module_deps.bzl",
         "semver.bzl",
@@ -43,5 +44,11 @@ bzl_library(
 bzl_library(
     name = "semver",
     srcs = ["semver.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "go_helper",
+    srcs = ["go_helper.bzl"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -18,7 +18,7 @@ def _repo_name(importpath):
 _GO_DEPS_HELPER_DEFS_BZL = """load("@bazel_gazelle//internal/bzlmod:go_helper.bzl", "go_helper")
 
 def go(import_path):
-    return go_helper(import_path, _GO_DEPS)
+    return go_helper(import_path, _GO_DEPS, lambda x: Label(x))
 
 _GO_DEPS = {}
 """
@@ -58,19 +58,6 @@ _go_repository_directives = repository_rule(
 
 def _noop(s):
     pass
-
-def _to_canonical(repo_name):
-    """Converts the apparent name of a repository defined by the go_deps
-    extension to the canonical name of the repository, including the leading @.
-
-    WARNING: This is a wild hack and should not be committed as is.
-    """
-
-    # Only repos that are use_repo-ed by gazelle itself can be canonicalized in
-    # this way.
-    go_deps_canonical = Label("@bazel_gazelle_go_repository_directives//foo").workspace_name
-    base_canonical = go_deps_canonical[:go_deps_canonical.rfind("~") + 1]
-    return "@" + base_canonical + repo_name
 
 def _go_deps_impl(module_ctx):
     module_resolutions = {}
@@ -177,7 +164,7 @@ def _go_deps_impl(module_ctx):
     _go_deps_helper(
         name = "go_deps",
         go_deps = {
-            path: _to_canonical(module.repo_name)
+            path: module.repo_name
             for path, module in module_resolutions.items()
         },
     )

--- a/internal/bzlmod/go_helper.bzl
+++ b/internal/bzlmod/go_helper.bzl
@@ -1,0 +1,38 @@
+def _is_version_suffix(s):
+    if not s or s[0] != "v":
+        return False
+    return s[1:].isdigit()
+
+def _lib_name_from_import_path(import_path):
+    """Starlark implementation of libNameFromImportPath in package.go."""
+    i = import_path.rfind("/")
+    if i < 0:
+        # TODO: Should we replace '.' with '_' also in this case?
+        #  libNameFromImportPath doesn't do that, but that seems wrong.
+        return import_path
+    name = import_path[i + 1:]
+    if _is_version_suffix(name):
+        unversioned_import_path = import_path[:i]
+        i = unversioned_import_path.rfind("/")
+        if i >= 0:
+            name = unversioned_import_path[i + 1:]
+    return name.replace(".", "_")
+
+def go_helper(import_path, module_path_to_repo):
+    split_pos = len(import_path)
+    for i in range(import_path.count("/") + 1):
+        module_path = import_path[:split_pos]
+        module_repo = module_path_to_repo.get(module_path, None)
+        if module_repo:
+            package_path = import_path[split_pos:].removeprefix("/")
+            return "@{}//{}:{}".format(module_repo, package_path, _lib_name_from_import_path(import_path))
+        split_pos = module_path.rfind("/", 0, split_pos)
+
+    fail("""
+
+No Go module in go.mod provides package '{import_path}'.
+Add the missing dependency via:
+
+    go get {import_path}
+
+""".format(import_path = import_path))

--- a/internal/bzlmod/go_helper.bzl
+++ b/internal/bzlmod/go_helper.bzl
@@ -18,14 +18,14 @@ def _lib_name_from_import_path(import_path):
             name = unversioned_import_path[i + 1:]
     return name.replace(".", "_")
 
-def go_helper(import_path, module_path_to_repo):
+def go_helper(import_path, module_path_to_repo, canonicalize):
     split_pos = len(import_path)
     for i in range(import_path.count("/") + 1):
         module_path = import_path[:split_pos]
         module_repo = module_path_to_repo.get(module_path, None)
         if module_repo:
             package_path = import_path[split_pos:].removeprefix("/")
-            return "@{}//{}:{}".format(module_repo, package_path, _lib_name_from_import_path(import_path))
+            return canonicalize("@{}//{}:{}".format(module_repo, package_path, _lib_name_from_import_path(import_path)))
         split_pos = module_path.rfind("/", 0, split_pos)
 
     fail("""

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@rules_go//go:def.bzl", "go_test")
 load("@gazelle//:def.bzl", "gazelle")
+load("@go_deps//:def.bzl", "go")
 
 gazelle(name = "gazelle")
 
@@ -10,6 +11,6 @@ go_test(
     srcs = ["mvs_test.go"],
     deps = [
         "@com_github_pelletier_go_toml//:go-toml",
-        "@com_github_stretchr_testify//require",
+        go("github.com/stretchr/testify/require"),
     ],
 )

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -38,7 +38,7 @@ go_deps.module(
 use_repo(
     go_deps,
      "com_github_pelletier_go_toml",
-     "com_github_stretchr_testify",
      # It is not necessary to list transitive dependencies here, only direct ones.
      # "in_gopkg_yaml_v3",
+     "go_deps",
 )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

bzlmod

**What does this PR do? Why is it needed?**

With the new `go` helper macro provided by the `go_deps` module extension, users can optionally specify their external Go dependencies in `deps` lists using their Go import paths rather than Bazel labels.

For example, to depend on `github.com/stretchr/testify/require`, users can add either of the following to the `deps` of a `go_*` rule after loading the `go` macro from `@go_deps//:def.bzl`:

- `"@com_github_stretchr_testify//require"` (old)
- `go("github.com/stretchr/testify/require")` (new)

When users specify an import path that isn't provided by a `go_repository`, they are shown the Go command that fetches the missing dependency (assuming they are already using `go_deps.from_file`).

**Other notes for review**

This commit does *not* add support for this new deps format to Gazelle itself.