### PR TITLE
Extend `labelRepoRegexp` regex pattern

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,7 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
+	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z0-9.-][A-Za-z0-9_.-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
 	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_` \"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -76,6 +76,8 @@ func TestParse(t *testing.T) {
 		{str: "@a//b", want: Label{Repo: "a", Pkg: "b", Name: "b"}},
 		{str: "@a//b:c", want: Label{Repo: "a", Pkg: "b", Name: "c"}},
 		{str: "@a//@b:c", want: Label{Repo: "a", Pkg: "@b", Name: "c"}},
+		{str: "@2022ABC//b:c", want: Label{Repo: "2022ABC", Pkg: "b", Name: "c"}},
+		{str: "@ABC2022//b:c", want: Label{Repo: "ABC2022", Pkg: "b", Name: "c"}},
 		{str: "@..//b:c", want: Label{Repo: "..", Pkg: "b", Name: "c"}},
 		{str: "@--//b:c", want: Label{Repo: "--", Pkg: "b", Name: "c"}},
 		{str: "//api_proto:api.gen.pb.go_checkshtest", want: Label{Pkg: "api_proto", Name: "api.gen.pb.go_checkshtest"}},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`label/label.go`

**What does this PR do? Why is it needed?**

This change allows repo names to begin with a number. It is needed because valid labels which begin with a number are currently returned as invalid by `label.parse()`.

**Which issues(s) does this PR fix?**

Fixes https://github.com/bazelbuild/bazel-gazelle/issues/1460

**Other notes for review**
