### PR TITLE
Fix directive table in Readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -921,12 +921,17 @@ The following directives are recognized:
 |   # gazelle:resolve proto go foo/foo.proto //foo:foo_go_proto                              |
 |                                                                                            |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:resolve_regexp ...`                    | n/a                                    |
+| :direc:`# gazelle:resolve_regexp ...`             | n/a                                    |
 +---------------------------------------------------+----------------------------------------+
-| Specifies an explicit mapping from an import regex to a label for                         |
+| Specifies an explicit mapping from an import regex to a label for                          |
 | `Dependency resolution`_. The format for a resolve directive is:                           |
 |                                                                                            |
-| ``# gazelle:resolve source-lang import-lang import-string-regex label``                          |
+| ``# gazelle:resolve source-lang import-lang import-string-regex label``                    |
+|                                                                                            |
+| Specifies an explicit mapping from an import regex to a label for                          |
+| `Dependency resolution`_. The format for a resolve directive is:                           |
+|                                                                                            |
+| ``# gazelle:resolve source-lang import-lang import-string-regex label``                    |
 |                                                                                            |
 | * ``source-lang`` is the language of the source code being imported.                       |
 | * ``import-lang`` is the language importing the library. This is usually                   |
@@ -935,15 +940,15 @@ The following directives are recognized:
 |   ``source-lang`` would be ``"proto"`` and ``import-lang`` would be ``"go"``.              |
 |   ``import-lang`` may be omitted if it is the same as ``source-lang``.                     |
 | * ``import-string-regex`` is the regex applied to the import in the source code.           |
-|   If it matches, that import will be resolved to the label specified below.
+|   If it matches, that import will be resolved to the label specified below.                |
 | * ``label`` is the Bazel label that Gazelle should write in ``deps``.                      |
 |                                                                                            |
 | For example:                                                                               |
 |                                                                                            |
 | .. code:: bzl                                                                              |
 |                                                                                            |
-|   # gazelle:resolve_regexp go example.com/.* //foo:go_default_library                            |
-|   # gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto                              |
+|   # gazelle:resolve_regexp go example.com/.* //foo:go_default_library                      |
+|   # gazelle:resolve_regexp proto go foo/.*\.proto //foo:foo_go_proto                       |
 |                                                                                            |
 +---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:go_visibility label`            | n/a                                    |


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Documentation

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

This PR repairs the directive table in the Readme file by adding back a missing terminating pipe symbol in a table cell (which cause the whole table not to be rendered), and while there cleaning up a bit of white space near line ends in the same table.

