### PR TITLE
Fix path for google/gnostic-models

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -33,6 +33,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/google/gnostic": [
         "gazelle:proto disable",
     ],
+    "github.com/google/gnostic-models": [
+        "gazelle:proto disable",
+    ],
     "github.com/google/safetext": [
         "gazelle:build_file_name BUILD.bazel",
         "gazelle:build_file_proto_mode disable_global",
@@ -41,9 +44,6 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:proto disable",
     ],
     "github.com/googleapis/gnostic": [
-        "gazelle:proto disable",
-    ],
-    "github.com/googleapis/gnostic-models": [
         "gazelle:proto disable",
     ],
     "google.golang.org/grpc": [

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -988,7 +988,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
-      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
+      "bzlTransitiveDigest": "AiaY10NhWcgsalMu5ilFj340MbOBXt7eNCCvYgVDXkc=",
       "accumulatedFileDigests": {},
       "envVariables": {},
       "generatedRepoSpecs": {
@@ -1015,7 +1015,7 @@
       }
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
-      "bzlTransitiveDigest": "bLVsEKSV08GAeuZX8095gby0x521phmbd1X2jIaIHhc=",
+      "bzlTransitiveDigest": "AiaY10NhWcgsalMu5ilFj340MbOBXt7eNCCvYgVDXkc=",
       "accumulatedFileDigests": {
         "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
         "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",


### PR DESCRIPTION
I messed up this path. Looks like github.com/googleapis/gnostic directs to github.com/google/gnostic, but there's no equivalent redirect for gnostic-models.