### PR TITLE
docs: fix target for python plugin

### DIFF
--- a/extend.md
+++ b/extend.md
@@ -53,7 +53,7 @@ load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle_binary")
 gazelle_binary(
     name = "gazelle",
     languages = [
-        "@rules_python//gazelle",  # Use gazelle from rules_python.
+        "@rules_python_gazelle_plugin//python",  # Use gazelle from rules_python.
         "@bazel_gazelle//language/go",  # Built-in rule from gazelle for Golang.
         "@bazel_gazelle//language/proto",  # Built-in rule from gazelle for Protos.
          # Any languages that depend on Gazelle's proto plugin must come after it.


### PR DESCRIPTION
**What type of PR is this?**

Documentation


**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Change the example for how to use python plugin with other languages to use the rules_python_gazelle_plugin. This avoids errors with references to @bazel_gazelle. 

**Which issues(s) does this PR fix?**

None

**Other notes for review**

Ref: https://bazelbuild.slack.com/archives/CA306CEV6/p1700567711994209 
