### PR TITLE
fix(bzlmod): allow passing build_extra_args in gazelle_override

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -59,3 +59,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:proto disable",
     ],
 }
+
+DEFAULT_BUILD_EXTRA_ARGS_BY_PATH = {
+    "github.com/census-instrumentation/opencensus-proto": [
+        "-exclude=src",
+    ],
+}

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -81,7 +81,7 @@ def _get_build_extra_args(path, gazelle_overrides):
     if override:
         return override.build_extra_args
 
-    return []
+    return DEFAULT_BUILD_EXTRA_ARGS_BY_PATH.get(path, [])
 
 def _get_directives(path, gazelle_overrides):
     override = gazelle_overrides.get(path)
@@ -94,7 +94,7 @@ def _get_patches(path, module_overrides):
     override = module_overrides.get(path)
     if override:
         return override.patches
-    return DEFAULT_BUILD_EXTRA_ARGS_BY_PATH.get(path, [])
+    return []
 
 def _get_patch_args(path, module_overrides):
     override = module_overrides.get(path)

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -75,6 +75,13 @@ def _get_build_file_generation(path, gazelle_overrides):
 
     return DEFAULT_BUILD_FILE_GENERATION_BY_PATH.get(path, "auto")
 
+def _get_build_extra_args(path, gazelle_overrides):
+    override = gazelle_overrides.get(path)
+    if override:
+        return override.build_extra_args
+
+    return []
+
 def _get_directives(path, gazelle_overrides):
     override = gazelle_overrides.get(path)
     if override:
@@ -131,6 +138,7 @@ def _process_gazelle_override(gazelle_override_tag):
     return struct(
         directives = gazelle_override_tag.directives,
         build_file_generation = gazelle_override_tag.build_file_generation,
+        build_extra_args = gazelle_override_tag.build_extra_args,
     )
 
 def _process_module_override(module_override_tag):
@@ -374,6 +382,7 @@ def _go_deps_impl(module_ctx):
             "importpath": path,
             "build_directives": _get_directives(path, gazelle_overrides),
             "build_file_generation": _get_build_file_generation(path, gazelle_overrides),
+            "build_extra_args": _get_build_extra_args(path, gazelle_overrides),
             "patches": _get_patches(path, module_overrides),
             "patch_args": _get_patch_args(path, module_overrides),
         }
@@ -526,6 +535,12 @@ _gazelle_override_tag = tag_class(
                 "off",
                 "on",
             ],
+        ),
+        "build_extra_args": attr.string_list(
+            default = [],
+            doc = """
+            A list of additional command line arguments to pass to Gazelle when generating build files.
+            """,
         ),
         "directives": attr.string_list(
             doc = """Gazelle configuration directives to use for this Go module's external repository.

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -80,7 +80,6 @@ def _get_build_extra_args(path, gazelle_overrides):
     override = gazelle_overrides.get(path)
     if override:
         return override.build_extra_args
-
     return DEFAULT_BUILD_EXTRA_ARGS_BY_PATH.get(path, [])
 
 def _get_directives(path, gazelle_overrides):

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -16,6 +16,7 @@ load("//internal:go_repository.bzl", "go_repository")
 load(":go_mod.bzl", "deps_from_go_mod", "sums_from_go_mod")
 load(
     ":default_gazelle_overrides.bzl",
+    "DEFAULT_BUILD_EXTRA_ARGS_BY_PATH",
     "DEFAULT_BUILD_FILE_GENERATION_BY_PATH",
     "DEFAULT_DIRECTIVES_BY_PATH",
 )
@@ -93,7 +94,7 @@ def _get_patches(path, module_overrides):
     override = module_overrides.get(path)
     if override:
         return override.patches
-    return []
+    return DEFAULT_BUILD_EXTRA_ARGS_BY_PATH.get(path, [])
 
 def _get_patch_args(path, module_overrides):
     override = module_overrides.get(path)

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1015,7 +1015,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
+      "bzlTransitiveDigest": "UbsXI/pKqJGKgGEvF3NdJeiekaFnMih9dP4U4/mP89A=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",
@@ -1031,132 +1031,132 @@
         "org_golang_x_tools_go_vcs": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_tools_go_vcs","importpath":"--golang.org/x/tools/go/vcs","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=","replace":"--","version":"--v0.1.0-deprecated"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_tools_go_vcs","importpath":"--golang.org/x/tools/go/vcs","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=","replace":"--","version":"--v0.1.0-deprecated"}
         },
         "com_github_fsnotify_fsnotify": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_fsnotify_fsnotify","importpath":"--github.com/fsnotify/fsnotify","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=","replace":"--","version":"--v1.6.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_fsnotify_fsnotify","importpath":"--github.com/fsnotify/fsnotify","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=","replace":"--","version":"--v1.6.0"}
         },
         "com_github_bmatcuk_doublestar_v4": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_bmatcuk_doublestar_v4","importpath":"--github.com/bmatcuk/doublestar/v4","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=","replace":"--github.com/bmatcuk/doublestar","version":"--v1.3.4"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_bmatcuk_doublestar_v4","importpath":"--github.com/bmatcuk/doublestar/v4","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=","replace":"--github.com/bmatcuk/doublestar","version":"--v1.3.4"}
         },
         "com_github_pmezard_go_difflib": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_pmezard_go_difflib","importpath":"--github.com/pmezard/go-difflib","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=","replace":"--","version":"--v1.0.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_pmezard_go_difflib","importpath":"--github.com/pmezard/go-difflib","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=","replace":"--","version":"--v1.0.0"}
         },
         "com_github_davecgh_go_spew": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_davecgh_go_spew","importpath":"--github.com/davecgh/go-spew","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=","replace":"--","version":"--v1.1.1"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_davecgh_go_spew","importpath":"--github.com/davecgh/go-spew","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=","replace":"--","version":"--v1.1.1"}
         },
         "com_github_datadog_sketches_go": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_datadog_sketches_go","importpath":"--github.com/DataDog/sketches-go","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=","replace":"--","version":"--v1.4.1"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_datadog_sketches_go","importpath":"--github.com/DataDog/sketches-go","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:j5G6as+9FASM2qC36lvpvQAj9qsv/jUs3FtO8CwZNAY=","replace":"--","version":"--v1.4.1"}
         },
         "org_golang_x_tools": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_tools","importpath":"--golang.org/x/tools","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=","replace":"--","version":"--v0.9.1"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_tools","importpath":"--golang.org/x/tools","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=","replace":"--","version":"--v0.9.1"}
         },
         "com_github_bazelbuild_buildtools": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_bazelbuild_buildtools","importpath":"--github.com/bazelbuild/buildtools","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","patches":[],"patch_args":[],"urls":["--https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz"],"strip_prefix":"--buildtools-ae8e3206e815d086269eb208b01f300639a4b194","sha256":"--05d7c3d2bd3cc0b02d15672fefa0d6be48c7aebe459c1c99dced7ac5e598508f"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_bazelbuild_buildtools","importpath":"--github.com/bazelbuild/buildtools","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"urls":["--https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz"],"strip_prefix":"--buildtools-ae8e3206e815d086269eb208b01f300639a4b194","sha256":"--05d7c3d2bd3cc0b02d15672fefa0d6be48c7aebe459c1c99dced7ac5e598508f"}
         },
         "org_golang_x_net": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_net","importpath":"--golang.org/x/net","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=","replace":"--","version":"--v0.0.0-20210405180319-a5a99cb37ef4"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_net","importpath":"--golang.org/x/net","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=","replace":"--","version":"--v0.0.0-20210405180319-a5a99cb37ef4"}
         },
         "org_golang_google_genproto": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_genproto","importpath":"--google.golang.org/genproto","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=","replace":"--","version":"--v0.0.0-20200526211855-cb27e3aa2013"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_genproto","importpath":"--google.golang.org/genproto","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=","replace":"--","version":"--v0.0.0-20200526211855-cb27e3aa2013"}
         },
         "com_github_fmeum_dep_on_gazelle": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_fmeum_dep_on_gazelle","importpath":"--github.com/fmeum/dep_on_gazelle","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:7gEtQ2CoD77tYca+1iUnKjIBUZ4mX7mZwjdWp3uuN/E=","replace":"--","version":"--v1.0.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_fmeum_dep_on_gazelle","importpath":"--github.com/fmeum/dep_on_gazelle","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:7gEtQ2CoD77tYca+1iUnKjIBUZ4mX7mZwjdWp3uuN/E=","replace":"--","version":"--v1.0.0"}
         },
         "com_github_gogo_protobuf": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_gogo_protobuf","importpath":"--github.com/gogo/protobuf","build_directives":["--gazelle:proto disable"],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=","replace":"--","version":"--v1.3.2"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_gogo_protobuf","importpath":"--github.com/gogo/protobuf","build_directives":["--gazelle:proto disable"],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=","replace":"--","version":"--v1.3.2"}
         },
         "com_github_stretchr_testify": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_stretchr_testify","importpath":"--github.com/stretchr/testify","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","patches":["@@//patches:testify.patch"],"patch_args":["---p1"],"sum":"--h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=","replace":"--","version":"--v1.8.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_stretchr_testify","importpath":"--github.com/stretchr/testify","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","build_extra_args":[],"patches":["@@//patches:testify.patch"],"patch_args":["---p1"],"sum":"--h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=","replace":"--","version":"--v1.8.0"}
         },
         "org_golang_x_sync": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_sync","importpath":"--golang.org/x/sync","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=","replace":"--","version":"--v0.3.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_sync","importpath":"--golang.org/x/sync","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=","replace":"--","version":"--v0.3.0"}
         },
         "com_github_golang_mock": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_golang_mock","importpath":"--github.com/golang/mock","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=","replace":"--","version":"--v1.6.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_golang_mock","importpath":"--github.com/golang/mock","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=","replace":"--","version":"--v1.6.0"}
         },
         "org_golang_google_grpc": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_grpc","importpath":"--google.golang.org/grpc","build_directives":["--gazelle:proto disable"],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=","replace":"--","version":"--v1.50.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_grpc","importpath":"--google.golang.org/grpc","build_directives":["--gazelle:proto disable"],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=","replace":"--","version":"--v1.50.0"}
         },
         "com_github_google_go_cmp": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_google_go_cmp","importpath":"--github.com/google/go-cmp","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=","replace":"--","version":"--v0.5.9"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_google_go_cmp","importpath":"--github.com/google/go-cmp","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=","replace":"--","version":"--v0.5.9"}
         },
         "org_golang_x_text": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_text","importpath":"--golang.org/x/text","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=","replace":"--","version":"--v0.3.3"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_text","importpath":"--golang.org/x/text","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=","replace":"--","version":"--v0.3.3"}
         },
         "com_github_google_safetext": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_google_safetext","importpath":"--github.com/google/safetext","build_directives":["--gazelle:build_file_name BUILD.bazel","--gazelle:build_file_proto_mode disable_global"],"build_file_generation":"--on","patches":[],"patch_args":[],"sum":"--h1:SJ+NtwL6QaZ21U+IrK7d0gGgpjGGvd2kz+FzTHVzdqI=","replace":"--","version":"--v0.0.0-20220905092116-b49f7bc46da2"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_google_safetext","importpath":"--github.com/google/safetext","build_directives":["--gazelle:build_file_name BUILD.bazel","--gazelle:build_file_proto_mode disable_global"],"build_file_generation":"--on","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:SJ+NtwL6QaZ21U+IrK7d0gGgpjGGvd2kz+FzTHVzdqI=","replace":"--","version":"--v0.0.0-20220905092116-b49f7bc46da2"}
         },
         "com_github_kr_text": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_kr_text","importpath":"--github.com/kr/text","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=","replace":"--","version":"--v0.2.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_kr_text","importpath":"--github.com/kr/text","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=","replace":"--","version":"--v0.2.0"}
         },
         "org_golang_google_protobuf": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_protobuf","importpath":"--google.golang.org/protobuf","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=","replace":"--","version":"--v1.28.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_google_protobuf","importpath":"--google.golang.org/protobuf","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=","replace":"--","version":"--v1.28.0"}
         },
         "org_golang_x_mod": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_mod","importpath":"--golang.org/x/mod","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=","replace":"--","version":"--v0.12.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_mod","importpath":"--golang.org/x/mod","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=","replace":"--","version":"--v0.12.0"}
         },
         "com_github_bwesterb_go_ristretto": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_bwesterb_go_ristretto","importpath":"--github.com/bwesterb/go-ristretto","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=","replace":"--","version":"--v1.2.3"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_bwesterb_go_ristretto","importpath":"--github.com/bwesterb/go-ristretto","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=","replace":"--","version":"--v1.2.3"}
         },
         "in_gopkg_yaml_v3": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~in_gopkg_yaml_v3","importpath":"--gopkg.in/yaml.v3","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=","replace":"--","version":"--v3.0.1"}
+          "attributes": {"name":"--gazelle~override~go_deps~in_gopkg_yaml_v3","importpath":"--gopkg.in/yaml.v3","build_directives":["--gazelle:go_naming_convention go_default_library"],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=","replace":"--","version":"--v3.0.1"}
         },
         "org_golang_x_crypto": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_crypto","importpath":"--golang.org/x/crypto","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=","replace":"--","version":"--v0.3.1-0.20221117191849-2c476679df9a"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_crypto","importpath":"--golang.org/x/crypto","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=","replace":"--","version":"--v0.3.1-0.20221117191849-2c476679df9a"}
         },
         "com_github_golang_protobuf": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_golang_protobuf","importpath":"--github.com/golang/protobuf","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=","replace":"--","version":"--v1.5.2"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_golang_protobuf","importpath":"--github.com/golang/protobuf","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=","replace":"--","version":"--v1.5.2"}
         },
         "bazel_gazelle_go_repository_config": {
           "bzlFile": "@@gazelle~override//internal/bzlmod:go_deps.bzl",
@@ -1166,12 +1166,12 @@
         "com_github_envoyproxy_protoc_gen_validate": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~com_github_envoyproxy_protoc_gen_validate","importpath":"--github.com/envoyproxy/protoc-gen-validate","build_directives":["--gazelle:build_file_name BUILD.bazel"],"build_file_generation":"--on","patches":[],"patch_args":[],"sum":"--h1:kt9FtLiooDc0vbwTLhdg3dyNX1K9Qwa1EK9LcD4jVUQ=","replace":"--","version":"--v1.0.1"}
+          "attributes": {"name":"--gazelle~override~go_deps~com_github_envoyproxy_protoc_gen_validate","importpath":"--github.com/envoyproxy/protoc-gen-validate","build_directives":["--gazelle:build_file_name BUILD.bazel"],"build_file_generation":"--on","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:kt9FtLiooDc0vbwTLhdg3dyNX1K9Qwa1EK9LcD4jVUQ=","replace":"--","version":"--v1.0.1"}
         },
         "org_golang_x_sys": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_sys","importpath":"--golang.org/x/sys","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=","replace":"--","version":"--v0.12.0"}
+          "attributes": {"name":"--gazelle~override~go_deps~org_golang_x_sys","importpath":"--golang.org/x/sys","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=","replace":"--","version":"--v0.12.0"}
         }
       }
     },

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1015,7 +1015,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "UbsXI/pKqJGKgGEvF3NdJeiekaFnMih9dP4U4/mP89A=",
+      "bzlTransitiveDigest": "dtNBKTx0oxsD0FtL0HK1lPZPkGpFrAGsDAfsWMKaZK4=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -988,7 +988,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
-      "bzlTransitiveDigest": "Fs6FNx96GwUeeHupWLq5+3waobJ48g39/KdJ2uTYoYY=",
+      "bzlTransitiveDigest": "RTvzANN2+/EJOBq18Leq/MKK1ZjvSj0R51rzhxUZZis=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {
@@ -1015,7 +1015,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "Fs6FNx96GwUeeHupWLq5+3waobJ48g39/KdJ2uTYoYY=",
+      "bzlTransitiveDigest": "RTvzANN2+/EJOBq18Leq/MKK1ZjvSj0R51rzhxUZZis=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -988,14 +988,14 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
-      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
+      "bzlTransitiveDigest": "gjeaDf1/bJ6w+0PQ7ruXjUQuJnaHnsQbmXf/h+N2cLE=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {
         "com_github_stretchr_testify": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~com_github_stretchr_testify","importpath":"--github.com/stretchr/testify","build_directives":["--gazelle:go_naming_convention import"],"build_file_generation":"--auto","patches":["@@test_dep~override//patches:testify.patch"],"patch_args":["---p1"],"sum":"--h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=","replace":"--","version":"--v1.8.0"}
+          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~com_github_stretchr_testify","importpath":"--github.com/stretchr/testify","build_directives":["--gazelle:go_naming_convention import"],"build_file_generation":"--auto","build_extra_args":[],"patches":["@@test_dep~override//patches:testify.patch"],"patch_args":["---p1"],"sum":"--h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=","replace":"--","version":"--v1.8.0"}
         },
         "bazel_gazelle_go_repository_config": {
           "bzlFile": "@@gazelle~override//internal/bzlmod:go_deps.bzl",
@@ -1005,17 +1005,17 @@
         "com_github_davecgh_go_spew": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~com_github_davecgh_go_spew","importpath":"--github.com/davecgh/go-spew","build_directives":[],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=","replace":"--","version":"--v1.1.1"}
+          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~com_github_davecgh_go_spew","importpath":"--github.com/davecgh/go-spew","build_directives":[],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=","replace":"--","version":"--v1.1.1"}
         },
         "in_gopkg_yaml_v3": {
           "bzlFile": "@@gazelle~override//internal:go_repository.bzl",
           "ruleClassName": "go_repository",
-          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~in_gopkg_yaml_v3","importpath":"--gopkg.in/yaml.v3","build_directives":["--gazelle:go_naming_convention import"],"build_file_generation":"--auto","patches":[],"patch_args":[],"sum":"--h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=","replace":"--","version":"--v3.0.1"}
+          "attributes": {"name":"--gazelle~override~_go_deps~test_dep~~go_deps~in_gopkg_yaml_v3","importpath":"--gopkg.in/yaml.v3","build_directives":["--gazelle:go_naming_convention import"],"build_file_generation":"--auto","build_extra_args":[],"patches":[],"patch_args":[],"sum":"--h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=","replace":"--","version":"--v3.0.1"}
         }
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "dtNBKTx0oxsD0FtL0HK1lPZPkGpFrAGsDAfsWMKaZK4=",
+      "bzlTransitiveDigest": "gjeaDf1/bJ6w+0PQ7ruXjUQuJnaHnsQbmXf/h+N2cLE=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",


### PR DESCRIPTION
**What type of PR is this?**

Fix

**What package or component does this PR mostly affect?**

bzlmod

**What does this PR do? Why is it needed?**

When using `bzlmod` the `gazelle_override` doesn't support command line arguments to pass to Gazelle.
This PR adds the `build_extra_args` attribute

**Which issues(s) does this PR fix?**

Fixes #1647
