### PR TITLE
language/go: Handle `unix` build tag.

### DIFF
--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -559,8 +559,7 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 		if isIgnoredTag(tag) {
 			return true
 		}
-
-		if _, ok := rule.KnownOSSet[tag]; ok {
+		if _, ok := rule.KnownOSSet[tag]; ok || tag == "unix" {
 			if os == "" {
 				return false
 			}

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -525,6 +525,9 @@ func matchesOS(os, value string) bool {
 	if os == value {
 		return true
 	}
+	if value == "unix" {
+		return rule.UnixOS[os]
+	}
 	for _, alias := range rule.OSAliases[os] {
 		if alias == value {
 			return true

--- a/rule/platform.go
+++ b/rule/platform.go
@@ -102,6 +102,23 @@ var OSAliases = map[string][]string{
 	"ios":     {"darwin"},
 }
 
+// UnixOS is the set of GOOS values matched by the "unix" build tag.
+// This list is from go/src/cmd/dist/build.go.
+var UnixOS = map[string]bool{
+	"aix":       true,
+	"android":   true,
+	"darwin":    true,
+	"dragonfly": true,
+	"freebsd":   true,
+	"hurd":      true,
+	"illumos":   true,
+	"ios":       true,
+	"linux":     true,
+	"netbsd":    true,
+	"openbsd":   true,
+	"solaris":   true,
+}
+
 var (
 	// KnownOSs is the sorted list of operating systems that Go supports.
 	KnownOSs []string
@@ -133,6 +150,8 @@ func init() {
 		KnownOSArchs[p.OS] = append(KnownOSArchs[p.OS], p.Arch)
 		KnownArchOSs[p.Arch] = append(KnownArchOSs[p.Arch], p.OS)
 	}
+	// unix is a pseudo os
+	KnownOSSet["unix"] = true
 	KnownOSs = make([]string, 0, len(KnownOSSet))
 	KnownArchs = make([]string, 0, len(KnownArchSet))
 	for os := range KnownOSSet {

--- a/rule/platform.go
+++ b/rule/platform.go
@@ -150,8 +150,6 @@ func init() {
 		KnownOSArchs[p.OS] = append(KnownOSArchs[p.OS], p.Arch)
 		KnownArchOSs[p.Arch] = append(KnownArchOSs[p.Arch], p.OS)
 	}
-	// unix is a pseudo os
-	KnownOSSet["unix"] = true
 	KnownOSs = make([]string, 0, len(KnownOSSet))
 	KnownArchs = make([]string, 0, len(KnownArchSet))
 	for os := range KnownOSSet {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix
**What package or component does this PR mostly affect?**


language/go and rules

**What does this PR do? Why is it needed?**

Adds support for the "unix" build tag added via https://github.com/golang/go/issues/20322

jackc/pgx is a popular pg lib that currently fails to build with bazel. Requires a local patch to change pgx code. 
https://github.com/jackc/pgx/issues/1520

**Which issues(s) does this PR fix?**

Fixes #1465

**Other notes for review**
