### PR TITLE
[README.rst] Mention kotlin PoC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,13 @@ Gazelle can generate Bazel BUILD files for many languages:
   BenchSci's `rules_nodejs_gazelle`_ supports generating `ts_project`, `js_library`, `jest_test`,
   and `web_asset` rules, and is able to support module bundlers like Webpack and Next.js
 
+
+* Kotlin
+
+  Aspect Build provides some [Kotlin Support](https://github.com/aspect-build/aspect-cli/blob/main/gazelle/kotlin/)
+  in the repo of their aspect-cli (also usable separately). Still under development, please check the README for 
+  currently available features.
+
 * Protocol Buffers
 
   Support for the `proto_library` rule, as well as `go_proto_library` is in this repository, see below.


### PR DESCRIPTION
**What type of PR is this?**

> Documentation

**What package or component does this PR mostly affect?**

README.md

**What does this PR do? Why is it needed?**

I want to hint at the existence of a Kotlin PoC because I wasn't aware of it first and started implementing my own prototype.

[I am not involved with the creation of the linked PoC]