### PR TITLE
Pass data arg through to sh_binary if defined

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -184,4 +184,5 @@ def gazelle(name, **kwargs):
         srcs = [runner_name],
         tags = tags,
         visibility = visibility,
+        data = kwargs["data"] if "data" in kwargs else [],
     )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

When trying to run an update-repos with a go.mod generated from a genrule() target, the go.mod isn't built as a dependency despite being specified as one with `data`. AFAICT this is because data isn't passed through to sh_binary.

Without the patch, this fails because go.mod doesn't exist:
`bazel run //:gazelle-update-repos`

```
gazelle: error from go list: running '/private/var/tmp/_bazel_preston4tw/416b5eb0536fd56dcbcf19cedbdb737f/external/go_sdk/bin/go /private/var/tmp/_bazel_preston4tw/416b5eb0536fd56dcbcf19cedbdb737f/external/go_sdk/bin/go list -mod=readonly -e -m -json all': go: cannot match "all": go.mod file not found in current directory or any parent directory; see 'go help modules'
```

With the patch go.mod is generated and the command works:

```
INFO: Analyzed target //:gazelle-update-repos (19 packages loaded, 99 targets configured).
INFO: Found 1 target...
INFO: From Executing genrule //:gomod:
external/com_github_xo_usql/go.mod -> bazel-out/darwin_arm64-fastbuild/bin/go.mod
Target //:gazelle-update-repos up-to-date:
  bazel-bin/gazelle-update-repos-runner.bash
  bazel-bin/gazelle-update-repos
INFO: Elapsed time: 1.223s, Critical Path: 0.02s
INFO: 4 processes: 3 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/gazelle-update-repos
```

Example: https://github.com/Preston4tw/gazelle-example-1

Relatedly it would be handy if:
- go.mod files were exported in gazelle's generated build files so I didn't have to patch `go_repository()`s: https://github.com/Preston4tw/gazelle-example-1/blob/main/usql.patch
- `-from_file` supported labels but it's not obvious if this is even possible

https://github.com/Preston4tw/gazelle-example-1/blob/main/BUILD#L16-L21 this is because gazelle seems to want to `chdir` to where go.mod is. `$(location @com_github_xo_usql//:go.mod)` seems to fail because the chdir fails for reasons I don't understand.