### PR TITLE
remove circular override hack

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_go", version = "0.38.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -56,10 +56,7 @@ def _report_forbidden_override(module, tag_class, attribute = None):
     return message + _DIRECTIVES_CALL_TO_ACTION
 
 def _fail_on_non_root_overrides(module, tag_class, attribute = None):
-    # TODO: Gazelle and the "rules_go" module depend on each other circularly.
-    #  Tolerate overrides in the latter module until we can update it to no
-    #  longer need them.
-    if module.is_root or module.name == "rules_go":
+    if module.is_root:
         return
 
     tags = getattr(module.tags, tag_class)

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -8,7 +8,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_go", version = "0.38.1")
+bazel_dep(name = "rules_go", version = "0.39.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 


### PR DESCRIPTION
This fixes a hack to `go_deps` which allows overrides from `rules_go` to still work (even when `rules_go` is not the main module.

This provides a dangerous experience by causing potential confusion regarding where an override could be coming from.

Because of that, this hack should be removed, since it is no longer needed with the latest `0.39.1` of rules_go.