### PR TITLE
Fixes directives table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -921,12 +921,12 @@ The following directives are recognized:
 |   # gazelle:resolve proto go foo/foo.proto //foo:foo_go_proto                              |
 |                                                                                            |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:resolve_regexp ...`                    | n/a                                    |
+| :direc:`# gazelle:resolve_regexp ...`                    | n/a                             |
 +---------------------------------------------------+----------------------------------------+
-| Specifies an explicit mapping from an import regex to a label for                         |
+| Specifies an explicit mapping from an import regex to a label for                          |
 | `Dependency resolution`_. The format for a resolve directive is:                           |
 |                                                                                            |
-| ``# gazelle:resolve source-lang import-lang import-string-regex label``                          |
+| ``# gazelle:resolve source-lang import-lang import-string-regex label``                    |
 |                                                                                            |
 | * ``source-lang`` is the language of the source code being imported.                       |
 | * ``import-lang`` is the language importing the library. This is usually                   |
@@ -935,15 +935,15 @@ The following directives are recognized:
 |   ``source-lang`` would be ``"proto"`` and ``import-lang`` would be ``"go"``.              |
 |   ``import-lang`` may be omitted if it is the same as ``source-lang``.                     |
 | * ``import-string-regex`` is the regex applied to the import in the source code.           |
-|   If it matches, that import will be resolved to the label specified below.
+|   If it matches, that import will be resolved to the label specified below.                |
 | * ``label`` is the Bazel label that Gazelle should write in ``deps``.                      |
 |                                                                                            |
 | For example:                                                                               |
 |                                                                                            |
 | .. code:: bzl                                                                              |
 |                                                                                            |
-|   # gazelle:resolve_regexp go example.com/.* //foo:go_default_library                            |
-|   # gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto                              |
+|   # gazelle:resolve_regexp go example.com/.* //foo:go_default_library                      |
+|   # gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto                       |
 |                                                                                            |
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:go_visibility label`            | n/a                                    |


### PR DESCRIPTION
At some point a `|` character got dropped and the README wasn't rendering the directives table in full.