### PR TITLE
Option to include diff header line

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -51,6 +51,7 @@ type updateConfig struct {
 	walkMode       walk.Mode
 	patchPath      string
 	patchBuffer    bytes.Buffer
+	diffHeader     string
 	print0         bool
 }
 
@@ -84,6 +85,7 @@ func (ucr *updateConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *conf
 	fs.StringVar(&ucr.mode, "mode", "fix", "print: prints all of the updated BUILD files\n\tfix: rewrites all of the BUILD files in place\n\tdiff: computes the rewrite but then just does a diff")
 	fs.BoolVar(&ucr.recursive, "r", true, "when true, gazelle will update subdirectories recursively")
 	fs.StringVar(&uc.patchPath, "patch", "", "when set with -mode=diff, gazelle will write to a file instead of stdout")
+	fs.StringVar(&uc.diffHeader, "diff-header", "", "when set with -mode=diff, gazelle will include a header line in the given style for each file; currently valid options are 'git' and 'diff'")
 	fs.BoolVar(&uc.print0, "print0", false, "when set with -mode=fix, gazelle will print the names of rewritten files separated with \\0 (NULL)")
 	fs.Var(&gzflag.MultiFlag{Values: &ucr.knownImports}, "known_import", "import path for which external resolution is skipped (can specify multiple times)")
 	fs.StringVar(&ucr.repoConfigPath, "repo_config", "", "file where Gazelle should load repository configuration. Defaults to WORKSPACE.")


### PR DESCRIPTION
`git apply` works for existing files only when there is a "git diff"
header line for each file that begins with `git --diff`. Without this
header line, we get `error: new file ... depends on old contents`.

It may be reasonable to give Gazelle an option to output such lines to
play nice with git.

In general, `diff -u` also outputs a similar header line, although
`patch` does not seem to care as long as the patch conforms to the
unified diff format.
