### PR TITLE
feat: allow passing GIT_CONFIG_COUNT and it's related configs

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -207,22 +207,23 @@ def _go_repository_impl(ctx):
         "GIT_SSL_CAINFO",
         "GIT_SSH",
         "GIT_SSH_COMMAND",
-        "GIT_CONFIG_COUNT"
+        "GIT_CONFIG_COUNT",
     ]
 
     # Git allows passing configuration through environmental variables, this will be picked
     # by go get properly: https://www.git-scm.com/docs/git-config/#Documentation/git-config.txt-GITCONFIGCOUNT
-    if 'GIT_CONFIG_COUNT' in ctx.os.environ:
-        count = ctx.os.environ['GIT_CONFIG_COUNT']
+    if "GIT_CONFIG_COUNT" in ctx.os.environ:
+        count = ctx.os.environ["GIT_CONFIG_COUNT"]
         if count:
             if not count.isdigit or int(count) < 1:
-                fail("GIT_CONFIG_COUNT has to be a positive over 0 integer")
-            for i in range(int(count)):
-                key = 'GIT_CONFIG_KEY_%d' % i
-                value = 'GIT_CONFIG_VALUE_%d' % i
+                fail("GIT_CONFIG_COUNT has to be a positive integer")
+            count = int(count)
+            for i in range(count):
+                key = "GIT_CONFIG_KEY_%d" % i
+                value = "GIT_CONFIG_VALUE_%d" % i
                 for j in [key, value]:
                     if j not in ctx.os.environ:
-                        fail("%s is not defined as an environmetal variable, but you asked for GIT_COUNT_COUNT=%i" % (j, count))
+                        fail("%s is not defined as an environment variable, but you asked for GIT_COUNT_COUNT=%d" % (j, count))
                 env_keys = env_keys + [key, value]
 
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -209,11 +209,22 @@ def _go_repository_impl(ctx):
         "GIT_SSH_COMMAND",
         "GIT_CONFIG_COUNT"
     ]
+
+    # Git allows passing configuration through environmental variables, this will be picked
+    # by go get properly: https://www.git-scm.com/docs/git-config/#Documentation/git-config.txt-GITCONFIGCOUNT
     if 'GIT_CONFIG_COUNT' in ctx.os.environ:
         count = ctx.os.environ['GIT_CONFIG_COUNT']
-        if count and count.isdigit() and int(count) > 0:
+        if count:
+            if not count.isdigit or int(count) < 1:
+                fail("GIT_CONFIG_COUNT has to be a positive over 0 integer")
             for i in range(int(count)):
-                env_keys = env_keys + ['GIT_CONFIG_KEY_%d' % i, 'GIT_CONFIG_VALUE_%d' % i]
+                key = 'GIT_CONFIG_KEY_%d' % i
+                value = 'GIT_CONFIG_VALUE_%d' % i
+                for j in [key, value]:
+                    if j not in ctx.os.environ:
+                        fail("%s is not defined as an environmetal variable, but you asked for GIT_COUNT_COUNT=%i" % (j, count))
+                env_keys = env_keys + [key, value]
+
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 
     if fetch_repo_args:

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -207,7 +207,13 @@ def _go_repository_impl(ctx):
         "GIT_SSL_CAINFO",
         "GIT_SSH",
         "GIT_SSH_COMMAND",
+        "GIT_CONFIG_COUNT"
     ]
+    if 'GIT_CONFIG_COUNT' in ctx.os.environ:
+        count = ctx.os.environ['GIT_CONFIG_COUNT']
+        if count and count.isdigit() and int(count) > 0:
+            for i in range(int(count)):
+                env_keys = env_keys + ['GIT_CONFIG_KEY_%d' % i, 'GIT_CONFIG_VALUE_%d' % i]
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
 
     if fetch_repo_args:


### PR DESCRIPTION


**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

Sometimes, specially when dealing with internal reposositories, it may be desirable to be able to pass variables into git through go mod tooling, this change allows someone to add this lines to their bazelrc and use ssh instead of https for their internal repositories:

```
build --repo_env=GONOSUMDB=gitserver.somecompany.com
build --repo_env=GIT_CONFIG_COUNT=1
build --repo_env=GIT_CONFIG_KEY_0=url.git@gitserver.somecompany.com:.insteadof
build --repo_env=GIT_CONFIG_VALUE_0=https://gitserver.somecompany.com
```

**Which issues(s) does this PR fix?**

Fixes #946 

**Other notes for review**
