### PR TITLE
Update File.Sync to propertly position package() rule immediately after load()s

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -315,6 +315,17 @@ func (f *File) Sync() {
 	for r, w = 0, 0; r < len(f.Rules); r++ {
 		s := f.Rules[r]
 		s.sync()
+
+		// package() rules are special in that they are REQUIRED to occur
+		// after all load()s and before any other rules. Therefore we
+		// manually update the index of any Rule{name:"package"} we
+		// find to the index of the last load(). This is safe because
+		// "statements at the same index will occur in order" and rules
+		// always occur after load()s in the call to updateStmt below.
+		if s.Kind() == "package" {
+			s.index = len(f.Loads)
+		}
+
 		if s.deleted {
 			ruleDeletes = append(ruleDeletes, &s.stmt)
 			continue

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -323,7 +323,7 @@ func (f *File) Sync() {
 		// "statements at the same index will occur in order" and rules
 		// always occur after load()s in the call to updateStmt below.
 		if s.Kind() == "package" {
-			s.index = len(f.Loads)
+			s.index = len(f.Loads) - 1
 		}
 
 		if s.deleted {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -316,9 +316,9 @@ func (f *File) Sync() {
 		s := f.Rules[r]
 		s.sync()
 
-		// package() rules are special in that they are REQUIRED to occur
+		// the package() rule is special in that it is REQUIRED to occur
 		// after all load()s and before any other rules. Therefore we
-		// manually update the index of any Rule{name:"package"} we
+		// manually update the index of any Rule{kind:"package"} we
 		// find to the index of the last load(). This is safe because
 		// "statements at the same index will occur in order" and rules
 		// always occur after load()s in the call to updateStmt below.

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -69,6 +69,10 @@ y_library(name = "bar")
 	})
 	baz.Insert(f)
 
+	packageRule := NewRule("package", "")
+	packageRule.SetAttr("default_visibility", "//visibility:public")
+	packageRule.Insert(f)
+
 	got := strings.TrimSpace(string(f.Format()))
 	want := strings.TrimSpace(`
 load("//some:maybe.bzl", "maybe")
@@ -78,6 +82,8 @@ load(
     "y_library",
     z = "z_library",
 )
+
+package(default_visibility = "//visibility:public")
 
 y_library(
     name = "bar",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

The documentation explicitly requires a package() rule to occur immediate after the load() calls in a BUILD.bazel file, but before any other rules. There was no enforcement of this within gazelle's file formatting functionality. Rather than requiring future extension authors manipulating package() rules to search for the proper insertion location, this PR updates the central Sync function (which does load() and rule() rearranging already) to position the package() invocation correctly.

**Which issues(s) does this PR fix?**

**Other notes for review**
