### PR TITLE
feature: gazelle wrapper allows to pass environment variables

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,9 @@ gazelle(
     name = "gazelle",
     command = "fix",
     gazelle = ":gazelle_local",
+    env = {
+        "FOO": "bar",
+    },
 )
 
 # gazelle_ci is called from CI to verify the repo is up-to-date, see: .bazelci/presubmit.yml

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,9 +15,6 @@ gazelle(
     name = "gazelle",
     command = "fix",
     gazelle = ":gazelle_local",
-    env = {
-        "FOO": "bar",
-    },
 )
 
 # gazelle_ci is called from CI to verify the repo is up-to-date, see: .bazelci/presubmit.yml

--- a/def.bzl
+++ b/def.bzl
@@ -45,6 +45,20 @@ DEFAULT_LANGUAGES = [
     Label("//language/go:go_default_library"),
 ]
 
+def _valid_env_variable_name(name):
+    """ Returns if a string is in the regex [a-zA-Z_][a-zA-Z0-9_]*
+
+    Given that bazel lacks support of regex, we need to implement
+    a poor man validation
+    """
+    if not name:
+        return False
+    for i, c in enumerate(name.elems()):
+        if c.isalpha() or c == "_" or (i > 0 and c.isdigit()):
+            continue
+        return False
+    return True
+
 def _gazelle_runner_impl(ctx):
     args = [ctx.attr.command]
     if ctx.attr.mode:
@@ -57,7 +71,11 @@ def _gazelle_runner_impl(ctx):
         args.extend(["-build_tags", ",".join(ctx.attr.build_tags)])
     args.extend([ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.extra_args])
 
-    env = "\n".join([ "export %s='%s'" % (x, y) for (x, y) in ctx.attr.env.items() ])
+    for key in ctx.attr.env:
+        if not _valid_env_variable_name(key):
+            fail("Invalid environmental variable name: '%s'" % key)
+
+    env = "\n".join(["export %s=%s" % (x, shell.quote(y)) for (x, y) in ctx.attr.env.items()])
 
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     go_tool = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk.go

--- a/def.bzl
+++ b/def.bzl
@@ -57,6 +57,8 @@ def _gazelle_runner_impl(ctx):
         args.extend(["-build_tags", ",".join(ctx.attr.build_tags)])
     args.extend([ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.extra_args])
 
+    env = "\n".join([ "export %s='%s'" % (x, y) for (x, y) in ctx.attr.env.items() ])
+
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     go_tool = ctx.toolchains["@io_bazel_rules_go//go:toolchain"].sdk.go
     substitutions = {
@@ -69,6 +71,7 @@ def _gazelle_runner_impl(ctx):
 """.format(label = str(ctx.label)),
         "@@RUNNER_LABEL@@": shell.quote(str(ctx.label)),
         "@@GOTOOL@@": shell.quote(go_tool.short_path),
+        "@@ENV@@": env,
     }
     ctx.actions.expand_template(
         template = ctx.file._template,
@@ -118,6 +121,7 @@ _gazelle_runner = rule(
         "prefix": attr.string(),
         "extra_args": attr.string_list(),
         "data": attr.label_list(allow_files = True),
+        "env": attr.string_dict(),
         "_template": attr.label(
             default = "//internal:gazelle.bash.in",
             allow_single_file = True,

--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -24,6 +24,8 @@ GAZELLE_LABEL=@@GAZELLE_LABEL@@
 ARGS=@@ARGS@@
 GOTOOL=@@GOTOOL@@
 
+@@ENV@@
+
 # find_runfile prints the location of a runfile in the source workspace,
 # either by reading the symbolic link or reading the runfiles manifest.
 function find_runfile {

--- a/tests/cli/BUILD.bazel
+++ b/tests/cli/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":env_variables_test.bzl", "env_variables_test_suite")
+
+env_variables_test_suite()

--- a/tests/cli/env_variables_test.bzl
+++ b/tests/cli/env_variables_test.bzl
@@ -1,0 +1,65 @@
+load("@bazel_skylib//rules:analysis_test.bzl", "analysis_test")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//:def.bzl", "gazelle")
+
+def _invalid_var_failure_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    var_name = ctx.attr.var_name
+    if var_name == None:
+        unittest.fail(env, "var_name can't be null")
+    asserts.expect_failure(env, "Invalid environmental variable name: '%s'" % var_name)
+    return analysistest.end(env)
+
+invalid_var_failure_test = analysistest.make(
+    _invalid_var_failure_test_impl,
+    expect_failure = True,
+    attrs = {
+        "var_name": attr.string(),
+    },
+)
+
+def env_variables_test_suite():
+    gazelle(
+        name = "gazelle-valid-env-variables",
+        env = {
+            "SOME_VARIABLE": "1",
+            "YET_ANOTHER_VARIABLE_0": "2",
+            "_another_variable": "3",
+        },
+        tags = ["manual"],
+    )
+
+    analysis_test(
+        name = "valid_env_variables_test",
+        targets = [
+            ":gazelle-valid-env-variables",
+        ],
+    )
+
+    gazelle(
+        name = "gazelle-numbers-in-var-name",
+        env = {
+            "0foo": "",
+        },
+        tags = ["manual"],
+    )
+
+    invalid_var_failure_test(
+        name = "env_variable_name_cant_start_with_numbers_test",
+        target_under_test = ":gazelle-numbers-in-var-name",
+        var_name = "0foo",
+    )
+
+    gazelle(
+        name = "gazelle-empty-var-name",
+        env = {
+            "": "",
+        },
+        tags = ["manual"],
+    )
+
+    invalid_var_failure_test(
+        name = "env_variable_name_cant_be_empty",
+        target_under_test = ":gazelle-empty-var-name",
+        var_name = "",
+    )


### PR DESCRIPTION
In certain cases it may be useful to have predefined values like GONOSUMDB or others passed into the gazelle helper, with this change the caller to helper can pass those values, and make them part of the code tree instead of a mess of environment variables in the command line.

For example this means someone can now add this to their BUILD.bazel and get a properly working gazelle setup against their ssh private repositories:

```
gazelle(
    name = "gazelle",
    env = {
        "GONOSUMDB": "git.somecompany.com",
        "GIT_CONFIG_COUNT": "1",
        "GIT_CONFIG_KEY_0": "url.git@git.somecompany.com:.insteadof",
        "GIT_CONFIG_VALUE_0": "https://git.somecompany.com",
    },
)
```

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Since moving to bzlmod this feature got lost, now it can be reenabled.

**Which issues(s) does this PR fix?**

Fixes #946
