### PR TITLE
bzlmod: Add `build_file_generation` to `gazelle_override`

### DIFF
--- a/internal/bzlmod/BUILD.bazel
+++ b/internal/bzlmod/BUILD.bazel
@@ -16,17 +16,11 @@ filegroup(
 )
 
 bzl_library(
-    name = "directives",
-    srcs = ["default_gazelle_overrides.bzl"],
-    visibility = ["//:__subpackages__"],
-)
-
-bzl_library(
     name = "go_deps",
     srcs = ["go_deps.bzl"],
     visibility = ["//:__subpackages__"],
     deps = [
-        ":directives",
+        ":default_gazelle_overrides",
         ":semver",
         "//internal:go_repository",
     ],

--- a/internal/bzlmod/BUILD.bazel
+++ b/internal/bzlmod/BUILD.bazel
@@ -5,7 +5,7 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
-        "directives.bzl",
+        "default_gazelle_overrides.bzl",
         "go_deps.bzl",
         "go_mod.bzl",
         "non_module_deps.bzl",
@@ -17,7 +17,7 @@ filegroup(
 
 bzl_library(
     name = "directives",
-    srcs = ["directives.bzl"],
+    srcs = ["default_gazelle_overrides.bzl"],
     visibility = ["//:__subpackages__"],
 )
 
@@ -58,5 +58,11 @@ bzl_library(
 bzl_library(
     name = "utils",
     srcs = ["utils.bzl"],
+    visibility = ["//:__subpackages__"],
+)
+
+bzl_library(
+    name = "default_gazelle_overrides",
+    srcs = ["default_gazelle_overrides.bzl"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -1,5 +1,9 @@
 visibility("private")
 
+DEFAULT_BUILD_FILE_GENERATION_BY_PATH = {
+    "github.com/google/safetext": "on",
+}
+
 DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/census-instrumentation/opencensus-proto": [
         "gazelle:proto disable",
@@ -9,6 +13,10 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     ],
     "github.com/google/gnostic": [
         "gazelle:proto disable",
+    ],
+    "github.com/google/safetext": [
+        "gazelle:build_file_name BUILD.bazel",
+        "gazelle:build_file_proto_mode disable_global",
     ],
     "github.com/googleapis/gnostic": [
         "gazelle:proto disable",

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -91,14 +91,14 @@ def _synthesize_gazelle_override(module, gazelle_overrides, fixups):
         directives.append(directive)
 
     if directives:
-        _safe_append_directives(module, gazelle_overrides, directives)
+        _safe_update_overrides(module, gazelle_overrides, directives)
         fixups.extend([
             buildozer_cmd("new", "go_deps.gazelle_override", module.path),
             buildozer_cmd("add", "directives", name = module.path, *directives),
             buildozer_cmd("rename", "name", "path", name = module.path),
         ])
 
-def _safe_append_directives(module, gazelle_overrides, directives):
+def _safe_update_overrides(module, gazelle_overrides, directives):
     if module.path in gazelle_overrides:
         existing = gazelle_overrides[module.path].directives
         build_file_generation = gazelle_overrides[module.path].build_file_generation
@@ -458,9 +458,9 @@ _gazelle_override_tag = tag_class(
             `"auto"` mode, Gazelle will run if there is no build file in the Go
             module's root directory.""",
             values = [
-                "on",
                 "auto",
                 "off",
+                "on",
             ],
         ),
         "directives": attr.string_list(

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -63,6 +63,7 @@ go_deps.module(
 use_repo(
     go_deps,
     "com_github_bmatcuk_doublestar_v4",
+    "com_github_google_safetext",
     "com_github_pelletier_go_toml",
     "com_github_stretchr_testify",
     # It is not necessary to list transitive dependencies here, only direct ones.

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -6,7 +6,6 @@ go 1.19
 // Validate go.mod replace directives can be properly used:
 replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
 
-
 require (
 	github.com/bmatcuk/doublestar/v4 v4.0.0
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -6,4 +6,8 @@ go 1.19
 // Validate go.mod replace directives can be properly used:
 replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
 
-require github.com/bmatcuk/doublestar/v4 v4.0.0
+
+require (
+	github.com/bmatcuk/doublestar/v4 v4.0.0
+	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
+)

--- a/tests/bcr/go.sum
+++ b/tests/bcr/go.sum
@@ -1,2 +1,4 @@
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 h1:SJ+NtwL6QaZ21U+IrK7d0gGgpjGGvd2kz+FzTHVzdqI=
+github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC9t8wNnpPdctvtSUOPUUg4SHeE6vR1Ir2hmg=

--- a/tests/bcr/pkg/BUILD.bazel
+++ b/tests/bcr/pkg/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = ["mvs_test.go"],
     deps = [
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
+        "@com_github_google_safetext//yamltemplate",
         "@com_github_pelletier_go_toml//:go-toml",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/tests/bcr/pkg/mvs_test.go
+++ b/tests/bcr/pkg/mvs_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 
 	"github.com/bmatcuk/doublestar/v4"
-	toml "github.com/pelletier/go-toml"
+	"github.com/google/safetext/yamltemplate"
+	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +31,10 @@ func TestReplace(t *testing.T) {
 func TestPatch(t *testing.T) {
 	// a patch is used to add this constant.
 	require.Equal(t, "hello", require.Hello)
+}
+
+func TestBuildFileGeneration(t *testing.T) {
+	// github.com/google/safetext@v0.0.0-20220905092116-b49f7bc46da2 requires overwriting the BUILD
+	// files it provides as well as directives.
+	yamltemplate.HTMLEscapeString("<b>foo</b>")
 }


### PR DESCRIPTION
This attribute is required as `build_file_generation` on `go_repository` doesn't have an equivalent directive.

Fixes https://github.com/bazelbuild/bazel-gazelle/issues/1520