### PR TITLE
Add github.com/google/gnostic-models to default_gazelle_overrides.bzl

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -43,6 +43,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/googleapis/gnostic": [
         "gazelle:proto disable",
     ],
+    "github.com/googleapis/gnostic-models": [
+        "gazelle:proto disable",
+    ],
     "google.golang.org/grpc": [
         "gazelle:proto disable",
     ],

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -988,7 +988,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
-      "bzlTransitiveDigest": "EGHU0Zz5+tB+AiRHsn9EXyVISl5KZhojgalqT1/XXuA=",
+      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {
@@ -1015,7 +1015,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "EGHU0Zz5+tB+AiRHsn9EXyVISl5KZhojgalqT1/XXuA=",
+      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",


### PR DESCRIPTION
Apparently, github.com/google/gnostic now references modules in github.com/google/gnostic-models. This seems to be related to this PR recent PR: https://github.com/google/gnostic/pull/400
After doing an update that pulled in this new module, we needed to add the directive proposed by this PR similar to how this was already needed for github.com/google/gnostic.