### PR TITLE
gazelle: add CPU profiling to aid troubleshooting

### DIFF
--- a/extend.md
+++ b/extend.md
@@ -26,6 +26,21 @@ Tests
 To write tests for your gazelle extension, you can use [gazelle_generation_test](#gazelle_generation_test),
 which will run a gazelle binary of your choosing on a set of test workspaces.
 
+Troubleshooting
+-----
+
+Gazelle supports [Go's profiling](https://go.dev/blog/pprof) that enable you to inspect performance
+bottlenecks.
+
+```bash
+# Execute gazelle to create a Go profile
+$ gazelle --cpu_profile_path=/tmp/gazelle.prof fix
+
+# Analyze Go profile
+$ go tool pprof -http :8080 /tmp/gazelle.prof
+```
+
+This could be particularly helpful to generate a flame graph and/or identify slow code paths when writing a Gazelle extension.
 
 Supported languages
 -------------------

--- a/internal/extend_docs.bzl
+++ b/internal/extend_docs.bzl
@@ -26,6 +26,21 @@ Tests
 To write tests for your gazelle extension, you can use [gazelle_generation_test](#gazelle_generation_test),
 which will run a gazelle binary of your choosing on a set of test workspaces.
 
+Troubleshooting
+-----
+
+Gazelle supports [Go's profiling](https://go.dev/blog/pprof) that enable you to inspect performance
+bottlenecks.
+
+```bash
+# Execute gazelle to create a Go profile
+$ gazelle --cpu_profile_path=/tmp/gazelle.prof fix
+
+# Analyze Go profile
+$ go tool pprof -http :8080 /tmp/gazelle.prof
+```
+
+This could be particularly helpful to generate a flame graph and/or identify slow code paths when writing a Gazelle extension.
 
 Supported languages
 -------------------


### PR DESCRIPTION
As Gazelle becomes the defacto tool to generate BUILD files for several languages in Bazel ecosystem, we gain more contributors and extension authors from a diverse set of background and experience.

However, Gazelle itself is complicated and not all the contributors are familiar with the Go ecosystem. This led to difficulty in developing language extensions and troubleshooting edge cases.

Provides a way to turn on Go profiling(1) is a great way to help with that. Go's pprof tool is well-documented and CLI friendly. Rules author could simply turn on the CPU profile capture to analyze it and figure out where is the bottleneck, how does the call stack look like.

Add environment variables `GAZELLE_CPU_PROFILE` to collect Go CPU profile for later analysis.

(1): https://go.dev/blog/pprof