### PR TITLE
Revert "go_repository: fix missing default GOPROXY (#1602)"

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -115,9 +115,6 @@ Authorization: Bearer RANDOM-TOKEN
 # We can't disable timeouts on Bazel, but we can set them to large values.
 _GO_REPOSITORY_TIMEOUT = 86400
 
-# Default value from `go env GOPROXY`
-_GOPROXY_DEFAULT = "https://proxy.golang.org,direct"
-
 def _go_repository_impl(ctx):
     # TODO(#549): vcs repositories are not cached and still need to be fetched.
     # Download the repository or module.
@@ -239,10 +236,6 @@ def _go_repository_impl(ctx):
                 env_keys = env_keys + [key, value]
 
     env.update({k: ctx.os.environ[k] for k in env_keys if k in ctx.os.environ})
-
-    # Since Go 1.21.0, GOPROXY must be set to a non-empty value.
-    if "GOPROXY" not in env:
-        env["GOPROXY"] = _GOPROXY_DEFAULT
 
     if fetch_repo_args:
         # Disable sumdb in fetch_repo. In module mode, the sum is a mandatory


### PR DESCRIPTION
This reverts commit adce430fa38848f0b3805e05f9520e419a41dfd7.

We found an alternative fix to this to this issue in
https://github.com/bazelbuild/rules_go/pull/3666.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
