### PR TITLE
Output test errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,4 +6,5 @@ build:ci --sandbox_debug
 build:ci --spawn_strategy=standalone
 build:ci --genrule_strategy=standalone
 test:ci --test_strategy=standalone
-test:ci --test_output=errors
+
+test --test_output=errors


### PR DESCRIPTION
Let Bazel always print out test errors, so we don't need to open the log when tests fail