### PR TITLE
Fix `go:embed` failing to add `embedsrcs` for subdirectories named build

### DIFF
--- a/language/go/embed.go
+++ b/language/go/embed.go
@@ -130,7 +130,7 @@ func newEmbedResolver(dir, rel string, validBuildFileNames []string, pkgRels map
 				return filepath.SkipDir
 			}
 			for _, name := range validBuildFileNames {
-				if _, err := os.Stat(filepath.Join(p, name)); err == nil {
+				if bFileInfo, err := os.Stat(filepath.Join(p, name)); err == nil && !bFileInfo.IsDir() {
 					// Directory already contains a build file.
 					return filepath.SkipDir
 				}

--- a/language/go/testdata/embedsrcs/BUILD.want
+++ b/language/go/testdata/embedsrcs/BUILD.want
@@ -11,6 +11,7 @@ go_library(
         "m_static.txt",
         "n_/static.txt",
         "o_dir/_hidden.txt",
+        "p_dir/build.old/static.txt",
     ],
     importpath = "example.com/repo/embedsrcs",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/embedsrcs/embedsrcs.go
+++ b/language/go/testdata/embedsrcs/embedsrcs.go
@@ -2,5 +2,5 @@ package embedsrcs
 
 import "embed"
 
-//go:embed *m_* n_/* all:o*
+//go:embed *m_* n_/* p_dir/* all:o*
 var fs embed.FS

--- a/language/go/testdata/embedsrcs/p_dir/build.old/static.txt
+++ b/language/go/testdata/embedsrcs/p_dir/build.old/static.txt
@@ -1,0 +1,2 @@
+# p_dir/build.old/static.txt should be embedded because while the subdirectory is named `build.old`,
+# it is a directory and not an actual BUILD file.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> language/go

**What does this PR do? Why is it needed?**

A bug  presently exists in `language/go/embed.go` where subdirectories with the name  `build` , e.g. `some/path/build` are being recognized as BUILD files, thereby resulting in those directories being skipped by the embed resolver. Please see more details in the linked issue.

To fix the issue, we only consider a path a `BUILD` or `BUILD.BAZEL` file if they are in fact not a directory.

**Which issues(s) does this PR fix?**

Fixes #1538
