### PR TITLE
feat(bzlmod): support go.mod replace directives

### DIFF
--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_go", version = "0.38.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 
-# Read the empty go.mod file in this test module.
+# Validate a go.mod replace directive works.
 go_deps.from_file(go_mod = "//:go.mod")
 
 # Using an older version than a transitive dependency (in this case, gazelle itself) emits a warning for the root
@@ -53,6 +53,7 @@ go_deps.module(
 )
 use_repo(
     go_deps,
+    "com_github_bmatcuk_doublestar_v4",
     "com_github_pelletier_go_toml",
     "com_github_stretchr_testify",
     # It is not necessary to list transitive dependencies here, only direct ones.

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -1,5 +1,9 @@
-// Only here to stop go mod from descending into this directory.
-
+// This will stop go mod from descending into this directory.
 module github.com/bazelbuild/bazel-gazelle/tests/bcr
 
 go 1.19
+
+// Validate go.mod replace directives can be properly used:
+replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
+
+require github.com/bmatcuk/doublestar/v4 v4.0.0

--- a/tests/bcr/go.sum
+++ b/tests/bcr/go.sum
@@ -1,0 +1,2 @@
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=

--- a/tests/bcr/pkg/BUILD.bazel
+++ b/tests/bcr/pkg/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "pkg_test",
     srcs = ["mvs_test.go"],
     deps = [
+        "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_pelletier_go_toml//:go-toml",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/tests/bcr/pkg/mvs_test.go
+++ b/tests/bcr/pkg/mvs_test.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"testing"
 
+	"github.com/bmatcuk/doublestar/v4"
 	toml "github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/require"
 )
@@ -16,4 +17,12 @@ func TestMvs(t *testing.T) {
 deps = ["gazelle", "rules_go"]`)
 	require.NoError(t, err)
 	require.Equal(t, []string{"gazelle", "rules_go"}, tree.GetArray("modules.deps"))
+}
+
+func TestReplace(t *testing.T) {
+	// doublestar.StandardOS does NOT exist in doublestar/v4
+	// See: https://pkg.go.dev/github.com/bmatcuk/doublestar#OS
+	// If we are able to initialize this variable, it validates that the dependency is properly
+	// being replaced with github.com/bmatcuk/doublestar@v1.3.4
+	_ = doublestar.StandardOS
 }

--- a/tests/bzlmod/BUILD.bazel
+++ b/tests/bzlmod/BUILD.bazel
@@ -1,6 +1,9 @@
 load(":go_mod_test.bzl", "go_mod_test_suite")
 load(":semver_test.bzl", "semver_test_suite")
+load(":utils_test.bzl", "utils_test_suite")
 
 go_mod_test_suite(name = "go_mod_test")
 
 semver_test_suite(name = "semver_test")
+
+utils_test_suite(name = "utils_test")

--- a/tests/bzlmod/go_mod_test.bzl
+++ b/tests/bzlmod/go_mod_test.bzl
@@ -9,7 +9,10 @@ require (
 github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	// some comment
 	`golang.org/x/tools` "v0.1.11" // foobar
+	github.com/go-fsnotify/fsnotify v1.5.4
 )
+
+replace github.com/go-fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.2
 
 module github.com/bazelbuild/bazel-gazelle
 
@@ -25,11 +28,13 @@ require golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
 _EXPECTED_GO_MOD_PARSE_RESULT = struct(
     go = (1, 18),
     module = "github.com/bazelbuild/bazel-gazelle",
+    replace_map = {"github.com/go-fsnotify/fsnotify": struct(to_path = "github.com/fsnotify/fsnotify", version = "1.4.2")},
     require = (
         struct(direct = True, path = "github.com/bazelbuild/buildtools", version = "v0.0.0-20220531122519-a43aed7014c8"),
         struct(direct = True, path = "github.com/bazelbuild/rules_go", version = "v0.n\\\"33.0"),
         struct(direct = False, path = "github.com/bmatcuk/doublestar/v4", version = "v4.0.2"),
         struct(direct = True, path = "golang.org/x/tools", version = "v0.1.11"),
+        struct(direct = True, path = "github.com/go-fsnotify/fsnotify", version = "v1.5.4"),
         struct(direct = False, path = "golang.org/x/sys", version = "v0.0.0-20220624220833-87e55d714810"),
     ),
 )

--- a/tests/bzlmod/utils_test.bzl
+++ b/tests/bzlmod/utils_test.bzl
@@ -1,0 +1,32 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//internal/bzlmod:utils.bzl", "with_replaced_or_new_fields")
+
+_BEFORE_STRUCT = struct(
+    direct = True,
+    path = "github.com/bazelbuild/buildtools",
+    version = "v0.0.0-20220531122519-a43aed7014c8",
+)
+
+_EXPECT_REPLACED_STRUCT = struct(
+    direct = True,
+    path = "github.com/bazelbuild/buildtools",
+    replace = "path/to/add/replace",
+    version = "v1.2.2"
+)
+
+def _with_replaced_or_new_fields_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, _EXPECT_REPLACED_STRUCT, with_replaced_or_new_fields(
+        _BEFORE_STRUCT,
+        replace = "path/to/add/replace",
+        version = "v1.2.2",
+    ))
+    return unittest.end(env)
+
+with_replaced_or_new_fields_test = unittest.make(_with_replaced_or_new_fields_test_impl)
+
+def utils_test_suite(name):
+    unittest.suite(
+        name,
+        with_replaced_or_new_fields_test,
+    )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

internal/bzlmod/go_mod

**What does this PR do? Why is it needed?**

This PR adds support for`replace` directives in `go.mod` files. There are multiple acceptible formats for `replace` directives:
```
    golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
    golang.org/x/net => example.com/fork/net v1.4.5 (SUPPORT ADDED)
    golang.org/x/net v1.2.3 => ./fork/net
    golang.org/x/net => ./fork/net
```
For now, we will ONLY allow the second one in the list: replacing a path with a new path and version. Local directories will not be allowed.

**Which issues(s) does this PR fix?**

Fixes #1449