### PR TITLE
language/go: add //go:embed all:<pattern> support

### DIFF
--- a/language/go/testdata/embedsrcs/BUILD.want
+++ b/language/go/testdata/embedsrcs/BUILD.want
@@ -10,6 +10,7 @@ go_library(
         "m_gen.txt",
         "m_static.txt",
         "n_/static.txt",
+        "o_dir/_hidden.txt",
     ],
     importpath = "example.com/repo/embedsrcs",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/embedsrcs/embedsrcs.go
+++ b/language/go/testdata/embedsrcs/embedsrcs.go
@@ -2,5 +2,5 @@ package embedsrcs
 
 import "embed"
 
-//go:embed *m_* n_/*
+//go:embed *m_* n_/* all:o*
 var fs embed.FS

--- a/language/go/testdata/embedsrcs/o_dir/_hidden.txt
+++ b/language/go/testdata/embedsrcs/o_dir/_hidden.txt
@@ -1,0 +1,2 @@
+# o_dir/_hidden.txt should be embeded because o_dir overrides exclusion rule
+# for hidden files with :all.


### PR DESCRIPTION

**What type of PR is this?**

Feature


**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**

The original support for embedding was added at the time of go1.16.
`go1.18` added the support for `all:`  in https://github.com/golang/go/issues/43854 
This PR adds it here. 

**Which issues(s) does this PR fix?**

Fixes #1431

**Other notes for review**
