### PR TITLE
Add default directives for github.com/envoyproxy/protoc-gen-validate

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -1,12 +1,16 @@
 visibility("private")
 
 DEFAULT_BUILD_FILE_GENERATION_BY_PATH = {
+    "github.com/envoyproxy/protoc-gen-validate": "on",
     "github.com/google/safetext": "on",
 }
 
 DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/census-instrumentation/opencensus-proto": [
         "gazelle:proto disable",
+    ],
+    "github.com/envoyproxy/protoc-gen-validate": [
+        "gazelle:build_file_name BUILD.bazel",
     ],
     "github.com/gogo/protobuf": [
         "gazelle:proto disable",

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -63,6 +63,7 @@ use_repo(
     go_deps,
     "com_github_bmatcuk_doublestar_v4",
     "com_github_datadog_sketches_go",
+    "com_github_envoyproxy_protoc_gen_validate",
     "com_github_google_safetext",
     "com_github_stretchr_testify",
     # It is not necessary to list transitive dependencies here, only direct ones.

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -7,7 +7,8 @@ go 1.19
 replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
 
 require (
-	github.com/bmatcuk/doublestar/v4 v4.0.0
-	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
 	github.com/DataDog/sketches-go v1.4.1
+	github.com/bmatcuk/doublestar/v4 v4.0.0
+	github.com/envoyproxy/protoc-gen-validate v1.0.1
+	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
 )

--- a/tests/bcr/go.sum
+++ b/tests/bcr/go.sum
@@ -3,6 +3,8 @@ github.com/DataDog/sketches-go v1.4.1/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/envoyproxy/protoc-gen-validate v1.0.1 h1:kt9FtLiooDc0vbwTLhdg3dyNX1K9Qwa1EK9LcD4jVUQ=
+github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/tests/bcr/pkg/BUILD.bazel
+++ b/tests/bcr/pkg/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     deps = [
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_datadog_sketches_go//ddsketch",
+        "@com_github_envoyproxy_protoc_gen_validate//validate",
         "@com_github_google_safetext//yamltemplate",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/tests/bcr/pkg/mvs_test.go
+++ b/tests/bcr/pkg/mvs_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/google/safetext/yamltemplate"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 )
 
 func TestReplace(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

Default directives

**What does this PR do? Why is it needed?**

Sets default build file generation and default directives for `github.com/envoyproxy/protoc-gen-validate`

**Which issues(s) does this PR fix?**

Fixes an issue when importing `github.com/envoyproxy/protoc-gen-validate` as a go module. This project is built with Bazel. The current (pre-fix) behaviour is for the WORKSPACE file in this project to be unaltered, which causes an error when it is used as a pure go module.

**Other notes for review**

The test case feels a bit light, but it does validate the fix