### PR TITLE
feat(bzlmod): allow patches in `archive_override`s

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -152,6 +152,8 @@ def _process_archive_override(archive_override_tag):
         urls = archive_override_tag.urls,
         sha256 = archive_override_tag.sha256,
         strip_prefix = archive_override_tag.strip_prefix,
+        patches = archive_override_tag.patches,
+        patch_strip = archive_override_tag.patch_strip,
     )
 
 def _extension_metadata(module_ctx, *, root_module_direct_deps, root_module_direct_dev_deps):
@@ -393,6 +395,8 @@ def _go_deps_impl(module_ctx):
                 "urls": archive_override.urls,
                 "strip_prefix": archive_override.strip_prefix,
                 "sha256": archive_override.sha256,
+                "patches": _get_patches(path, archive_overrides),
+                "patch_args": _get_patch_args(path, archive_overrides),
             })
         else:
             go_repository_args.update({
@@ -509,6 +513,13 @@ _archive_override_tag = tag_class(
             doc = """If the repository is downloaded via HTTP (`urls` is set), this is the
             SHA-256 sum of the downloaded archive. When set, Bazel will verify the archive
             against this sum before extracting it.""",
+        ),
+        "patches": attr.label_list(
+            doc = "A list of patches to apply to the repository *after* gazelle runs.",
+        ),
+        "patch_strip": attr.int(
+            default = 0,
+            doc = "The number of leading path segments to be stripped from the file name in the patches.",
         ),
     },
     doc = "Override the default source location on a given Go module in this extension.",

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -59,6 +59,10 @@ go_deps.archive_override(
     urls = [
         "https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz",
     ],
+    patch_strip = 1,
+    patches = [
+        "//patches:buildtools.patch",
+    ],
     strip_prefix = "buildtools-ae8e3206e815d086269eb208b01f300639a4b194",
     path = "github.com/bazelbuild/buildtools",
     sha256 = "05d7c3d2bd3cc0b02d15672fefa0d6be48c7aebe459c1c99dced7ac5e598508f",

--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "105c6aed54358f932e73e9600d1333ed61e10215e3ff5b8903a486518ea466d4",
+  "moduleFileHash": "35778fdefbacb956fac662765e79476a44e508bf686b406b8e20a1c724c83cd9",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -126,6 +126,10 @@
                 "urls": [
                   "https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz"
                 ],
+                "patch_strip": 1,
+                "patches": [
+                  "//patches:buildtools.patch"
+                ],
                 "strip_prefix": "buildtools-ae8e3206e815d086269eb208b01f300639a4b194",
                 "path": "github.com/bazelbuild/buildtools",
                 "sha256": "05d7c3d2bd3cc0b02d15672fefa0d6be48c7aebe459c1c99dced7ac5e598508f"
@@ -148,7 +152,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 68,
+                "line": 72,
                 "column": 15
               }
             },
@@ -163,7 +167,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 74,
+                "line": 78,
                 "column": 25
               }
             },
@@ -178,7 +182,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 82,
+                "line": 86,
                 "column": 15
               }
             }
@@ -1335,7 +1339,7 @@
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
       "general": {
-        "bzlTransitiveDigest": "RTvzANN2+/EJOBq18Leq/MKK1ZjvSj0R51rzhxUZZis=",
+        "bzlTransitiveDigest": "hxVTSAg3X82nHfibhRDy0s6HkpFt+/TM4p5q9fgmPj8=",
         "accumulatedFileDigests": {
           "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
           "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",
@@ -1471,8 +1475,12 @@
               ],
               "build_file_generation": "auto",
               "build_extra_args": [],
-              "patches": [],
-              "patch_args": [],
+              "patches": [
+                "@@//patches:buildtools.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ],
               "urls": [
                 "https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz"
               ],
@@ -1885,7 +1893,7 @@
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
       "general": {
-        "bzlTransitiveDigest": "RTvzANN2+/EJOBq18Leq/MKK1ZjvSj0R51rzhxUZZis=",
+        "bzlTransitiveDigest": "hxVTSAg3X82nHfibhRDy0s6HkpFt+/TM4p5q9fgmPj8=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/tests/bcr/patches/buildtools.patch
+++ b/tests/bcr/patches/buildtools.patch
@@ -1,0 +1,13 @@
+diff --git a/labels/labels.go b/labels/labels.go
+index 7564621..aba07c0 100644
+--- a/labels/labels.go
++++ b/labels/labels.go
+@@ -23,6 +23,8 @@ import (
+ 	"strings"
+ )
+ 
++const Patched = "hello"
++
+ // Label represents a Bazel target label.
+ type Label struct {
+ 	Repository string // Repository of the target, can be empty if the target belongs to the current repository

--- a/tests/bcr/pkg/pkg_test.go
+++ b/tests/bcr/pkg/pkg_test.go
@@ -73,3 +73,7 @@ func TestArchiveOverrideUsed(t *testing.T) {
 	label := labels.Parse("@com_github_bazelbuild_buildtools//labels:labels")
 	require.NotEmpty(t, label)
 }
+
+func TestArchiveOverrideWithPatch(t *testing.T) {
+	require.Equal(t, labels.Patched, "hello")
+}


### PR DESCRIPTION
There are times when we need to specify custom `urls`, custom `directives` and custom `patches` to an archive. 

We should allow users to apply `patches` to the `archive_override`, similar to https://docs.bazel.build/versions/5.0.0/skylark/lib/globals.html#archive_override