### PR TITLE
Set runfiles environment variables for Gazelle

### DIFF
--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -98,4 +98,5 @@ if [[ "${is_fix_or_update:-}" == "true"  ]] && [[ -n $REPO_CONFIG_PATH ]]; then
   ARGS=("${ARGS[0]}" "-repo_config" "$(rlocation "$REPO_CONFIG_PATH")" "${ARGS[@]:1}")
 fi
 
+runfiles_export_envvars
 "$gazelle_path" "${ARGS[@]}"


### PR DESCRIPTION
This ensures that Gazelle itself or a language linked into it can discover runfiles no matter whether it needs `RUNFILES_MANIFEST_FILE` or `RUNFILES_DIR`. The latter is especially relevant for Python, which is run as part of the Gazelle Python plugin.
