### PR TITLE
language/go: Emit apparent repo name of rules_go in select keys

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//config",
         "//internal/wspace",
         "//testtools",
+        "@com_github_google_go_cmp//cmp",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     deps = [
         "//config",
         "//flag",
+        "//internal/module",
         "//internal/version",
         "//label",
         "//language",

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -382,11 +382,11 @@ func saveCgo(info *fileInfo, rel string, cg *ast.CommentGroup) error {
 //
 // For example, the following string:
 //
-//     a b:"c d" 'e''f'  "g\""
+//	a b:"c d" 'e''f'  "g\""
 //
 // Would be parsed as:
 //
-//     []string{"a", "b:c d", "ef", `g"`}
+//	[]string{"a", "b:c d", "ef", `g"`}
 //
 // Copied from go/build.splitQuoted
 func splitQuoted(s string) (r []string, err error) {
@@ -540,7 +540,7 @@ func matchesOS(os, value string) bool {
 // a given platform.
 //
 // The first few arguments describe the platform. genericTags is the set
-// of build tags that are true on all platforms. os and arch are the platform
+// of build tags that are true on all platformConstraints. os and arch are the platform
 // GOOS and GOARCH strings. If os or arch is empty, checkConstraints will
 // return false in the presence of OS and architecture constraints, even
 // if they are negated.

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -66,6 +66,7 @@ use_repo(
     "com_github_envoyproxy_protoc_gen_validate",
     "com_github_google_safetext",
     "com_github_stretchr_testify",
+    "org_golang_x_sys",
     # It is not necessary to list transitive dependencies here, only direct ones.
     # "in_gopkg_yaml_v3",
 )

--- a/tests/bcr/go.mod
+++ b/tests/bcr/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.0.0
 	github.com/envoyproxy/protoc-gen-validate v1.0.1
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
+	golang.org/x/sys v0.8.0
 )

--- a/tests/bcr/go.sum
+++ b/tests/bcr/go.sum
@@ -14,6 +14,8 @@ github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2/go.mod h1:Tv1PlzqC
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/tests/bcr/pkg/BUILD.bazel
+++ b/tests/bcr/pkg/BUILD.bazel
@@ -1,8 +1,9 @@
-load("@rules_go//go:def.bzl", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "pkg_test",
     srcs = ["mvs_test.go"],
+    embed = [":pkg"],
     deps = [
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_datadog_sketches_go//ddsketch",
@@ -10,4 +11,50 @@ go_test(
         "@com_github_google_safetext//yamltemplate",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
+)
+
+go_library(
+    name = "pkg",
+    srcs = [
+        "platform_lib_unix.go",
+        "platform_lib_windows.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-gazelle/tests/bcr/pkg",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/tests/bcr/pkg/mvs_test.go
+++ b/tests/bcr/pkg/mvs_test.go
@@ -33,3 +33,7 @@ func TestBuildFileGeneration(t *testing.T) {
 func TestGeneratedFilesPreferredOverProtos(t *testing.T) {
 	_, _ = ddsketch.NewDefaultDDSketch(0.01)
 }
+
+func TestPlatformDependentDep(t *testing.T) {
+	PlatformDependentFunction()
+}

--- a/tests/bcr/pkg/platform_lib_unix.go
+++ b/tests/bcr/pkg/platform_lib_unix.go
@@ -1,0 +1,10 @@
+//go:build unix
+
+package pkg
+
+import "golang.org/x/sys/unix"
+
+func PlatformDependentFunction() string {
+	home, _ := unix.Getenv("HOME")
+	return home
+}

--- a/tests/bcr/pkg/platform_lib_windows.go
+++ b/tests/bcr/pkg/platform_lib_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package pkg
+
+func PlatformDependentFunction() string {
+	return "C:\\Users\\gopher"
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

The constraint labels emitted as `select` keys now use the apparent name of the `rules_go` repository when using Bzlmod, with a fallback to `io_bazel_rules_go` if the `rules_go` module is not a declared `bazel_dep`.

