### PR TITLE
Generate BUILD files for grpc-gateway by default

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -3,6 +3,7 @@ visibility("private")
 DEFAULT_BUILD_FILE_GENERATION_BY_PATH = {
     "github.com/envoyproxy/protoc-gen-validate": "on",
     "github.com/google/safetext": "on",
+    "github.com/grpc-ecosystem/grpc-gateway/v2": "on",
 }
 
 DEFAULT_DIRECTIVES_BY_PATH = {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix


**What package or component does this PR mostly affect?**

Default Go module configuration

**What does this PR do? Why is it needed?**

Specify that Gazelle should generate BUILD files for the _github.com/grpc-ecosystem/grpc-gateway/v2_ Go module, since the BUILD files already present in that module's source repository contain references to Bazel repositories that are no longer created automatically by Gazelle.

**Other notes for review**

See [the preceding discussion in the "go" channel](https://bazelbuild.slack.com/archives/CDBP88Z0D/p1689260233455729?thread_ts=1689168021.180399&cid=CDBP88Z0D) of the "Bazel" Slack workspace. There @fmeum suggested this fix.

I'm not sure whether or not we'll need to retain this default value if the upstream _grpc-ecosystem/grpc-gateway_ repository adapts to [Gazelle's recent version 0.32.0 release](https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.32.0), removing its current use of the `go_googleapis` Bazel repository.