### PR TITLE
language/go: Add windows arm64 as a known platform.

### DIFF
--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -621,7 +621,8 @@ func rulesGoSupportsPlatform(v version.Version, p rule.Platform) bool {
 			p.OS == "linux" && p.Arch == "riscv64" ||
 			p.OS == "netbsd" && p.Arch == "arm64" ||
 			p.OS == "openbsd" && p.Arch == "arm64" ||
-			p.OS == "windows" && p.Arch == "arm") {
+			p.OS == "windows" && p.Arch == "arm" ||
+			p.OS == "windows" && p.Arch == "arm64") {
 		return false
 	}
 	return true

--- a/rule/platform.go
+++ b/rule/platform.go
@@ -94,6 +94,7 @@ var KnownPlatforms = []Platform{
 	{"windows", "386"},
 	{"windows", "amd64"},
 	{"windows", "arm"},
+	{"windows", "arm64"},
 }
 
 var OSAliases = map[string][]string{


### PR DESCRIPTION
Before this change `_windows_arm64.go` files were ignored by gazelle.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

This PR adds windows + arm64 as a known platform.

**Which issues(s) does this PR fix?**

Fixes #1506

**Other notes for review**
