### PR TITLE
Fix `go mod download` output expectation for errors

### DIFF
--- a/language/go/update_import_test.go
+++ b/language/go/update_import_test.go
@@ -253,9 +253,7 @@ definitely.doesnotexist/ever v0.1.0/go.mod h1:HI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqw
 				return []byte(`{
 "Path": "definitely.doesnotexist/ever",
 "Version": "0.1.0",
-"Error": {
-    "Err": "Did not exist"
-}
+"Error": "Did not exist"
 }`), fmt.Errorf("failed to download")
 			},
 		}, {

--- a/language/go/utils.go
+++ b/language/go/utils.go
@@ -62,10 +62,6 @@ type moduleError struct {
 	Err string
 }
 
-type downloadError struct {
-	Err string
-}
-
 // moduleFromDownload is an abstraction to preserve the output of `go mod download`.
 // The output schema is documented at https://go.dev/ref/mod#go-mod-download
 type moduleFromDownload struct {
@@ -74,7 +70,7 @@ type moduleFromDownload struct {
 	Replace            *struct {
 		Path, Version string
 	}
-	Error *downloadError
+	Error string
 }
 
 // extractModules lists all modules except for the main module,
@@ -136,8 +132,8 @@ func fillMissingSums(pathToModule map[string]*moduleFromList) (map[string]*modul
 					err = fmt.Errorf("%w\nError parsing module for more error information: %v", err, decodeErr)
 					break
 				}
-				if dl.Error != nil {
-					err = fmt.Errorf("%w\nError downloading %v: %v", err, dl.Path, dl.Error.Err)
+				if dl.Error != "" {
+					err = fmt.Errorf("%w\nError downloading %v: %v", err, dl.Path, dl.Error)
 				}
 			}
 			err = fmt.Errorf("error from go mod download: %w", err)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Fixes the expected format of a struct emitted by `go mod download`.

See https://go.dev/ref/mod#go-mod-download for the specification.