### PR TITLE
Make known imports package vars public

### DIFF
--- a/language/proto/BUILD.bazel
+++ b/language/proto/BUILD.bazel
@@ -10,7 +10,7 @@ known_imports(
     key = 0,
     package = "proto",
     value = 1,
-    var = "knownImports",
+    var = "KnownImports",
 )
 
 known_imports(
@@ -20,7 +20,7 @@ known_imports(
     key = 0,
     package = "proto",
     value = 3,
-    var = "knownProtoImports",
+    var = "KnownProtoImports",
 )
 
 known_imports(
@@ -30,7 +30,7 @@ known_imports(
     key = 2,
     package = "proto",
     value = 3,
-    var = "knownGoProtoImports",
+    var = "KnownGoProtoImports",
 )
 
 go_library(

--- a/language/proto/known_go_imports.go
+++ b/language/proto/known_go_imports.go
@@ -5,7 +5,7 @@ package proto
 
 import "github.com/bazelbuild/bazel-gazelle/label"
 
-var knownGoProtoImports = map[string]label.Label{
+var KnownGoProtoImports = map[string]label.Label{
 
 	"github.com/golang/protobuf/ptypes/any":                                                        label.Label{Repo: "io_bazel_rules_go", Pkg: "proto/wkt", Name: "any_go_proto"},
 	"google.golang.org/genproto/protobuf/api":                                                      label.Label{Repo: "io_bazel_rules_go", Pkg: "proto/wkt", Name: "api_go_proto"},

--- a/language/proto/known_imports.go
+++ b/language/proto/known_imports.go
@@ -5,7 +5,7 @@ package proto
 
 import "github.com/bazelbuild/bazel-gazelle/label"
 
-var knownImports = map[string]label.Label{
+var KnownImports = map[string]label.Label{
 
 	"google/protobuf/any.proto":                                                                              label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "any_proto"},
 	"google/protobuf/api.proto":                                                                              label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "api_proto"},

--- a/language/proto/known_proto_imports.go
+++ b/language/proto/known_proto_imports.go
@@ -5,7 +5,7 @@ package proto
 
 import "github.com/bazelbuild/bazel-gazelle/label"
 
-var knownProtoImports = map[string]label.Label{
+var KnownProtoImports = map[string]label.Label{
 
 	"google/protobuf/any.proto":                                                                              label.Label{Repo: "io_bazel_rules_go", Pkg: "proto/wkt", Name: "any_go_proto"},
 	"google/protobuf/api.proto":                                                                              label.Label{Repo: "io_bazel_rules_go", Pkg: "proto/wkt", Name: "api_go_proto"},

--- a/language/proto/resolve.go
+++ b/language/proto/resolve.go
@@ -118,7 +118,7 @@ func resolveProto(c *config.Config, ix *resolve.RuleIndex, r *rule.Rule, imp str
 		return l, nil
 	}
 
-	if l, ok := knownImports[imp]; ok && pc.Mode.ShouldUseKnownImports() {
+	if l, ok := KnownImports[imp]; ok && pc.Mode.ShouldUseKnownImports() {
 		if l.Equal(from) {
 			return label.NoLabel, errSkipImport
 		} else {
@@ -161,7 +161,7 @@ func (*protoLang) CrossResolve(c *config.Config, ix *resolve.RuleIndex, imp reso
 	}
 	pc := GetProtoConfig(c)
 	if imp.Lang == "proto" && pc.Mode.ShouldUseKnownImports() {
-		if l, ok := knownProtoImports[imp.Imp]; ok {
+		if l, ok := KnownProtoImports[imp.Imp]; ok {
 			return []resolve.FindResult{{Label: l}}
 		}
 	}
@@ -186,7 +186,7 @@ func (*protoLang) CrossResolve(c *config.Config, ix *resolve.RuleIndex, imp reso
 		case "google.golang.org/grpc":
 			return []resolve.FindResult{{Label: label.New("org_golang_google_grpc", "", "go_default_library")}}
 		}
-		if l, ok := knownGoProtoImports[imp.Imp]; ok {
+		if l, ok := KnownGoProtoImports[imp.Imp]; ok {
 			return []resolve.FindResult{{Label: l}}
 		}
 	}


### PR DESCRIPTION
Gazelle has a "known imports" feature that operates during the resolve phase. First, the overrides are checked.  If an override is not found, known imports are checked.  If a known import is not found, the index is checked.

These "known import" maps are hardcoded using internal codegen tools that read @com_google_protobuf and @go_googleapis.

There is no way to opt-out of the known imports for "well known" types from @com_google_protobuf and @go_googleapis in most indexing modes.  

This makes it not possible to use gazelle to index the protos in those repositories (in file mode for example) because the resolve data should come from the index. In that case, override rules don't make sense (one would need to pre-index the repo being indexed!); the hardcoded ones correspond to -mode=package so they are not appropriate for file mode (or other modes).

In theory the unsafe package with go:linkname would make it technically possible to override these private variables from other packages, but apparently the compiler is inlining these variables because go:linkname does not work. 

This PR makes the known imports related variable public so gazelle extension authors have full control over the known imports and can set it at initialization time. In the case described above, an empty known import map is the correct one to resolve from the index.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
