### PR TITLE
fix: add missing bzl_library declaration and dep

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,6 +98,7 @@ bzl_library(
         "//internal:go_repository",
         "//internal:overlay_repository",
         "//internal/generationtest",
+        "@bazel_gazelle_is_bazel_module//:defs",
         "@bazel_skylib//lib:shell",
     ],
 )

--- a/internal/is_bazel_module.bzl
+++ b/internal/is_bazel_module.bzl
@@ -14,7 +14,15 @@
 
 def _is_bazel_module_impl(repository_ctx):
     repository_ctx.file("WORKSPACE")
-    repository_ctx.file("BUILD")
+    repository_ctx.file("BUILD", """\
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+)
+""")
     repository_ctx.file("defs.bzl", "GAZELLE_IS_BAZEL_MODULE = {}".format(
         repr(repository_ctx.attr.is_bazel_module),
     ))

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -966,7 +966,7 @@
       }
     },
     "@gazelle~override//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
-      "bzlTransitiveDigest": "idtJXxcHUd75fcvggtK/s6naCFjcaysxF0U5OKBm2LE=",
+      "bzlTransitiveDigest": "wdirRXKNPbbln3dfsr2tlza6Y8itKEhUmqgQx8l634g=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

- Add missing `bzl_library` declaration in repo generated by `is_bazel_module`. 
- Add dep to the above target to `//:def`.

**Which issues(s) does this PR fix?**

NA

**Other notes for review**

I added [a test to rules_swift](https://github.com/bazelbuild/rules_swift/blob/master/test/bzl_test.bzl) to catch these missing declarations. Would the maintainers be open to a PR adding this test to this repo?