### PR TITLE
resolve: Add a resolve_regexp directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -921,6 +921,30 @@ The following directives are recognized:
 |   # gazelle:resolve proto go foo/foo.proto //foo:foo_go_proto                              |
 |                                                                                            |
 +---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:resolve_regexp ...`                    | n/a                                    |
++---------------------------------------------------+----------------------------------------+
+| Specifies an explicit mapping from an import regex to a label for                         |
+| `Dependency resolution`_. The format for a resolve directive is:                           |
+|                                                                                            |
+| ``# gazelle:resolve source-lang import-lang import-string-regex label``                          |
+|                                                                                            |
+| * ``source-lang`` is the language of the source code being imported.                       |
+| * ``import-lang`` is the language importing the library. This is usually                   |
+|   the same as ``source-lang`` but may differ with generated code. For                      |
+|   example, when resolving dependencies for a ``go_proto_library``,                         |
+|   ``source-lang`` would be ``"proto"`` and ``import-lang`` would be ``"go"``.              |
+|   ``import-lang`` may be omitted if it is the same as ``source-lang``.                     |
+| * ``import-string-regex`` is the regex used in source code to import a library.                 |
+| * ``label`` is the Bazel label that Gazelle should write in ``deps``.                      |
+|                                                                                            |
+| For example:                                                                               |
+|                                                                                            |
+| .. code:: bzl                                                                              |
+|                                                                                            |
+|   # gazelle:resolve_regexp go example.com/.* //foo:go_default_library                            |
+|   # gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto                              |
+|                                                                                            |
++---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:go_visibility label`            | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
 | By default, internal packages are only visible to its siblings. This directive adds a label|

--- a/README.rst
+++ b/README.rst
@@ -934,7 +934,8 @@ The following directives are recognized:
 |   example, when resolving dependencies for a ``go_proto_library``,                         |
 |   ``source-lang`` would be ``"proto"`` and ``import-lang`` would be ``"go"``.              |
 |   ``import-lang`` may be omitted if it is the same as ``source-lang``.                     |
-| * ``import-string-regex`` is the regex used in source code to import a library.                 |
+| * ``import-string-regex`` is the regex applied to the import in the source code.           |
+|   If it matches, that import will be resolved to the label specified below.
 | * ``label`` is the Bazel label that Gazelle should write in ``deps``.                      |
 |                                                                                            |
 | For example:                                                                               |

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -616,6 +616,46 @@ go_proto_library(
 )
 `,
 		}, {
+			desc: "proto_override_regexp",
+			index: []buildFile{{
+				rel: "",
+				content: `
+# gazelle:resolve_regexp proto go google/rpc/.*\.proto :good
+
+proto_library(
+    name = "bad_proto",
+    srcs = ["google/rpc/status.proto"],
+)
+
+go_proto_library(
+    name = "bad_go_proto",
+    proto = ":bad_proto",
+    importpath = "bad",
+)
+`,
+			}},
+			old: buildFile{
+				rel: "test",
+				content: `
+go_proto_library(
+    name = "dep_go_proto",
+    importpath = "test",
+    _imports = [
+		"google/rpc/status.proto",
+		"google/rpc/status1.proto",
+		"google/rpc/status2.proto",
+	],
+)
+`,
+			},
+			want: `
+go_proto_library(
+    name = "dep_go_proto",
+    importpath = "test",
+    deps = ["//:good"],
+)
+`,
+		}, {
 			desc: "proto_index",
 			index: []buildFile{{
 				rel: "sub",

--- a/resolve/config.go
+++ b/resolve/config.go
@@ -18,6 +18,7 @@ package resolve
 import (
 	"flag"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -37,6 +38,13 @@ func FindRuleWithOverride(c *config.Config, imp ImportSpec, lang string) (label.
 			return o.dep, true
 		}
 	}
+	for i := len(rc.regexpOverrides) - 1; i >= 0; i-- {
+		o := rc.regexpOverrides[i]
+		if o.matches(imp, lang) {
+			return o.dep, true
+		}
+	}
+
 	return label.NoLabel, false
 }
 
@@ -52,8 +60,22 @@ func (o overrideSpec) matches(imp ImportSpec, lang string) bool {
 		(o.lang == "" || o.lang == lang)
 }
 
+type regexpOverrideSpec struct {
+	ImpLang  string
+	ImpRegex *regexp.Regexp
+	lang     string
+	dep      label.Label
+}
+
+func (o regexpOverrideSpec) matches(imp ImportSpec, lang string) bool {
+	return imp.Lang == o.ImpLang &&
+		o.ImpRegex.MatchString(imp.Imp) &&
+		(o.lang == "" || o.lang == lang)
+}
+
 type resolveConfig struct {
-	overrides []overrideSpec
+	overrides       []overrideSpec
+	regexpOverrides []regexpOverrideSpec
 }
 
 const resolveName = "_resolve"
@@ -71,13 +93,14 @@ func (*Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config)
 func (*Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
 
 func (*Configurer) KnownDirectives() []string {
-	return []string{"resolve"}
+	return []string{"resolve", "resolve_regexp"}
 }
 
 func (*Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	rc := getResolveConfig(c)
 	rcCopy := &resolveConfig{
-		overrides: rc.overrides[:len(rc.overrides):len(rc.overrides)],
+		overrides:       rc.overrides[:len(rc.overrides):len(rc.overrides)],
+		regexpOverrides: rc.regexpOverrides[:len(rc.regexpOverrides):len(rc.regexpOverrides)],
 	}
 
 	if f != nil {
@@ -107,6 +130,42 @@ func (*Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 				}
 				o.dep = o.dep.Abs("", rel)
 				rcCopy.overrides = append(rcCopy.overrides, o)
+			} else if d.Key == "resolve_regexp" {
+				parts := strings.Fields(d.Value)
+				o := regexpOverrideSpec{}
+				var lbl string
+				if len(parts) == 3 {
+					o.ImpLang = parts[0]
+					var err error
+					o.ImpRegex, err = regexp.Compile(parts[1])
+					if err != nil {
+						log.Printf("gazelle:resolve_exp %s: %v", d.Value, err)
+						continue
+					}
+					lbl = parts[2]
+				} else if len(parts) == 4 {
+					o.ImpLang = parts[0]
+					o.lang = parts[1]
+					var err error
+					o.ImpRegex, err = regexp.Compile(parts[2])
+					if err != nil {
+						log.Printf("gazelle:resolve_exp %s: %v", d.Value, err)
+						continue
+					}
+
+					lbl = parts[3]
+				} else {
+					log.Printf("could not parse directive: %s\n\texpected gazelle:resolve_regexp source-language [import-language] import-string-regex label", d.Value)
+					continue
+				}
+				var err error
+				o.dep, err = label.Parse(lbl)
+				if err != nil {
+					log.Printf("gazelle:resolve_regexp %s: %v", d.Value, err)
+					continue
+				}
+				o.dep = o.dep.Abs("", rel)
+				rcCopy.regexpOverrides = append(rcCopy.regexpOverrides, o)
 			}
 		}
 	}


### PR DESCRIPTION
Similar to the resolve directive, resolve_regexp will match the import string against a regex instead of a direct string match. This is useful when matching protos which are part of single rule.

Syntax is the same as the resolve directive except that the import string can be a regex.

ie: 
```
# gazelle:resolve_regexp py foo\..* //foo:py_lib                            
# gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto   
```

Partially addresses #817

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

resolve/

**Other notes for review**

I didn't add tests yet since I wasn't sure if this implementation agreeable. If we think that this is something that is upstreamable, I will add tests.

Thanks!