### PR TITLE
Add an entry for "github.com/googleapis/gax-go/v2" to default_gazelle_overrides.bzl

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -23,6 +23,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:build_file_name BUILD.bazel",
         "gazelle:build_file_proto_mode disable_global",
     ],
+    "github.com/googleapis/gax-go/v2": [
+        "gazelle:proto disable",
+    ],
     "github.com/googleapis/gnostic": [
         "gazelle:proto disable",
     ],

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1228,7 +1228,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
-      "bzlTransitiveDigest": "ti6/wrYI3K/ecfLzekOUxKJVqza2UYx79wFadZG0AMQ=",
+      "bzlTransitiveDigest": "/K0VG842rhxf79zqsWaTHVXGr//yhT+oZy6MvwjYSKk=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1255,7 +1255,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "ti6/wrYI3K/ecfLzekOUxKJVqza2UYx79wFadZG0AMQ=",
+      "bzlTransitiveDigest": "/K0VG842rhxf79zqsWaTHVXGr//yhT+oZy6MvwjYSKk=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

bzlmod default config

**What does this PR do? Why is it needed?**

When updating to v0.32.0 anyone with a transient dependency on `github.com/googleapis/gax-go/v2` will need to add an override `gazelle:proto disable` directive. See here for discussion: https://github.com/bazelbuild/rules_go/issues/3625#issuecomment-1674275131

Adding the directive as a default should prevent a bunch of manual effort.
