### PR TITLE
Default Visibility extension overwrite on descent (fixes #1467)

### DIFF
--- a/language/bazel/visibility/config.go
+++ b/language/bazel/visibility/config.go
@@ -50,14 +50,21 @@ func (*visibilityExtension) Configure(c *config.Config, _ string, f *rule.File) 
 		return
 	}
 
+	var newVisTargets []string
 	for _, d := range f.Directives {
 		switch d.Key {
 		case _directiveName:
 			for _, target := range strings.Split(d.Value, ",") {
-				cfg.visibilityTargets = append(cfg.visibilityTargets, target)
+				newVisTargets = append(newVisTargets, target)
 			}
 		}
 	}
+
+	// if visibility targets were specified, overwrite the config
+	if len(newVisTargets) != 0 {
+		cfg.visibilityTargets = newVisTargets
+	}
+
 	c.Exts[_extName] = cfg
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/bazel

**What does this PR do? Why is it needed?**

Previously the logic of this extension accumulated default visibilities to the list across all configurations without any reset. As noted in the attached issue, this is unintuitive and did not add real value so long as multiple directives within the same file can still aggregate values.

**Which issues(s) does this PR fix?**

Fixes #1467
