### PR TITLE
Export workspace file in go_repository_config.bzl

### DIFF
--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -62,7 +62,7 @@ def _go_repository_config_impl(ctx):
     # add an empty build file so Bazel recognizes the config
     ctx.file(
         "BUILD.bazel",
-        "",
+        "exports_files([\"WORKSPACE\"])",
         False,
     )
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

Fixes the following error when gazelle is loaded from WORKSPACE, and `--enable_bzlmod` is set:

```
ERROR: /foo/BUILD.bazel:63:8: every rule of type _gazelle_runner implicitly depends upon
the target '@bazel_gazelle_go_repository_config//:WORKSPACE', but this target could 
not be found because of: no such target '@bazel_gazelle_go_repository_config//:WORKSPACE': 
target 'WORKSPACE' not declared in package '' defined by 
/home/vscode/.cache/bazel/_bazel_vscode/3dbdfd10a1e163b9a670d9ed81dfe3af/external/bazel_gazelle_go_repository_config/BUILD.bazel; however, a source file of this name exists.
(Perhaps add 'exports_files(["WORKSPACE"])' to /BUILD?)
```
