### PR TITLE
bug fix: don't generate invalid go_binary rules for empty main packages

### DIFF
--- a/cmd/gazelle/fix_test.go
+++ b/cmd/gazelle/fix_test.go
@@ -172,7 +172,7 @@ func TestNoChanges(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	goFile := filepath.Join(dir, "main.go")
-	if err = ioutil.WriteFile(goFile, []byte("package main"), 0o600); err != nil {
+	if err = ioutil.WriteFile(goFile, []byte("package main\n\nfunc main() {}"), 0o600); err != nil {
 		t.Fatalf("error writing file %q: %v", goFile, err)
 	}
 

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1998,7 +1998,10 @@ go_library(
 		},
 		{
 			Path:    "enabled/multiple_mappings/multiple_mappings.go",
-			Content: `package main`,
+			Content: `
+package main
+
+func main() {}`,
 		},
 		{
 			Path: "depend_on_mapped_kind/lib.go",

--- a/language/go/package.go
+++ b/language/go/package.go
@@ -36,6 +36,7 @@ type goPackage struct {
 	library, binary, test goTarget
 	proto                 protoTarget
 	hasTestdata           bool
+	hasMainFunction       bool
 	importPath            string
 }
 
@@ -112,6 +113,7 @@ func (pkg *goPackage) addFile(c *config.Config, er *embedResolver, info fileInfo
 			pkg.test.hasInternalTest = true
 		}
 	default:
+		pkg.hasMainFunction = pkg.hasMainFunction || info.hasMainFunction
 		pkg.library.addFile(c, er, info)
 	}
 
@@ -120,7 +122,7 @@ func (pkg *goPackage) addFile(c *config.Config, er *embedResolver, info fileInfo
 
 // isCommand returns true if the package name is "main".
 func (pkg *goPackage) isCommand() bool {
-	return pkg.name == "main"
+	return pkg.name == "main" && pkg.hasMainFunction
 }
 
 // isBuildable returns true if anything in the package is buildable.

--- a/language/go/testdata/default_visibility/cmd/main.go
+++ b/language/go/testdata/default_visibility/cmd/main.go
@@ -1,1 +1,4 @@
 package main
+
+func main() {
+}

--- a/language/go/testdata/main_no_bin/BUILD.want
+++ b/language/go/testdata/main_no_bin/BUILD.want
@@ -1,16 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "main_no_bin_lib",
     srcs = ["main.go"],
     _gazelle_imports = [],
     importpath = "example.com/repo/main_no_bin",
-    visibility = ["//visibility:private"],
-)
-
-go_binary(
-    name = "main_no_bin",
-    _gazelle_imports = [],
-    embed = [":main_no_bin_lib"],
     visibility = ["//visibility:public"],
 )

--- a/language/go/testdata/main_no_bin/BUILD.want
+++ b/language/go/testdata/main_no_bin/BUILD.want
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "main_no_bin_lib",
+    srcs = ["main.go"],
+    _gazelle_imports = [],
+    importpath = "example.com/repo/main_no_bin",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "main_no_bin",
+    _gazelle_imports = [],
+    embed = [":main_no_bin_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/language/go/testdata/main_no_bin/main.go
+++ b/language/go/testdata/main_no_bin/main.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Presently, gazelle generates `go_binary` targets for main packages with library code even if
the library doesn't have a main function. The no-main-function `go_binary` targets don't compile.

This PR updates gazelle to skip generation of `go_binary` for main packages where a main
function isn't present.

**Which issues(s) does this PR fix?**

**Other notes for review**

The first commits add a test showing the undesirable behavior. The tests pass because we aren't compiling the generated BUILD files -- but if we did compile them, it would fail.

The subsequent commits fix the issue and update the tests.
