### PR TITLE
fix: avoid updating `WORKSPACE` file when running `update-repos` when bzlmod is enabled

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4366,7 +4366,61 @@ go_library(
 }
 
 func TestUpdateReposWithBzlmodWithToMacro(t *testing.T) {
-	t.Error("IMPLEMENT ME!")
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+		{
+			Path: "go.mod",
+			Content: `
+module example.com/foo/v2
+
+go 1.19
+
+require (
+	github.com/stretchr/testify v1.8.4
+)
+`,
+		},
+	})
+
+	defer cleanup()
+
+	args := []string{
+		"update-repos",
+		"-from_file=go.mod",
+		"-to_macro=go_deps.bzl%my_go_deps",
+		"-bzlmod",
+	}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm that the WORKSPACE is still empty
+	want := ""
+	if got, err := ioutil.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
+		t.Fatal(err)
+	} else if string(got) != want {
+		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
+	}
+
+	// Confirm that the macro file was written
+	want = `load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def my_go_deps():
+    go_repository(
+        name = "com_github_stretchr_testify",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=",
+        version = "v1.8.4",
+    )
+`
+	if got, err := ioutil.ReadFile(filepath.Join(dir, "go_deps.bzl")); err != nil {
+		t.Fatal(err)
+	} else if string(got) != want {
+		// DEBUG BEGIN
+		log.Printf("*** CHUCK:  string(got):\n%s", string(got))
+		// DEBUG END
+		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
+	}
 }
 
 func TestUpdateReposWithBzlmodWithoutToMacro(t *testing.T) {

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4416,9 +4416,6 @@ def my_go_deps():
 	if got, err := ioutil.ReadFile(filepath.Join(dir, "go_deps.bzl")); err != nil {
 		t.Fatal(err)
 	} else if string(got) != want {
-		// DEBUG BEGIN
-		log.Printf("*** CHUCK:  string(got):\n%s", string(got))
-		// DEBUG END
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
 	}
 }

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4396,7 +4396,7 @@ require (
 
 	// Confirm that the WORKSPACE is still empty
 	want := ""
-	if got, err := ioutil.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
+	if got, err := os.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
 		t.Fatal(err)
 	} else if string(got) != want {
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
@@ -4413,7 +4413,7 @@ def my_go_deps():
         version = "v1.8.4",
     )
 `
-	if got, err := ioutil.ReadFile(filepath.Join(dir, "go_deps.bzl")); err != nil {
+	if got, err := os.ReadFile(filepath.Join(dir, "go_deps.bzl")); err != nil {
 		t.Fatal(err)
 	} else if string(got) != want {
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
@@ -4437,7 +4437,7 @@ require (
 		},
 	})
 
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	args := []string{
 		"update-repos",
@@ -4450,7 +4450,7 @@ require (
 
 	// Confirm that the WORKSPACE is still empty
 	want := ""
-	if got, err := ioutil.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
+	if got, err := os.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
 		t.Fatal(err)
 	} else if string(got) != want {
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4382,7 +4382,7 @@ require (
 		},
 	})
 
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	args := []string{
 		"update-repos",

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4364,3 +4364,57 @@ go_library(
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
 	}
 }
+
+func TestUpdateReposWithBzlmodWithToMacro(t *testing.T) {
+	t.Error("IMPLEMENT ME!")
+}
+
+func TestUpdateReposWithBzlmodWithoutToMacro(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+		{
+			Path:    "MODULE.bazel",
+			Content: `bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "bazel_gazelle")`,
+		},
+		{
+			Path: "go.mod",
+			Content: `
+module example.com/foo/v2
+
+go 1.19
+
+require (
+	github.com/stretchr/testify v1.8.4
+)
+`,
+		},
+	})
+
+	defer cleanup()
+
+	// DEBUG BEGIN
+	log.Printf("*** CHUCK: TestUpdateReposWithBzlmodWithoutToMacro START ======================")
+	// DEBUG END
+
+	args := []string{
+		"update-repos",
+		"-from_file=go.mod",
+		"-bzlmod",
+	}
+	if err := runGazelle(dir, args); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm that the WORKSPACE is still empty
+	want := ""
+	if got, err := ioutil.ReadFile(filepath.Join(dir, "WORKSPACE")); err != nil {
+		t.Fatal(err)
+	} else if string(got) != want {
+		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
+	}
+
+	// DEBUG BEGIN
+	log.Printf("*** CHUCK: TestUpdateReposWithBzlmodWithoutToMacro STOP ======================")
+	// DEBUG END
+
+}

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -4373,10 +4373,6 @@ func TestUpdateReposWithBzlmodWithoutToMacro(t *testing.T) {
 	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
 		{Path: "WORKSPACE"},
 		{
-			Path:    "MODULE.bazel",
-			Content: `bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "bazel_gazelle")`,
-		},
-		{
 			Path: "go.mod",
 			Content: `
 module example.com/foo/v2
@@ -4391,10 +4387,6 @@ require (
 	})
 
 	defer cleanup()
-
-	// DEBUG BEGIN
-	log.Printf("*** CHUCK: TestUpdateReposWithBzlmodWithoutToMacro START ======================")
-	// DEBUG END
 
 	args := []string{
 		"update-repos",
@@ -4412,9 +4404,4 @@ require (
 	} else if string(got) != want {
 		t.Fatalf("got %s ; want %s; diff %s", string(got), want, cmp.Diff(string(got), want))
 	}
-
-	// DEBUG BEGIN
-	log.Printf("*** CHUCK: TestUpdateReposWithBzlmodWithoutToMacro STOP ======================")
-	// DEBUG END
-
 }

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -196,6 +197,10 @@ func updateRepos(wd string, args []string) (err error) {
 		return err
 	}
 
+	// DEBUG BEGIN
+	log.Printf("*** CHUCK: updateRepos c.Bzlmod: %+#v", c.Bzlmod)
+	// DEBUG END
+
 	// Organize generated and empty rules by file. A rule should go into the file
 	// it came from (by name). New rules should go into WORKSPACE or the file
 	// specified with -to_macro.
@@ -300,7 +305,7 @@ func updateRepos(wd string, args []string) (err error) {
 	for _, f := range sortedFiles {
 		merger.MergeFile(f, emptyForFiles[f], genForFiles[f], merger.PreResolve, kinds)
 		merger.FixLoads(f, loads)
-		if f == uc.workspace {
+		if f == uc.workspace && !c.Bzlmod {
 			if err := merger.CheckGazelleLoaded(f); err != nil {
 				return err
 			}

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -288,9 +288,7 @@ func updateRepos(wd string, args []string) (err error) {
 			sortedFiles = append(sortedFiles, f)
 		}
 	}
-	// If we are in bzlmod mode, then do not update the workspace. However, if a macro file was
-	// specified, proceed with generating the macro file. This is useful for rule repositories that
-	// build with bzlmod enabled, but support clients that use legacy WORKSPACE dependency loading.
+	// If we are in bzlmod mode, then do not update the workspace.
 	if !c.Bzlmod && ensureMacroInWorkspace(uc, workspaceInsertIndex) {
 		if !seenFile[uc.workspace] {
 			seenFile[uc.workspace] = true

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -238,35 +238,40 @@ func updateRepos(wd string, args []string) (err error) {
 		emptyForFiles[f] = append(emptyForFiles[f], r)
 	}
 
-	var newGenFile *rule.File
 	var macroPath string
 	if uc.macroFileName != "" {
 		macroPath = filepath.Join(c.RepoRoot, filepath.Clean(uc.macroFileName))
 	}
-	for f := range genForFiles {
-		if macroPath == "" && wspace.IsWORKSPACE(f.Path) ||
-			macroPath != "" && f.Path == macroPath && f.DefName == uc.macroDefName {
-			newGenFile = f
-			break
-		}
-	}
-	if newGenFile == nil {
-		if uc.macroFileName == "" {
-			newGenFile = uc.workspace
-		} else {
-			var err error
-			newGenFile, err = rule.LoadMacroFile(macroPath, "", uc.macroDefName)
-			if os.IsNotExist(err) {
-				newGenFile, err = rule.EmptyMacroFile(macroPath, "", uc.macroDefName)
-				if err != nil {
-					return fmt.Errorf("error creating %q: %v", macroPath, err)
-				}
-			} else if err != nil {
-				return fmt.Errorf("error loading %q: %v", macroPath, err)
+	// If we are in bzlmod mode, then do not update the workspace. However, if a macro file was
+	// specified, proceed with generating the macro file. This is useful for rule repositories that
+	// build with bzlmod enabled, but support clients that use legacy WORKSPACE dependency loading.
+	if !c.Bzlmod || macroPath != "" {
+		var newGenFile *rule.File
+		for f := range genForFiles {
+			if macroPath == "" && wspace.IsWORKSPACE(f.Path) ||
+				macroPath != "" && f.Path == macroPath && f.DefName == uc.macroDefName {
+				newGenFile = f
+				break
 			}
 		}
+		if newGenFile == nil {
+			if uc.macroFileName == "" {
+				newGenFile = uc.workspace
+			} else {
+				var err error
+				newGenFile, err = rule.LoadMacroFile(macroPath, "", uc.macroDefName)
+				if os.IsNotExist(err) {
+					newGenFile, err = rule.EmptyMacroFile(macroPath, "", uc.macroDefName)
+					if err != nil {
+						return fmt.Errorf("error creating %q: %v", macroPath, err)
+					}
+				} else if err != nil {
+					return fmt.Errorf("error loading %q: %v", macroPath, err)
+				}
+			}
+		}
+		genForFiles[newGenFile] = append(genForFiles[newGenFile], newGen...)
 	}
-	genForFiles[newGenFile] = append(genForFiles[newGenFile], newGen...)
 
 	workspaceInsertIndex := findWorkspaceInsertIndex(uc.workspace, kinds, loads)
 	for _, r := range genForFiles[uc.workspace] {
@@ -288,7 +293,10 @@ func updateRepos(wd string, args []string) (err error) {
 			sortedFiles = append(sortedFiles, f)
 		}
 	}
-	if ensureMacroInWorkspace(uc, workspaceInsertIndex) {
+	// If we are in bzlmod mode, then do not update the workspace. However, if a macro file was
+	// specified, proceed with generating the macro file. This is useful for rule repositories that
+	// build with bzlmod enabled, but support clients that use legacy WORKSPACE dependency loading.
+	if !c.Bzlmod && ensureMacroInWorkspace(uc, workspaceInsertIndex) {
 		if !seenFile[uc.workspace] {
 			seenFile[uc.workspace] = true
 			sortedFiles = append(sortedFiles, uc.workspace)

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -196,10 +195,6 @@ func updateRepos(wd string, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// DEBUG BEGIN
-	log.Printf("*** CHUCK: updateRepos c.Bzlmod: %+#v", c.Bzlmod)
-	// DEBUG END
 
 	// Organize generated and empty rules by file. A rule should go into the file
 	// it came from (by name). New rules should go into WORKSPACE or the file


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

The `WORKSPACE` file should not be updated when `update-repos` is run with `-bzlmod` enabled.

**Which issues(s) does this PR fix?**

Fixes #1588.

**Other notes for review**
