### PR TITLE
Implement Merger interface

### DIFF
--- a/rule/merge_test.go
+++ b/rule/merge_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 func TestMergeRules(t *testing.T) {
@@ -32,6 +33,117 @@ func TestMergeRules(t *testing.T) {
 		if dst.PrivateAttr(privateAttrKey).(string) != privateAttrVal {
 			t.Fatalf("private attributes are merged: got %v; want %s",
 				dst.PrivateAttr(privateAttrKey), privateAttrVal)
+		}
+	})
+}
+
+func TestMergeRules_WithSortedStringAttr(t *testing.T) {
+	t.Run("sorted string attributes are merged to empty rule", func(t *testing.T) {
+		src := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrKey := "deps"
+		sortedStringAttrVal := rule.SortedStrings{"@qux", "//foo:bar", "//foo:baz"}
+		src.SetAttr(sortedStringAttrKey, sortedStringAttrVal)
+		dst := rule.NewRule("go_library", "go_default_library")
+		rule.MergeRules(src, dst, map[string]bool{}, "")
+
+		valExpr, ok := dst.Attr(sortedStringAttrKey).(*bzl.ListExpr)
+		if !ok {
+			t.Fatalf("sorted string attributes invalid: got %v; want *bzl.ListExpr",
+				dst.Attr(sortedStringAttrKey))
+		}
+
+		expected := []string{"//foo:bar", "//foo:baz", "@qux"}
+		for i, v := range valExpr.List {
+			if v.(*bzl.StringExpr).Value != expected[i] {
+				t.Fatalf("sorted string attributes are merged: got %v; want %v",
+					v.(*bzl.StringExpr).Value, expected[i])
+			}
+		}
+	})
+
+	t.Run("sorted string attributes are merged to non-empty rule", func(t *testing.T) {
+		src := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrKey := "deps"
+		sortedStringAttrVal := rule.SortedStrings{"@qux", "//foo:bar", "//foo:baz"}
+		src.SetAttr(sortedStringAttrKey, sortedStringAttrVal)
+		dst := rule.NewRule("go_library", "go_default_library")
+		dst.SetAttr(sortedStringAttrKey, rule.SortedStrings{"@qux", "//foo:bar", "//bacon:eggs"})
+		rule.MergeRules(src, dst, map[string]bool{"deps": true}, "")
+
+		valExpr, ok := dst.Attr(sortedStringAttrKey).(*bzl.ListExpr)
+		if !ok {
+			t.Fatalf("sorted string attributes are merged: got %v; want *bzl.ListExpr",
+				dst.Attr(sortedStringAttrKey))
+		}
+
+		expected := []string{"//foo:bar", "//foo:baz", "@qux"}
+		for i, v := range valExpr.List {
+			if v.(*bzl.StringExpr).Value != expected[i] {
+				t.Fatalf("sorted string attributes are merged: got %v; want %v",
+					v.(*bzl.StringExpr).Value, expected[i])
+			}
+		}
+	})
+	t.Run("delete existing sorted strings", func(t *testing.T) {
+		src := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrKey := "deps"
+		dst := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrVal := rule.SortedStrings{"@qux", "//foo:bar", "//foo:baz"}
+		dst.SetAttr(sortedStringAttrKey, sortedStringAttrVal)
+		rule.MergeRules(src, dst, map[string]bool{"deps": true}, "")
+
+		if dst.Attr(sortedStringAttrKey) != nil {
+			t.Fatalf("delete existing sorted strings: got %v; want nil",
+				dst.Attr(sortedStringAttrKey))
+		}
+	})
+}
+
+func TestMergeRules_WithUnsortedStringAttr(t *testing.T) {
+	t.Run("unsorted string attributes are merged to empty rule", func(t *testing.T) {
+		src := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrKey := "deps"
+		sortedStringAttrVal := rule.UnsortedStrings{"@qux", "//foo:bar", "//foo:baz"}
+		src.SetAttr(sortedStringAttrKey, sortedStringAttrVal)
+		dst := rule.NewRule("go_library", "go_default_library")
+		rule.MergeRules(src, dst, map[string]bool{}, "")
+
+		valExpr, ok := dst.Attr(sortedStringAttrKey).(*bzl.ListExpr)
+		if !ok {
+			t.Fatalf("sorted string attributes invalid: got %v; want *bzl.ListExpr",
+				dst.Attr(sortedStringAttrKey))
+		}
+
+		expected := []string{"@qux", "//foo:bar", "//foo:baz"}
+		for i, v := range valExpr.List {
+			if v.(*bzl.StringExpr).Value != expected[i] {
+				t.Fatalf("unsorted string attributes are merged: got %v; want %v",
+					v.(*bzl.StringExpr).Value, expected[i])
+			}
+		}
+	})
+
+	t.Run("unsorted string attributes are merged to non-empty rule", func(t *testing.T) {
+		src := rule.NewRule("go_library", "go_default_library")
+		sortedStringAttrKey := "deps"
+		sortedStringAttrVal := rule.UnsortedStrings{"@qux", "//foo:bar", "//foo:baz"}
+		src.SetAttr(sortedStringAttrKey, sortedStringAttrVal)
+		dst := rule.NewRule("go_library", "go_default_library")
+		dst.SetAttr(sortedStringAttrKey, rule.UnsortedStrings{"@qux", "//foo:bar", "//bacon:eggs"})
+		rule.MergeRules(src, dst, map[string]bool{"deps": true}, "")
+
+		valExpr, ok := dst.Attr(sortedStringAttrKey).(*bzl.ListExpr)
+		if !ok {
+			t.Fatalf("unsorted string attributes are merged: got %v; want *bzl.ListExpr",
+				dst.Attr(sortedStringAttrKey))
+		}
+
+		expected := []string{"@qux", "//foo:bar", "//foo:baz"}
+		for i, v := range valExpr.List {
+			if v.(*bzl.StringExpr).Value != expected[i] {
+				t.Fatalf("unsorted string attributes are merged: got %v; want %v",
+					v.(*bzl.StringExpr).Value, expected[i])
+			}
 		}
 	})
 }

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -991,7 +991,9 @@ func (r *Rule) sync() {
 	r.updated = false
 
 	for _, k := range []string{"srcs", "deps"} {
-		if attr, ok := r.attrs[k]; ok {
+		attr, ok := r.attrs[k]
+		_, isUnsorted := attr.val.(UnsortedStrings)
+		if ok && !isUnsorted {
 			bzl.Walk(attr.expr.RHS, sortExprLabels)
 		}
 	}

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -715,8 +715,17 @@ type Rule struct {
 	stmt
 	kind    bzl.Expr
 	args    []bzl.Expr
-	attrs   map[string]*bzl.AssignExpr
+	attrs   map[string]attrValue
 	private map[string]interface{}
+}
+
+type attrValue struct {
+	// expr is the expression that defines the attribute assignment. If mergeable
+	// this will be replaced with a call to the merge function.
+	expr *bzl.AssignExpr
+	// val is the value of the attribute. If the attribute is mergeable
+	// the value must implement the Merger interface. could be nil.
+	val interface{}
 }
 
 // NewRule creates a new, empty rule with the given kind and name.
@@ -726,16 +735,18 @@ func NewRule(kind, name string) *Rule {
 	r := &Rule{
 		stmt:    stmt{expr: call},
 		kind:    kindIdent,
-		attrs:   map[string]*bzl.AssignExpr{},
+		attrs:   map[string]attrValue{},
 		private: map[string]interface{}{},
 	}
 	if name != "" {
-		nameAttr := &bzl.AssignExpr{
-			LHS: &bzl.Ident{Name: "name"},
-			RHS: &bzl.StringExpr{Value: name},
-			Op:  "=",
-		}
-		call.List = []bzl.Expr{nameAttr}
+		nameAttr := attrValue{
+			expr: &bzl.AssignExpr{
+				LHS: &bzl.Ident{Name: "name"},
+				RHS: &bzl.StringExpr{Value: name},
+				Op:  "=",
+			},
+			val: name}
+		call.List = []bzl.Expr{nameAttr.expr}
 		r.attrs["name"] = nameAttr
 	}
 	return r
@@ -766,11 +777,11 @@ func ruleFromExpr(index int, expr bzl.Expr) *Rule {
 	}
 
 	var args []bzl.Expr
-	attrs := make(map[string]*bzl.AssignExpr)
+	attrs := make(map[string]attrValue, len(call.List))
 	for _, arg := range call.List {
 		if attr, ok := arg.(*bzl.AssignExpr); ok {
 			key := attr.LHS.(*bzl.Ident) // required by parser
-			attrs[key.Name] = attr
+			attrs[key.Name] = attrValue{expr: attr}
 		} else {
 			args = append(args, arg)
 		}
@@ -839,7 +850,7 @@ func (r *Rule) Attr(key string) bzl.Expr {
 	if !ok {
 		return nil
 	}
-	return attr.RHS
+	return attr.expr.RHS
 }
 
 // AttrString returns the value of the named attribute if it is a scalar string.
@@ -849,7 +860,7 @@ func (r *Rule) AttrString(key string) string {
 	if !ok {
 		return ""
 	}
-	str, ok := attr.RHS.(*bzl.StringExpr)
+	str, ok := attr.expr.RHS.(*bzl.StringExpr)
 	if !ok {
 		return ""
 	}
@@ -864,7 +875,7 @@ func (r *Rule) AttrStrings(key string) []string {
 	if !ok {
 		return nil
 	}
-	list, ok := attr.RHS.(*bzl.ListExpr)
+	list, ok := attr.expr.RHS.(*bzl.ListExpr)
 	if !ok {
 		return nil
 	}
@@ -883,17 +894,22 @@ func (r *Rule) DelAttr(key string) {
 	r.updated = true
 }
 
-// SetAttr adds or replaces the named attribute with an expression produced
-// by ExprFromValue.
+// SetAttr adds or replaces the named attribute with value. If the attribute is
+// mergeable, then the value must implement the Merger interface, or an error will
+// be returned.
 func (r *Rule) SetAttr(key string, value interface{}) {
 	rhs := ExprFromValue(value)
 	if attr, ok := r.attrs[key]; ok {
-		attr.RHS = rhs
+		attr.expr.RHS = rhs
+		attr.val = value
 	} else {
-		r.attrs[key] = &bzl.AssignExpr{
-			LHS: &bzl.Ident{Name: key},
-			RHS: rhs,
-			Op:  "=",
+		r.attrs[key] = attrValue{
+			expr: &bzl.AssignExpr{
+				LHS: &bzl.Ident{Name: key},
+				RHS: rhs,
+				Op:  "=",
+			},
+			val: value,
 		}
 	}
 	r.updated = true
@@ -976,7 +992,7 @@ func (r *Rule) sync() {
 
 	for _, k := range []string{"srcs", "deps"} {
 		if attr, ok := r.attrs[k]; ok {
-			bzl.Walk(attr.RHS, sortExprLabels)
+			bzl.Walk(attr.expr.RHS, sortExprLabels)
 		}
 	}
 
@@ -990,7 +1006,7 @@ func (r *Rule) sync() {
 	list := make([]bzl.Expr, 0, len(r.args)+len(r.attrs))
 	list = append(list, r.args...)
 	for _, attr := range r.attrs {
-		list = append(list, attr)
+		list = append(list, attr.expr)
 	}
 	sortedAttrs := list[len(r.args):]
 	key := func(e bzl.Expr) string { return e.(*bzl.AssignExpr).LHS.(*bzl.Ident).Name }

--- a/rule/value.go
+++ b/rule/value.go
@@ -43,6 +43,21 @@ type BzlExprValue interface {
 	BzlExpr() bzl.Expr
 }
 
+type SortedStrings []string
+
+func (s SortedStrings) BzlExpr() bzl.Expr {
+	list := make([]bzl.Expr, len(s))
+	for i, v := range s {
+		list[i] = &bzl.StringExpr{Value: v}
+	}
+	listExpr := &bzl.ListExpr{List: list}
+	sortExprLabels(listExpr, []bzl.Expr{})
+	return listExpr
+}
+
+type UnsortedStrings []string
+
+
 // SelectStringListValue is a value that can be translated to a Bazel
 // select expression that picks a string list based on a string condition.
 type SelectStringListValue map[string][]string

--- a/rule/value.go
+++ b/rule/value.go
@@ -65,8 +65,23 @@ func (s SortedStrings) BzlExpr() bzl.Expr {
 	return listExpr
 }
 
+func (s SortedStrings) Merge(other bzl.Expr) bzl.Expr {
+	if other == nil {
+		return s.BzlExpr()
+	}
+	merged := mergeList(s.BzlExpr().(*bzl.ListExpr), other.(*bzl.ListExpr))
+	sortExprLabels(merged, []bzl.Expr{})
+	return merged
+}
+
 type UnsortedStrings []string
 
+func (s UnsortedStrings) Merge(other bzl.Expr) bzl.Expr {
+	if other == nil {
+		return ExprFromValue(s)
+	}
+	return mergeList(ExprFromValue(s).(*bzl.ListExpr), other.(*bzl.ListExpr))
+}
 
 // SelectStringListValue is a value that can be translated to a Bazel
 // select expression that picks a string list based on a string condition.

--- a/rule/value.go
+++ b/rule/value.go
@@ -69,7 +69,7 @@ func (s SortedStrings) Merge(other bzl.Expr) bzl.Expr {
 	if other == nil {
 		return s.BzlExpr()
 	}
-	merged := mergeList(s.BzlExpr().(*bzl.ListExpr), other.(*bzl.ListExpr))
+	merged := MergeList(s.BzlExpr(), other)
 	sortExprLabels(merged, []bzl.Expr{})
 	return merged
 }
@@ -80,7 +80,7 @@ func (s UnsortedStrings) Merge(other bzl.Expr) bzl.Expr {
 	if other == nil {
 		return ExprFromValue(s)
 	}
-	return mergeList(ExprFromValue(s).(*bzl.ListExpr), other.(*bzl.ListExpr))
+	return MergeList(ExprFromValue(s), other)
 }
 
 // SelectStringListValue is a value that can be translated to a Bazel

--- a/rule/value.go
+++ b/rule/value.go
@@ -43,6 +43,16 @@ type BzlExprValue interface {
 	BzlExpr() bzl.Expr
 }
 
+// Merger is implemented by types that can merge their data into an
+// existing Starlark expression.
+//
+// When Merge is invoked, it is responsible for returning a Starlark expression that contains the
+// result of merging its data into the previously-existing expression provided as other.
+// Note that other can be nil, if no previous attr with this name existed.
+type Merger interface {
+	Merge(other bzl.Expr) bzl.Expr
+}
+
 type SortedStrings []string
 
 func (s SortedStrings) BzlExpr() bzl.Expr {

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -55,6 +55,26 @@ func TestExprFromValue(t *testing.T) {
 				},
 			},
 		},
+		"sorted strings": {
+			val: SortedStrings{"@b", ":a", "//:target"},
+			want: &bzl.ListExpr{
+				List: []bzl.Expr{
+					&bzl.StringExpr{Value: ":a"},
+					&bzl.StringExpr{Value: "//:target"},
+					&bzl.StringExpr{Value: "@b"},
+				},
+			},
+		},
+		"unsorted strings": {
+			val: UnsortedStrings{"@d", ":a", "//:b"},
+			want: &bzl.ListExpr{
+				List: []bzl.Expr{
+					&bzl.StringExpr{Value: "@d"},
+					&bzl.StringExpr{Value: ":a"},
+					&bzl.StringExpr{Value: "//:b"},
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := ExprFromValue(tt.val)


### PR DESCRIPTION

**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> - rule
> - merger

**What does this PR do? Why is it needed?**
Implements merger interface so that `rule.SetAttr` can take arbitrary structs that implement `Merge` method that returns a `bzl.Expr` enabling users to define custom logic for merging attribute values within their BUILD.bazel files

**Which issues(s) does this PR fix?**

Fixes #1072

**Other notes for review**

Easiest reviewed commit by commit to see the logical progression

This was mainly achieved by storing the original value next to a pre-computed expression on the `rule.attrs` map, then casting to check for the merger interface.

Currently we fallback to the original logic if no merger interface exists on the `src` (or newly generated/set value). 

Further work can be done to migrate the platform strings but seemed like larger refactor that would muddy the waters of this PR. 