### PR TITLE
Update: golang.org/x/exp & golang.org/x/oauth2 deps.

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -278,8 +278,8 @@ def gazelle_dependencies(
         go_repository,
         name = "org_golang_x_exp",
         importpath = "golang.org/x/exp",
-        sum = "h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=",
-        version = "v0.0.0-20190121172915-509febef88a4",
+        sum = "h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=",
+        version = "v0.0.0-20230713183714-613f0c0eb8a1",
     )
     _maybe(
         go_repository,
@@ -306,8 +306,8 @@ def gazelle_dependencies(
         go_repository,
         name = "org_golang_x_oauth2",
         importpath = "golang.org/x/oauth2",
-        sum = "h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=",
-        version = "v0.0.0-20180821212333-d2e6202438be",
+        sum = "h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=",
+        version = "v0.10.0",
     )
     _maybe(
         go_repository,


### PR DESCRIPTION
Update:
  - golang.org/x/exp    v0.0.0-20190121172915-509febef88a4 -> v0.0.0-20230713183714-613f0c0eb8a1
  - golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be -> v0.10.0

These were very old dependencies and there is no way to override them to newer ones by Gazelle user.
1. You cannot execute go_repository before calling gazelle_dependencies as @bazel_gazelle_go_repository_cache is not yet ready.
2. If you execute go_repository AFTER calling gazelle_dependences, the previously loaded old verision by gazelle_dependencies takes precendence.

It led to issues like:
  - https://github.com/bazelbuild/bazel-gazelle/issues/1468
  - https://stackoverflow.com/questions/64929217/bazel-gazelle-error-no-such-package-org-golang-x-tools-go-analysis-internal

Fixes: #1468

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
go_repository
> all

**What does this PR do? Why is it needed?**

Unblocks usage of gazelle with projects that depend on modern (last 2 years); `golang.org/x/exp` or `golang.org/x/oauth2`

**Which issues(s) does this PR fix?**

Fixes #1468

**Other notes for review**
