### PR TITLE
fix(bzlmod): fail on unused overrides

### DIFF
--- a/tests/bcr/MODULE.bazel.lock
+++ b/tests/bcr/MODULE.bazel.lock
@@ -1339,7 +1339,7 @@
     },
     "@gazelle~override//:extensions.bzl%go_deps": {
       "general": {
-        "bzlTransitiveDigest": "hxVTSAg3X82nHfibhRDy0s6HkpFt+/TM4p5q9fgmPj8=",
+        "bzlTransitiveDigest": "L3AZyX5+0E4G4CLl2qHH0wR716rVmra4pU+jYAVPz4A=",
         "accumulatedFileDigests": {
           "@@//:go.mod": "8e62c686b94b37593b38766d425ceccbf86a9b07c0121feaaf42293050a42ae3",
           "@@circl~1.3.3//:go.mod": "68b12e4662bb0639728490153ffc52d8bdd63be558bdd41bcb0d8f1eeeb03e41",
@@ -1893,7 +1893,7 @@
     },
     "@gazelle~override//:extensions.bzl%go_deps%test_dep@_~go_deps": {
       "general": {
-        "bzlTransitiveDigest": "hxVTSAg3X82nHfibhRDy0s6HkpFt+/TM4p5q9fgmPj8=",
+        "bzlTransitiveDigest": "L3AZyX5+0E4G4CLl2qHH0wR716rVmra4pU+jYAVPz4A=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {


### PR DESCRIPTION
### What does this PR do?

We should not allow users to specify overrides to Go dependencies which aren't defined. This adds a failure case for scenarios when overrides are declared by a user for a path that isn't loaded by the `go_deps` extension.

Fixes #[1668](https://github.com/bazelbuild/bazel-gazelle/issues/1668)

### Test Plan

```
tfrench@tfrench-go ~/bazel-gazelle/tests/bcr
 % git diff
diff --git a/tests/bcr/MODULE.bazel b/tests/bcr/MODULE.bazel
index 19c0c7e..a37b882 100644
--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -48,6 +48,14 @@ go_deps.module_override(
     path = "github.com/stretchr/testify",
 )
 
+go_deps.module_override(
+    patch_strip = 1,
+    patches = [
+        "//patches:testify.patch",
+    ],
+    path = "doesn't exist",
+)
+
 # Test an archive override from a known archive.
 go_deps.gazelle_override(
     directives = [
tfrench@tfrench-go ~/bazel-gazelle/tests/bcr
 % bazel-6.4.0 test //...                          
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 21cb2db5-6b11-45dc-8408-691d3ac55897
ERROR: Traceback (most recent call last):
        File "/home/user/.cache/bazel/_bazel_tfrench/d4c0c5951b0da2028e754ca4d0c138af/external/gazelle~override/internal/bzlmod/go_deps.bzl", line 325, column 33, in _go_deps_impl
                _fail_on_unmatched_overrides(module_overrides.keys(), module_resolutions, "module_overrides")
        File "/home/user/.cache/bazel/_bazel_tfrench/d4c0c5951b0da2028e754ca4d0c138af/external/gazelle~override/internal/bzlmod/go_deps.bzl", line 70, column 13, in _fail_on_unmatched_overrides
                fail("Some {} did not target a Go module with a matching path: {}".format(
Error in fail: Some module_overrides did not target a Go module with a matching path: doesn't exist
ERROR: Analysis of target '//pkg/data:data' failed; build aborted: error evaluating module extension go_deps in @gazelle~override//:extensions.bzl
INFO: Elapsed time: 4.796s
INFO: 0 processes.
ERROR: Couldn't start the build. Unable to run tests
FAILED: Build did NOT complete successfully (64 packages loaded, 499 targets configured)
    Fetching ...es_go~0.42.0~go_sdk~go_default_sdk; Downloading and extracting Go toolchain
tfrench@tfrench-go ~/bazel-gazelle/tests/bcr
```