### PR TITLE
Support macros/rules packed within bazel `struct`

### DIFF
--- a/merger/fix.go
+++ b/merger/fix.go
@@ -65,7 +65,15 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 			return
 		}
 
-		functionIdent, ok := ce.X.(*bzl.Ident)
+		var functionIdent *bzl.Ident
+
+		d, ok := ce.X.(*bzl.DotExpr)
+		if ok {
+			functionIdent, ok = d.X.(*bzl.Ident)
+		} else {
+			functionIdent, ok = ce.X.(*bzl.Ident)
+		}
+
 		if !ok {
 			return
 		}

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -47,6 +47,12 @@ func TestFixLoads(t *testing.T) {
 				"maybe",
 			},
 		},
+		{
+			Name: "@bazel_skylib//lib:selects.bzl",
+			Symbols: []string{
+				"selects",
+			},
+		},
 	}
 
 	type testCase struct {
@@ -127,7 +133,7 @@ foo_library(
 		"unused macro": {
 			input: `load("@bar", "magic")
 			load("@foo", "foo_binary")
-	
+
 foo_binary(name = "a")
 `,
 			want: `load("@foo", "foo_binary")
@@ -188,6 +194,26 @@ foo_library(name = "a_lib")
 foo_binary(name = "a")
 
 foo_library(name = "a_lib")
+`,
+		},
+		"struct macro": {
+			input: `selects.config_setting_group(
+    name = "a",
+    match_any = [
+        "//:config_a",
+        "//:config_b",
+    ],
+)
+`,
+			want: `load("@bazel_skylib//lib:selects.bzl", "selects")
+
+selects.config_setting_group(
+    name = "a",
+    match_any = [
+        "//:config_a",
+        "//:config_b",
+    ],
+)
 `,
 		},
 	} {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -713,7 +713,7 @@ func (l *Load) sync() {
 // Rule represents a rule statement within a build file.
 type Rule struct {
 	stmt
-	kind    string
+	kind    bzl.Expr
 	args    []bzl.Expr
 	attrs   map[string]*bzl.AssignExpr
 	private map[string]interface{}
@@ -721,10 +721,11 @@ type Rule struct {
 
 // NewRule creates a new, empty rule with the given kind and name.
 func NewRule(kind, name string) *Rule {
-	call := &bzl.CallExpr{X: &bzl.Ident{Name: kind}}
+	kindIdent := &bzl.Ident{Name: kind}
+	call := &bzl.CallExpr{X: kindIdent}
 	r := &Rule{
 		stmt:    stmt{expr: call},
-		kind:    kind,
+		kind:    kindIdent,
 		attrs:   map[string]*bzl.AssignExpr{},
 		private: map[string]interface{}{},
 	}
@@ -740,16 +741,30 @@ func NewRule(kind, name string) *Rule {
 	return r
 }
 
+func isNestedDotOrIdent(expr bzl.Expr) bool {
+	if _, ok := expr.(*bzl.Ident); ok {
+		return true
+	}
+
+	dot, ok := expr.(*bzl.DotExpr)
+	if !ok {
+		return false
+	}
+
+	return isNestedDotOrIdent(dot.X)
+}
+
 func ruleFromExpr(index int, expr bzl.Expr) *Rule {
 	call, ok := expr.(*bzl.CallExpr)
 	if !ok {
 		return nil
 	}
-	x, ok := call.X.(*bzl.Ident)
-	if !ok {
+
+	kind := call.X
+	if !isNestedDotOrIdent(kind) {
 		return nil
 	}
-	kind := x.Name
+
 	var args []bzl.Expr
 	attrs := make(map[string]*bzl.AssignExpr)
 	for _, arg := range call.List {
@@ -782,12 +797,12 @@ func (r *Rule) ShouldKeep() bool {
 
 // Kind returns the kind of rule this is (for example, "go_library").
 func (r *Rule) Kind() string {
-	return r.kind
+	return bzl.FormatString(r.kind)
 }
 
 // SetKind changes the kind of rule this is.
 func (r *Rule) SetKind(kind string) {
-	r.kind = kind
+	r.kind = &bzl.Ident{Name: kind}
 	r.updated = true
 }
 
@@ -966,7 +981,8 @@ func (r *Rule) sync() {
 	}
 
 	call := r.expr.(*bzl.CallExpr)
-	call.X.(*bzl.Ident).Name = r.kind
+	call.X = r.kind
+
 	if len(r.attrs) > 1 {
 		call.ForceMultiLine = true
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
cmd/gazelle

**What does this PR do? Why is it needed?**
Bazel allows to pack rules or macros within a struct, e.g. convenience interfaces for `select()`
(see https://github.com/bazelbuild/bazel-skylib/blob/main/lib/selects.bzl)

Changes adds support for macros/rules packed within bazel [struct](https://bazel.build/rules/lib/builtins/struct).

Load statements are not able to insert struct symbols. This is needed in case some macros are packaged into a struct like `selects.config_setting_group`
(see https://github.com/bazelbuild/bazel-skylib/blob/main/lib/selects.bzl#L245).

Any would like to generate `selects.config_setting_group` rule with `rule.LoadInfo`:
```go
{
	Name: "@bazel_skylib//lib:selects.bzl",
	Symbols: []string{
		"selects",
	},
},
```
needs a load statement in `BUILD.bazel` of:
```bzl
# GOOD
load("@bazel_skylib//lib:selects.bzl", "selects")
```
but NOT
```bzl
# WRONG
load("@bazel_skylib//lib:selects.bzl", "selects.config_setting_group")
```

**Which issues(s) does this PR fix?**
Fixes #1523 

**Other notes for review**
