### PR TITLE
language/go: Infer prefix from go.mod

### DIFF
--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//rule",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_pelletier_go_toml//:go-toml",
+        "@org_golang_x_mod//modfile",
         "@org_golang_x_mod//module",
         "@org_golang_x_sync//errgroup",
     ],

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@gazelle//:def.bzl", "gazelle")
 
-# gazelle:prefix github.com/bazelbuild/bazel-gazelle/tests/bcr
 # gazelle:go_naming_convention import
 # gazelle:go_naming_convention_external import
 gazelle(name = "gazelle")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

If no prefix has been set but a go.mod file is present, use the path in its `module` directive.

This allows simple Go projects to start using Gazelle without specifying any directives.

