### PR TITLE
Disable protobuf generation for more modules

### DIFF
--- a/internal/bzlmod/directives.bzl
+++ b/internal/bzlmod/directives.bzl
@@ -19,6 +19,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "k8s.io/api": [
         "gazelle:proto disable",
     ],
+    "k8s.io/apiextensions-apiserver": [
+        "gazelle:proto disable",
+    ],
     "k8s.io/apimachinery": [
         "gazelle:proto disable",
     ],

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -397,7 +397,7 @@ _module_tag = tag_class(
             repository.
 
             Deprecated: Use the "gazelle:build_file_names" directive
-            via gazelle_override tag's "directive" attribute
+            via gazelle_override tag's "directives" attribute
             instead.""",
             default = "",
             values = [
@@ -412,7 +412,7 @@ _module_tag = tag_class(
             repository.
 
             Deprecated: Use the "gazelle:proto" directive via
-            gazelle_override tag's "build_file_proto_mode" attribute
+            gazelle_override tag's "directives" attribute
             instead.""",
             default = "",
             values = [

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -103,7 +103,7 @@ def _safe_append_directives(module, gazelle_overrides, directives):
     else:
         existing = []
     gazelle_overrides[module.path] = struct(
-        directives = existing + directives
+        directives = existing + directives,
     )
 
 def _get_directives(path, gazelle_overrides):
@@ -279,7 +279,8 @@ def _go_deps_impl(module_ctx):
     for path, replace in replace_map.items():
         if path in module_resolutions:
             new_version = semver.to_comparable(replace.version)
-            module_resolutions[path] = with_replaced_or_new_fields(module_resolutions[path],
+            module_resolutions[path] = with_replaced_or_new_fields(
+                module_resolutions[path],
                 replace = replace.to_path,
                 version = new_version,
                 raw_version = replace.version,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

_bzlmod/go_deps_

**What does this PR do? Why is it needed?**

Disable protobuf generation for more modules. Include [the "k8s.io/apiextensions-apiserver" Go module](https://pkg.go.dev/k8s.io/apiextensions-apiserver) in the set for which we disable generation of Protocol Buffers files.

While we're here, correct the `go_deps` "module" tag class attribute documentation. In the deprecation notice introduced in #1456, mention the "gazelle_overrides" tag's "directives" attribute as the suggested target for the customizations to move.

**Which issues(s) does this PR fix?**

Relates to #1451.

**Other notes for review**

I discovered that I couldn't build my Go program that came to rely on this Go module without using the `go_deps` "gazelle_override" tag in my _MODULE.bazel_ file as follows:
```bazel
go_deps.gazelle_override(
    path = "k8s.io/apiextensions-apiserver",
    directives = [
        "gazelle:proto disable",
    ],
)
```
Since the Go module in question is used broadly, I figured that we should include it in the common set of directives, per our original intention stated in #1456.