### PR TITLE
Allow keep to be explained

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -979,6 +979,9 @@ In addition to directives, Gazelle supports ``# keep`` comments that protect
 parts of build files from being modified. ``# keep`` may be written before
 a rule, before an attribute, or after a string within a list.
 
+``# keep`` comments might take one of 2 forms; the ``# keep`` literal or a
+description prefixed by ``# keep: ``.
+
 Example
 ^^^^^^^
 
@@ -1003,6 +1006,7 @@ know what imports to resolve, so you may need to add dependencies manually with
       visibility = ["//visibility:public"],
       deps = [
           "@com_github_example_gen//:go_default_library",  # keep
+          "@com_github_example_gen//a/b/c:go_default_library",  # keep: this is also important
       ],
   )
 

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -996,7 +996,7 @@ func (r *Rule) sync() {
 func ShouldKeep(e bzl.Expr) bool {
 	for _, c := range append(e.Comment().Before, e.Comment().Suffix...) {
 		text := strings.TrimSpace(strings.TrimPrefix(c.Token, "#"))
-		if strings.HasPrefix(text, "keep") {
+		if text == "keep" || strings.HasPrefix(text, "keep: ") {
 			return true
 		}
 	}

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -996,7 +996,7 @@ func (r *Rule) sync() {
 func ShouldKeep(e bzl.Expr) bool {
 	for _, c := range append(e.Comment().Before, e.Comment().Suffix...) {
 		text := strings.TrimSpace(strings.TrimPrefix(c.Token, "#"))
-		if text == "keep" {
+		if strings.HasPrefix(text, "keep") {
 			return true
 		}
 	}

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -305,6 +305,13 @@ x_library(name = "x")
 `,
 			want: true,
 		}, {
+			desc: "prefix",
+			src: `
+# keep because of ticket #42
+x_library(name = "x")
+`,
+			want: true,
+		}, {
 			desc: "compact_suffix",
 			src: `
 x_library(name = "x") # keep
@@ -357,6 +364,13 @@ func TestShouldKeepExpr(t *testing.T) {
 			desc: "before",
 			src: `
 # keep
+"s"
+`,
+			want: true,
+		}, {
+			desc: "before",
+			src: `
+# keep because we need it for the ninja feature
 "s"
 `,
 			want: true,

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -375,6 +375,20 @@ func TestShouldKeepExpr(t *testing.T) {
 `,
 			want: true,
 		}, {
+			desc: "before but not the correct prefix (keeping)",
+			src: `
+			# keeping this for now
+"s"
+`,
+			want: false,
+		}, {
+			desc: "before but not the correct prefix (no colon)",
+			src: `
+			# keep this around for the time being
+"s"
+`,
+			want: false,
+		}, {
 			desc: "suffix",
 			src: `
 "s" # keep

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -305,9 +305,9 @@ x_library(name = "x")
 `,
 			want: true,
 		}, {
-			desc: "prefix",
+			desc: "prefix with description",
 			src: `
-# keep because of ticket #42
+# keep: hack, see more in ticket #42
 x_library(name = "x")
 `,
 			want: true,
@@ -368,9 +368,9 @@ func TestShouldKeepExpr(t *testing.T) {
 `,
 			want: true,
 		}, {
-			desc: "before",
+			desc: "before with description",
 			src: `
-# keep because we need it for the ninja feature
+# keep: we need it for the ninja feature
 "s"
 `,
 			want: true,


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

rule

**What does this PR do? Why is it needed?**

Allow the # keep comment to take more text after them for the keep author to add a reference to a ticket or to explain the need for the keep.