### PR TITLE
fix: go_repository: never shadow a module with a compatibility mapping for major versions.

### DIFF
--- a/repo/remote.go
+++ b/repo/remote.go
@@ -180,15 +180,28 @@ func NewRemoteCache(knownRepos []Repo) (r *RemoteCache, cleanup func() error) {
 	// allowed to use them. However, we'll return the same result nearly all
 	// the time, and simpler is better.
 	for _, repo := range knownRepos {
-		path := pathWithoutSemver(repo.GoPrefix)
-		if path == "" || r.root.cache[path] != nil {
+		newPath := pathWithoutSemver(repo.GoPrefix)
+		if newPath == "" {
 			continue
 		}
-		r.root.cache[path] = r.root.cache[repo.GoPrefix]
-		if e := r.remote.cache[repo.GoPrefix]; e != nil {
-			r.remote.cache[path] = e
+		// Avoid adding the semver-less path for this module if there
+		// is another known module which already covers this path.
+		// See https://github.com/bazelbuild/bazel-gazelle/issues/1595.
+		found := false
+		for prefix := newPath; prefix != "." && prefix != "/"; prefix = path.Dir(prefix) {
+			if _, ok := r.root.cache[prefix]; ok {
+				found = true
+				break
+			}
 		}
-		r.mod.cache[path] = r.mod.cache[repo.GoPrefix]
+		if found {
+			continue
+		}
+		r.root.cache[newPath] = r.root.cache[repo.GoPrefix]
+		if e := r.remote.cache[repo.GoPrefix]; e != nil {
+			r.remote.cache[newPath] = e
+		}
+		r.mod.cache[newPath] = r.mod.cache[repo.GoPrefix]
 	}
 
 	return r, r.cleanup

--- a/repo/remote_test.go
+++ b/repo/remote_test.go
@@ -289,6 +289,18 @@ func TestMod(t *testing.T) {
 			wantModPath: "example.com/known",
 			wantName:    "known",
 		}, {
+			desc:       "semver_less_path_is_safe",
+			importPath: "example.com/known/internal/endpoints",
+			repos: []Repo{{
+				Name:     "known",
+				GoPrefix: "example.com/known",
+			}, {
+				Name:     "known_internal_endpoints_v2",
+				GoPrefix: "example.com/known/internal/endpoints/v2",
+			}},
+			wantModPath: "example.com/known",
+			wantName:    "known",
+		}, {
 			desc:        "lookup",
 			importPath:  "example.com/stub/v2/foo",
 			wantModPath: "example.com/stub/v2",


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

The remote module mapping logic is overly aggressive with its compatibility mappings when it removes the major version from a versioned module path. It will shadow existing modules with an incorrect module path. This breaks recent versions of the AWS GoLang SDK with `go_repository`, for example. The only available work around is manual repository mappings passed to the `go_repository` workspace rule invocation, which should not be necessary.

**Which issues(s) does this PR fix?**

Fixes #1595

**Other notes for review**

It's possible `jayconrod`'s `TODO` on line 178 is a more appropriate fix here. But absent that, never shadowing seems appropriate and always more correct.