### PR TITLE
Support parsing labels that begin '@@'

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -82,6 +82,10 @@ func Parse(s string) (Label, error) {
 
 	relative := true
 	var repo string
+	// if target name begins @@ drop the first @
+	if strings.HasPrefix(s, "@@") {
+		s = s[len("@"):]
+	}
 	if strings.HasPrefix(s, "@") {
 		relative = false
 		endRepo := strings.Index(s, "//")

--- a/label/label_test.go
+++ b/label/label_test.go
@@ -87,6 +87,7 @@ func TestParse(t *testing.T) {
 		{str: "@a//some/pkg/[someId]:[someId]", want: Label{Repo: "a", Pkg: "some/pkg/[someId]", Name: "[someId]"}},
 		{str: "@rules_python~0.0.0~pip~name_dep//:_pkg", want: Label{Repo: "rules_python~0.0.0~pip~name_dep", Name: "_pkg"}},
 		{str: "@rules_python~0.0.0~pip~name//:dep_pkg", want: Label{Repo: "rules_python~0.0.0~pip~name", Name: "dep_pkg"}},
+		{str: "@@rules_python~0.26.0~python~python_3_10_x86_64-unknown-linux-gnu//:python_runtimes", want: Label{Repo: "rules_python~0.26.0~python~python_3_10_x86_64-unknown-linux-gnu", Name: "python_runtimes"}},
 	} {
 		got, err := Parse(tc.str)
 		if err != nil && !tc.wantErr {


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
gazelle as a library

**What does this PR do? Why is it needed?**
After upgrading to Bazel 6.4.0, target-determinator, which uses `label.Parse` from Gazelle fails with an error as described in the referenced issue.

**Which issues(s) does this PR fix?**

Fixes #1650

**Other notes for review**
