### PR TITLE
Allow splitting: gazelle_dependencies() into 2 phases by caller.

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -40,6 +40,17 @@ def gazelle_dependencies(
         go_sdk = "",
         go_repository_default_config = "@//:WORKSPACE",
         go_env = {}):
+    gazelle_init(go_sdk, go_repository_default_config, go_env)
+    gazelle_go_repositories()
+
+# gazelle_init configures basic gazelle infrastructure - like `go_repository` rule.
+# Usually you should use just `gazelle_dependencies`.
+# The pair of `gazelle_init` && `gazelle_go_repositories` is only needed if you need
+# to load custom version of the dependency using `go_repository` rule in between the calls.
+def gazelle_init(
+        go_sdk = "",
+        go_repository_default_config = "@//:WORKSPACE",
+        go_env = {}):
     _maybe(
         http_archive,
         name = "bazel_skylib",
@@ -84,6 +95,8 @@ def gazelle_dependencies(
         name = "bazel_gazelle_go_repository_config",
         config = go_repository_default_config,
     )
+
+def gazelle_go_repositories():
     _maybe(
         go_repository,
         name = "co_honnef_go_tools",


### PR DESCRIPTION
Allow splitting: gazelle_dependencies() into 2 phases by caller:
- gazelle_init()
- gazelle_go_repositories()

Thanks to it, the caller can call go_repository in between, loading their own (likely newer) version of the dependencies.

Currently `go_repository` cannot be called before `gazelle_dependencies`, as the `bazel_gazelle_go_repository_cache` is not yet initialized.

Fixes problems like:
  - https://github.com/bazelbuild/bazel-gazelle/pull/1582
  - https://github.com/bazelbuild/bazel-gazelle/issues/1468
  - https://github.com/bazelbuild/bazel-gazelle/issues/1305

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #1305

**Other notes for review**
