### PR TITLE
Adding more hooks to FinishableLanguage

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -269,6 +269,12 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		return err
 	}
 
+	for _, lang := range languages {
+		if finishable, ok := lang.(language.FinishableLanguage); ok {
+			finishable.BeforeGeneratingRules()
+		}
+	}
+
 	// Visit all directories in the repository.
 	var visits []visitRecord
 	uc := getUpdateConfig(c)
@@ -372,6 +378,12 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		}
 	})
 
+	for _, lang := range languages {
+		if finishable, ok := lang.(language.FinishableLanguage); ok {
+			finishable.DoneGeneratingRules()
+		}
+	}
+
 	if len(errorsFromWalk) == 1 {
 		return errorsFromWalk[0]
 	}
@@ -408,10 +420,9 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		merger.MergeFile(v.file, v.empty, v.rules, merger.PostResolve,
 			unionKindInfoMaps(kinds, v.mappedKindInfo))
 	}
-
 	for _, lang := range languages {
 		if finishable, ok := lang.(language.FinishableLanguage); ok {
-			finishable.DoneGeneratingRules()
+			finishable.DoneResolvingDeps()
 		}
 	}
 

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -23,11 +23,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	gzflag "github.com/bazelbuild/bazel-gazelle/flag"
@@ -272,7 +270,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		return err
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	for _, lang := range languages {
 		if finishable, ok := lang.(language.FinishableLanguage); ok {

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -385,7 +385,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 
 	for _, lang := range languages {
 		if finishable, ok := lang.(language.FinishableLanguage); ok {
-			finishable.DoneGeneratingRules(ctx)
+			finishable.DoneGeneratingRules()
 		}
 	}
 
@@ -427,7 +427,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 	}
 	for _, lang := range languages {
 		if finishable, ok := lang.(language.FinishableLanguage); ok {
-			finishable.DoneResolvingDeps(ctx)
+			finishable.DoneResolvingDeps()
 		}
 	}
 

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -372,12 +372,6 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		}
 	})
 
-	for _, lang := range languages {
-		if finishable, ok := lang.(language.FinishableLanguage); ok {
-			finishable.DoneGeneratingRules()
-		}
-	}
-
 	if len(errorsFromWalk) == 1 {
 		return errorsFromWalk[0]
 	}
@@ -413,6 +407,12 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		}
 		merger.MergeFile(v.file, v.empty, v.rules, merger.PostResolve,
 			unionKindInfoMaps(kinds, v.mappedKindInfo))
+	}
+
+	for _, lang := range languages {
+		if finishable, ok := lang.(language.FinishableLanguage); ok {
+			finishable.DoneGeneratingRules()
+		}
 	}
 
 	// Emit merged files.

--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -271,7 +271,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 
 	for _, lang := range languages {
 		if finishable, ok := lang.(language.FinishableLanguage); ok {
-			finishable.BeforeGeneratingRules()
+			finishable.Init()
 		}
 	}
 

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -97,11 +97,11 @@ func (l *testFilegroupLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc 
 	if !l.RulesGenerated {
 		panic("Expected a call to DoneGeneratingRules before Resolve")
 	}
-	l.DepsResolved = true
+	if l.DepsResolved {
+		panic("Resolve must be called before calling DoneResolvingDeps")
+	}
 }
 
 func (l *testFilegroupLang) DoneResolvingDeps() {
-	if !l.DepsResolved {
-		panic("Expected calls to Resolve before DoneResolvingDeps")
-	}
+	l.DepsResolved = true
 }

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -24,6 +24,7 @@ limitations under the License.
 package test_filegroup
 
 import (
+	"context"
 	"path"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -42,6 +43,11 @@ type testFilegroupLang struct {
 	Initialized, RulesGenerated, DepsResolved bool
 }
 
+var (
+	_ language.Language           = (*testFilegroupLang)(nil)
+	_ language.FinishableLanguage = (*testFilegroupLang)(nil)
+)
+
 func NewLanguage() language.Language {
 	return &testFilegroupLang{}
 }
@@ -59,7 +65,7 @@ var kinds = map[string]rule.KindInfo{
 	},
 }
 
-func (l *testFilegroupLang) Init() {
+func (l *testFilegroupLang) Init(ctx context.Context) {
 	l.Initialized = true
 }
 

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -59,13 +59,13 @@ var kinds = map[string]rule.KindInfo{
 	},
 }
 
-func (l *testFilegroupLang) BeforeGeneratingRules() {
+func (l *testFilegroupLang) Init() {
 	l.Initialized = true
 }
 
 func (l *testFilegroupLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	if !l.Initialized {
-		panic("GenerateRules must not be called before BeforeGeneratingRules")
+		panic("GenerateRules must not be called before Init")
 	}
 	if l.RulesGenerated {
 		panic("GenerateRules must not be called after DoneGeneratingRules")

--- a/language/base.go
+++ b/language/base.go
@@ -1,6 +1,7 @@
 package language
 
 import (
+	"context"
 	"flag"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -66,7 +67,7 @@ func (b *BaseLang) GenerateRules(args GenerateArgs) GenerateResult {
 	return GenerateResult{}
 }
 
-func (b *BaseLang) Init() {}
+func (b *BaseLang) Init(ctx context.Context) {}
 
 func (b *BaseLang) DoneGeneratingRules() {}
 

--- a/language/base.go
+++ b/language/base.go
@@ -25,7 +25,6 @@ import (
 //	func NewLanguage() language.Language {
 //		return &MyLang{}
 //	}
-//
 type BaseLang struct{}
 
 func (b *BaseLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
@@ -67,6 +66,10 @@ func (b *BaseLang) GenerateRules(args GenerateArgs) GenerateResult {
 	return GenerateResult{}
 }
 
+func (b *BaseLang) Init() {}
+
 func (b *BaseLang) DoneGeneratingRules() {}
+
+func (b *BaseLang) DoneResolvingDeps() {}
 
 func (b *BaseLang) Fix(c *config.Config, f *rule.File) {}

--- a/language/base.go
+++ b/language/base.go
@@ -11,11 +11,11 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
-// BaseLang implements the minimum of language.Language interface.
-// This is not meant to be used directly by Gazelle, but to be used by
-// a downstream struct through composition. End users could use this to
-// write an extensions iteratively without having to implement every
-// functions in the interface right away.
+// BaseLang implements the minimum of language.Language and FinishableLanguage
+// interfaces. This is not meant to be used directly by Gazelle, but to be
+// used by a downstream struct through composition. End users could use this to
+// write an extensions iteratively without having to implement every function
+// in the interface right away.
 //
 // Example usage:
 //
@@ -27,6 +27,11 @@ import (
 //		return &MyLang{}
 //	}
 type BaseLang struct{}
+
+var (
+	_ Language           = (*BaseLang)(nil)
+	_ FinishableLanguage = (*BaseLang)(nil)
+)
 
 func (b *BaseLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
 

--- a/language/lang.go
+++ b/language/lang.go
@@ -39,7 +39,7 @@ import (
 // state may be stored in this instance, but stateless behavior is encouraged,
 // especially since some operations may be concurrent in the future.
 //
-// Tasks languages are used for
+// # Tasks languages are used for
 //
 // * Configuration (embedded interface config.Configurer). Languages may
 // define command line flags and alter the configuration in a directory
@@ -53,7 +53,7 @@ import (
 // example, import strings like "github.com/foo/bar" in Go can be resolved
 // into Bazel labels like "@com_github_foo_bar//:go_default_library".
 //
-// Tasks languages support
+// # Tasks languages support
 //
 // * Generating load statements: languages list files and symbols that may
 // be loaded.
@@ -99,6 +99,10 @@ type Language interface {
 // FinishableLanguage allows a Language to be notified when Generate is finished
 // being called.
 type FinishableLanguage interface {
+	// BeforeGeneratingRules is called before any calls to GenerateRules
+	// This allows for hooks to be called, for instance to starting a background
+	// server process.
+	BeforeGeneratingRules()
 	// DoneGeneratingRules is called when all calls to GenerateRules have been
 	// completed.
 	// This allows for hooks to be called, for instance to release resources
@@ -106,6 +110,10 @@ type FinishableLanguage interface {
 	// No further calls will be made to GenerateRules on this Language instance
 	// after this method has been called.
 	DoneGeneratingRules()
+	// DoneResolvingDeps is called when all calls to Resolve have been completed
+	// No further calls will be made to Resolve on this Language instance after
+	// this method has been called
+	DoneResolvingDeps()
 }
 
 // GenerateArgs contains arguments for language.GenerateRules. Arguments are

--- a/language/lang.go
+++ b/language/lang.go
@@ -22,6 +22,7 @@ limitations under the License.
 package language
 
 import (
+	"context"
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
@@ -102,7 +103,7 @@ type FinishableLanguage interface {
 	// Init is called before any calls to GenerateRules
 	// This allows for hooks to be called, for instance to starting a background
 	// server process.
-	Init()
+	Init(ctx context.Context)
 	// DoneGeneratingRules is called when all calls to GenerateRules have been
 	// completed.
 	// This allows for hooks to be called, for instance to release resources

--- a/language/lang.go
+++ b/language/lang.go
@@ -110,11 +110,11 @@ type FinishableLanguage interface {
 	// such as shutting down a background server.
 	// No further calls will be made to GenerateRules on this Language instance
 	// after this method has been called.
-	DoneGeneratingRules()
+	DoneGeneratingRules(ctx context.Context)
 	// DoneResolvingDeps is called when all calls to Resolve have been completed
 	// No further calls will be made to Resolve on this Language instance after
 	// this method has been called
-	DoneResolvingDeps()
+	DoneResolvingDeps(ctx context.Context)
 }
 
 // GenerateArgs contains arguments for language.GenerateRules. Arguments are

--- a/language/lang.go
+++ b/language/lang.go
@@ -99,10 +99,10 @@ type Language interface {
 // FinishableLanguage allows a Language to be notified when Generate is finished
 // being called.
 type FinishableLanguage interface {
-	// BeforeGeneratingRules is called before any calls to GenerateRules
+	// Init is called before any calls to GenerateRules
 	// This allows for hooks to be called, for instance to starting a background
 	// server process.
-	BeforeGeneratingRules()
+	Init()
 	// DoneGeneratingRules is called when all calls to GenerateRules have been
 	// completed.
 	// This allows for hooks to be called, for instance to release resources

--- a/language/lang.go
+++ b/language/lang.go
@@ -110,11 +110,11 @@ type FinishableLanguage interface {
 	// such as shutting down a background server.
 	// No further calls will be made to GenerateRules on this Language instance
 	// after this method has been called.
-	DoneGeneratingRules(ctx context.Context)
+	DoneGeneratingRules()
 	// DoneResolvingDeps is called when all calls to Resolve have been completed
 	// No further calls will be made to Resolve on this Language instance after
 	// this method has been called
-	DoneResolvingDeps(ctx context.Context)
+	DoneResolvingDeps()
 }
 
 // GenerateArgs contains arguments for language.GenerateRules. Arguments are


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
cmd/gazelle

**What does this PR do? Why is it needed?**
`DoneGeneratingRules()` is called before resolving dependencies. However, some Gazelle extensions (e.g., [Python](https://github.com/bazelbuild/rules_python/tree/main/gazelle)) needs to start server processes to parse Python files and query standard modules before generating rules, and shutdown those processes after dependency resolution. Adding `BeforeGeneratingRules` and `DoneResolvingDeps` hooks to manage these server processes.

**Other notes for review**
This is a breaking change. Existing implementations of `FinishableLanguage` need to implement those two additional methods.
