### PR TITLE
feat(bzlmod): support archive_override in go_deps

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -45,6 +45,10 @@ def _fail_on_non_root_overrides(module_ctx, module, tag_class):
             module_name = module.name,
         ))
 
+def _fail_on_duplicate_overrides(path, module_name, overrides):
+    if path in overrides:
+        fail("Multiple overrides defined for Go module path \"{}\" in module \"{}\".".format(path, module_name))
+
 def _check_directive(directive):
     if directive.startswith("gazelle:") and " " in directive and not directive[len("gazelle:"):][0].isspace():
         return
@@ -132,6 +136,7 @@ def _go_deps_impl(module_ctx):
     replace_map = {}
     bazel_deps = {}
 
+    archive_overrides = {}
     gazelle_overrides = {}
     module_overrides = {}
 
@@ -159,8 +164,7 @@ def _go_deps_impl(module_ctx):
 
         _fail_on_non_root_overrides(module_ctx, module, "gazelle_override")
         for gazelle_override_tag in module.tags.gazelle_override:
-            if gazelle_override_tag.path in gazelle_overrides:
-                fail("Multiple overrides defined for Go module path \"{}\" in module \"{}\".".format(gazelle_override_tag.path, module.name))
+            _fail_on_duplicate_overrides(gazelle_override_tag.path, module.name, gazelle_overrides)
             for directive in gazelle_override_tag.directives:
                 _check_directive(directive)
 
@@ -169,13 +173,26 @@ def _go_deps_impl(module_ctx):
                 build_file_generation = gazelle_override_tag.build_file_generation,
             )
 
+
+        # A user is not able to specify both an archive override and a module override for the
+        # same module. This is checked by calling _fail_on_duplicate_overrides() for each override
         _fail_on_non_root_overrides(module_ctx, module, "module_override")
         for module_override_tag in module.tags.module_override:
-            if module_override_tag.path in module_overrides:
-                fail("Multiple overrides defined for Go module path \"{}\" in module \"{}\".".format(module_override_tag.path, module.name))
+            _fail_on_duplicate_overrides(module_override_tag.path, module.name, module_overrides)
+            _fail_on_duplicate_overrides(module_override_tag.path, module.name, archive_overrides)
             module_overrides[module_override_tag.path] = struct(
                 patches = module_override_tag.patches,
                 patch_strip = module_override_tag.patch_strip,
+            )
+
+        _fail_on_non_root_overrides(module, "archive_override")
+        for archive_override_tag in module.tags.archive_override:
+            _fail_on_duplicate_overrides(archive_override_tag.path, module.name, module_overrides)
+            _fail_on_duplicate_overrides(archive_override_tag.path, module.name, archive_overrides)
+            archive_overrides[archive_override_tag.path] = struct(
+                urls = archive_override_tag.urls,
+                sha256 = archive_override_tag.sha256,
+                strip_prefix = archive_override_tag.strip_prefix,
             )
 
         if len(module.tags.from_file) > 1:
@@ -296,7 +313,7 @@ def _go_deps_impl(module_ctx):
 
     for path, bazel_dep in bazel_deps.items():
         # We can't apply overrides to Bazel dependencies and thus fall back to using the Go module.
-        if path in gazelle_overrides or path in module_overrides or path in replace_map:
+        if path in archive_overrides or path in gazelle_overrides or path in module_overrides or path in replace_map:
             continue
 
         # Only use the Bazel module if it is at least as high as the required Go module version.
@@ -332,17 +349,30 @@ def _go_deps_impl(module_ctx):
             root_module_direct_dev_deps.pop(_repo_name(path), default = None)
             continue
 
-        go_repository(
-            name = module.repo_name,
-            importpath = path,
-            sum = _get_sum_from_module(path, module, sums),
-            replace = getattr(module, "replace", None),
-            version = "v" + module.raw_version,
-            build_directives = _get_directives(path, gazelle_overrides),
-            build_file_generation = _get_build_file_generation(path, gazelle_overrides),
-            patches = _get_patches(path, module_overrides),
-            patch_args = _get_patch_args(path, module_overrides),
-        )
+        go_repository_args = {
+            "name": module.repo_name,
+            "importpath": path,
+            "build_directives": _get_directives(path, gazelle_overrides),
+            "build_file_generation": _get_build_file_generation(path, gazelle_overrides),
+            "patches": _get_patches(path, module_overrides),
+            "patch_args": _get_patch_args(path, module_overrides),
+        }
+
+        archive_override = archive_overrides.get(path)
+        if archive_override:
+            go_repository_args.update({
+                "urls": archive_override.urls,
+                "strip_prefix": archive_override.strip_prefix,
+                "sha256": archive_override.sha256,
+            })
+        else:
+            go_repository_args.update({
+                "sum": _get_sum_from_module(path, module, sums),
+                "replace": getattr(module, "replace", None),
+                "version": "v" + module.raw_version,
+            })
+
+        go_repository(**go_repository_args)
 
     # Create a synthetic WORKSPACE file that lists all Go repositories created
     # above and contains all the information required by Gazelle's -repo_config
@@ -428,6 +458,33 @@ _module_tag = tag_class(
     },
 )
 
+_archive_override_tag = tag_class(
+    attrs = {
+        "path": attr.string(
+            doc = """The Go module path for the repository to be overridden.
+
+            This module path must be defined by other tags in this
+            extension within this Bazel module.""",
+            mandatory = True,
+        ),
+        "urls": attr.string_list(
+            doc = """A list of HTTP(S) URLs where an archive containing the project can be
+            downloaded. Bazel will attempt to download from the first URL; the others
+            are mirrors.""",
+        ),
+        "strip_prefix": attr.string(
+            doc = """If the repository is downloaded via HTTP (`urls` is set), this is a
+            directory prefix to strip. See [`http_archive.strip_prefix`].""",
+        ),
+        "sha256": attr.string(
+            doc = """If the repository is downloaded via HTTP (`urls` is set), this is the
+            SHA-256 sum of the downloaded archive. When set, Bazel will verify the archive
+            against this sum before extracting it.""",
+        ),
+    },
+    doc = "Override the default source location on a given Go module in this extension.",
+)
+
 _gazelle_override_tag = tag_class(
     attrs = {
         "path": attr.string(
@@ -485,6 +542,7 @@ _module_override_tag = tag_class(
 go_deps = module_extension(
     _go_deps_impl,
     tag_classes = {
+        "archive_override": _archive_override_tag,
         "config": _config_tag,
         "from_file": _from_file_tag,
         "gazelle_override": _gazelle_override_tag,

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -48,6 +48,22 @@ go_deps.module_override(
     path = "github.com/stretchr/testify",
 )
 
+# Test an archive override from a known archive.
+go_deps.gazelle_override(
+    directives = [
+        "gazelle:go_naming_convention go_default_library",
+    ],
+    path = "github.com/bazelbuild/buildtools",
+)
+go_deps.archive_override(
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.1.2.tar.gz",
+    ],
+    strip_prefix = "buildtools-6.1.2",
+    path = "github.com/bazelbuild/buildtools",
+    sha256 = "977a0bd4593c8d4c8f45e056d181c35e48aa01ad4f8090bdb84f78dca42f47dc",
+)
+
 # Transitive dependencies have to be listed here explicitly.
 go_deps.module(
     indirect = True,
@@ -71,6 +87,7 @@ go_deps.module(
 )
 use_repo(
     go_deps,
+    "com_github_bazelbuild_buildtools",
     "com_github_bmatcuk_doublestar_v4",
     "com_github_datadog_sketches_go",
     "com_github_envoyproxy_protoc_gen_validate",

--- a/tests/bcr/pkg/BUILD.bazel
+++ b/tests/bcr/pkg/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     deps = [
         "//pkg/data",
         "@circl//dh/x25519",
+        "@com_github_bazelbuild_buildtools//labels:go_default_library",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_datadog_sketches_go//ddsketch",
         "@com_github_envoyproxy_protoc_gen_validate//validate",

--- a/tests/bcr/pkg/pkg_test.go
+++ b/tests/bcr/pkg/pkg_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/bazelbuild/bazel-gazelle/tests/bcr/pkg/data"
+	"github.com/bazelbuild/buildtools/labels"
 	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/cloudflare/circl/dh/x25519"
@@ -66,4 +67,9 @@ func TestBazelDepUsedAsGoDep(t *testing.T) {
 	_, err := rand.Read(secret[:])
 	require.NoError(t, err)
 	x25519.KeyGen(&public, &secret)
+}
+
+func TestArchiveOverrideUsed(t *testing.T) {
+	label := labels.Parse("@com_github_bazelbuild_buildtools//labels:labels")
+	require.NotEmpty(t, label)
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

bzlmod/go_deps

**What does this PR do? Why is it needed?**

This adds the ability to specify a custom archive to a `go_deps` repository.

It can be used as part of the new tag `archive_override`:

```
go_deps.archive_override(
    urls = [
        "https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.1.2.tar.gz",
    ],
    strip_prefix = "buildtools-6.1.2",
    path = "github.com/bazelbuild/buildtools",
    sha256 = "977a0bd4593c8d4c8f45e056d181c35e48aa01ad4f8090bdb84f78dca42f47dc",
)
```

**Which issues(s) does this PR fix?**

Fixes #1560

**Other notes for review**

Tested in Uber's Go Monorepo, by overwriting to a bad URL:
```
Repository rule go_download_sdk_rule defined at:
  /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/rules_go~0.41.0/go/private/sdk.bzl:137:39: in <toplevel>
ERROR: /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/rules_go~0.41.0/proto/BUILD.bazel:64:19: @rules_go~0.41.0//proto:gogoslick_proto depends on @gazelle~override~go_deps~com_github_gogo_protobuf//proto:go_default_library in repository @gazelle~override~go_deps~com_github_gogo_protobuf which failed to fetch. no such package '@gazelle~override~go_deps~com_github_gogo_protobuf//proto': java.io.IOException: Error downloading [https://github.com/BADURL/archive/refs/tagggs/v1.3.2.zip] to /home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/gazelle~override~go_deps~com_github_gogo_protobuf/temp13642560055428541504/v1.3.2.zip: GET returned 404 Not Found
ERROR: Analysis of target '...' failed; build aborted: 
```
Tested failure on duplicate overrides:
```
ERROR: Traceback (most recent call last):
        File "/home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/gazelle~override/internal/bzlmod/go_deps.bzl", line 196, column 27, in _go_deps_impl
                _process_overrides(module, "archive_override", archive_overrides, _process_archive_override, module_overrides)
        File "/home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/gazelle~override/internal/bzlmod/go_deps.bzl", line 103, column 41, in _process_overrides
                _fail_on_duplicate_overrides(override_tag.path, module.name, additional_overrides)
        File "/home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/gazelle~override/internal/bzlmod/go_deps.bzl", line 44, column 13, in _fail_on_duplicate_overrides
                fail("Multiple overrides defined for Go module path \"{}\" in module \"{}\".".format(path, module_name))
Error in fail: Multiple overrides defined for Go module path "github.com/gogo/protobuf" in module "go-code".
```