### PR TITLE
Exclude `.ijwb` from repository tools srcs

### DIFF
--- a/internal/list_repository_tools_srcs.go
+++ b/internal/list_repository_tools_srcs.go
@@ -68,7 +68,7 @@ func main() {
 		}
 
 		base := filepath.Base(path)
-		if base == "bcr_tests" || base == "docs" || base == "vendor" || base == "third_party" || base == "testdata" {
+		if base == "bcr_tests" || base == "docs" || base == "vendor" || base == "third_party" || base == "testdata" || base == ".ijwb" {
 			return filepath.SkipDir
 		}
 		if !info.IsDir() &&


### PR DESCRIPTION
This breaks local builds when using IntelliJ with the Bazel plugin.