### PR TITLE
fix(bzlmod/go_deps): don't read go.sum for empty go.mod files

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -177,12 +177,14 @@ def _go_deps_impl(module_ctx):
             )
         additional_module_tags = []
         for from_file_tag in module.tags.from_file:
+            module_tags_from_go_mod = deps_from_go_mod(module_ctx, from_file_tag.go_mod)
+            additional_module_tags += module_tags_from_go_mod
 
-            # Load all sums from transitively resolved `go.sum` files.
-            # Only use these after version resolution is completed.
-            for entry, new_sum in sums_from_go_mod(module_ctx, from_file_tag.go_mod).items():
-                _safe_insert_sum(sums, entry, new_sum)
-            additional_module_tags += deps_from_go_mod(module_ctx, from_file_tag.go_mod)
+            # Load all sums from transitively resolved `go.sum` files that have modules.
+            if len(module_tags_from_go_mod) > 0:
+                for entry, new_sum in sums_from_go_mod(module_ctx, from_file_tag.go_mod).items():
+                    _safe_insert_sum(sums, entry, new_sum)
+
 
         # Load sums from manually specified modules separately.
         for module_tag in module.tags.module:

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -12,6 +12,9 @@ bazel_dep(name = "rules_go", version = "0.38.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 
+# Read the empty go.mod file in this test module.
+go_deps.from_file(go_mod = "//:go.mod")
+
 # Using an older version than a transitive dependency (in this case, gazelle itself) emits a warning for the root
 # module, but still fetches the most recent version due to Minimum Version Selection (MVS).
 go_deps.module(

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -1,1 +1,5 @@
 // Only here to stop go mod from descending into this directory.
+
+module github.com/bazelbuild/bazel-gazelle/tests/bcr
+
+go 1.19


### PR DESCRIPTION
We need to only call sums_from_go_mod if the corresponding go.mod file lists at least one dep. [See previous implementation](https://github.com/bazelbuild/bazel-gazelle/commit/97a754c6e45848828b27152fa64ca5dd3003d832#diff-3f46978d0add3c4448fb3dac679f46863ffaa5164f61f410f247179ebd80f6e5L15-L16)

Otherwise we get the following error:
```
	File "/.../external/gazelle~override/internal/bzlmod/go_deps.bzl", line 183, column 51, in _go_deps_impl
		for entry, new_sum in sums_from_go_mod(module_ctx, from_file_tag.go_mod).items():
	File "/.../external/gazelle~override/internal/bzlmod/go_mod.bzl", line 204, column 34, in sums_from_go_mod
		go_sum_path = module_ctx.path(go_sum_label)
Error in path: Not a regular file: /.../bazel-gazelle/tests/bcr/go.sum
```
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`internal/bzlmod/go_deps.bzl`

**What does this PR do? Why is it needed?**

This fixes the issue where an empty `go.mod` file causes a failure to read a non-existent `go.sum` file.

**Which issues(s) does this PR fix?**

Fixes #1485