### PR TITLE
Support '~' in label repo

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,7 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-~]*$`)
+	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.~-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
 	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_` \"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")

--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,8 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.~-]*$`)
+	// This was taken from https://github.com/bazelbuild/bazel/blob/71fb1e4188b01e582a308cfe4bcbf1c730eded1b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java#L159C1-L164
+	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z0-9_.-][A-Za-z0-9_.~-]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
 	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_` \"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")

--- a/label/label.go
+++ b/label/label.go
@@ -62,7 +62,7 @@ func New(repo, pkg, name string) Label {
 var NoLabel = Label{}
 
 var (
-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-]*$`)
+	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z.-][A-Za-z0-9_.-~]*$`)
 	labelPkgRegexp  = regexp.MustCompile(`^[A-Za-z0-9/._@-]*$`)
 	// This was taken from https://docs.bazel.build/versions/main/build-ref.html#name
 	labelNameRegexp = regexp.MustCompile("^[A-Za-z0-9!%-@^_` \"#$&'()*-+,;<=>?\\[\\]{|}~/.]*$")

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -82,6 +82,8 @@ func TestParse(t *testing.T) {
 		{str: "@go_sdk//:src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt", want: Label{Repo: "go_sdk", Name: "src/cmd/go/testdata/mod/rsc.io_!q!u!o!t!e_v1.5.2.txt"}},
 		{str: "//:a][b", want: Label{Name: "a][b"}},
 		{str: "//:a b", want: Label{Name: "a b"}},
+		{str: "@rules_python~0.0.0~pip~name_dep//:_pkg", want: Label{Repo: "rules_python~0.0.0~pip~name_dep", Name: "_pkg"}},
+		{str: "@rules_python~0.0.0~pip~name//:dep_pkg", want: Label{Repo: "rules_python~0.0.0~pip~name", Name: "dep_pkg"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

Gazelle extension using the label package

**What does this PR do? Why is it needed?**

Relax label validation to support `~` characters in repo names.

**Which issues(s) does this PR fix?**

Fixes #1517

**Other notes for review**

Related change #1508

