### PR TITLE
feat(tools): add a tool to automate the generation of go_deps overrides

### DIFF
--- a/internal/go_repository_tools_srcs.bzl
+++ b/internal/go_repository_tools_srcs.bzl
@@ -126,6 +126,8 @@ GO_REPOSITORY_TOOLS_SRCS = [
     Label("//testtools:config.go"),
     Label("//testtools:files.go"),
     Label("//tools:BUILD.bazel"),
+    Label("//tools/override-generator:BUILD.bazel"),
+    Label("//tools/override-generator:main.go"),
     Label("//tools/releaser:BUILD.bazel"),
     Label("//tools/releaser:main.go"),
     Label("//walk:BUILD.bazel"),

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
+        "//tools/override-generator:all_files",
         "//tools/releaser:all_files",
     ],
     visibility = ["//visibility:public"],

--- a/tools/override-generator/BUILD.bazel
+++ b/tools/override-generator/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_binary(
+    name = "override-generator",
+    embed = [":override-generator_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "override-generator_test",
+    srcs = ["main_test.go"],
+    embed = [":override-generator_lib"],
+)
+
+go_library(
+    name = "override-generator_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/bazelbuild/bazel-gazelle/tools/override-generator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//repo",
+        "//rule",
+        "@com_github_bazelbuild_buildtools//build",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+        "README.md",
+        "main.go",
+        "main_test.go",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/override-generator/README.md
+++ b/tools/override-generator/README.md
@@ -1,0 +1,25 @@
+# Bazel Go Repository to Gazelle Overrides Converter
+
+## WARNING: In development. This tool may functionally change and an experimental project.
+
+## Description
+This script converts `go_repository` rules to Gazelle `go_deps` overrides to assist in the migration to Bzlmod.
+
+## Usage
+Run the script with the following flags:
+
+- `--macro`: Path to a macro file to translate to overrides.
+- `--def_name`: Name of the macro's function name that loads the `go_repository` rules.
+- `--workspace`: Path to the workspace file, to load translate all rules loaded from the workspace.
+- `--output`: Path to the output file.
+- `--help`: Show help message.
+
+Only one of `--macro` or `--workspace` should be specified. The `--def_name` is required when `--macro` is specified.
+
+Example:
+```
+go run main.go --workspace /path/to/WORKSPACE --output /path/to/output.bzl
+```
+
+## Output
+The script outputs a file containing `go_deps` overrides based on the provided `go_repository` rules.

--- a/tools/override-generator/main.go
+++ b/tools/override-generator/main.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/buildtools/build"
+)
+
+const (
+	_name  = "override-generator"
+	_usage = "usage: This script converts `go_repository` rules to Gazelle `go_deps` overrides to assist in the migration to Bzlmod."
+)
+
+// override kinds.
+const (
+	_goDepsf         = `go_deps = use_extension("%s//:extensions.bzl", "go_deps")`
+	_gazelleOverride = "go_deps.gazelle_override"
+	_archiveOverride = "go_deps.archive_override"
+	_moduleOverride  = "go_deps.module_override"
+)
+
+// attribute constants that are used multiple times.
+const (
+	_buildFileGenerationAttr = "build_file_generation"
+	_buildFileProtoModeAttr  = "build_file_proto_mode"
+	_patchArgsAttr           = "patch_args"
+	_buildDirectivesAttr     = "build_directives"
+	_directivesAttr          = "directives"
+)
+
+var _defaultValues = map[string]string{
+	_buildFileGenerationAttr: "auto",
+	_buildFileProtoModeAttr:  "default",
+}
+
+var _mapAttrToOverride = map[string]string{
+	_buildDirectivesAttr:     _gazelleOverride,
+	_buildFileGenerationAttr: _gazelleOverride,
+	_patchArgsAttr:           _moduleOverride,
+	"patches":                _moduleOverride,
+	"build_extra_args":       _gazelleOverride,
+	"urls":                   _archiveOverride,
+	"strip_prefix":           _archiveOverride,
+	"sha256":                 _archiveOverride,
+}
+
+var _attrOverrideKeys = map[string]string{
+	_buildDirectivesAttr: _directivesAttr,
+}
+
+type overrideSet map[string]*rule.Rule
+
+type mainArgs struct {
+	macroPath       string
+	workspace       string
+	defName         string
+	outputFile      string
+	gazelleRepoName string
+}
+
+func main() {
+	a, err := parseArgs(os.Stderr, os.Args[1:])
+	if err != nil && !errors.Is(err, flag.ErrHelp) {
+		log.Fatalf("%+v", err)
+	}
+	if err := run(*a, os.Stderr); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseArgs(stderr io.Writer, osArgs []string) (*mainArgs, error) {
+	a := &mainArgs{}
+	flag := flag.NewFlagSet(_name, flag.ContinueOnError)
+	flag.SetOutput(stderr)
+	flag.Usage = func() {
+		fmt.Fprintf(flag.Output(), _usage)
+		flag.PrintDefaults()
+	}
+	flag.StringVar(&a.macroPath, "macro", "", "path to the macro file")
+	flag.StringVar(&a.workspace, "workspace", "", "path to workspace")
+	flag.StringVar(&a.defName, "def_name", "", "name of the macro definition")
+	flag.StringVar(&a.outputFile, "output", "", "path to the output file")
+	flag.StringVar(&a.gazelleRepoName, "gazelle_repo_name", "@bazel_gazelle", "name of the gazelle repo to load go_deps, (default: @bazel_gazelle)")
+	flag.Parse(osArgs)
+
+	if a.macroPath != "" && a.workspace != "" {
+		return nil, fmt.Errorf("only one of -macro or -workspace can be specified")
+	}
+	if a.macroPath == "" && a.workspace == "" {
+		return nil, fmt.Errorf("missing required flag: -macro or -workspace")
+	}
+	if a.macroPath != "" && a.defName == "" {
+		return nil, fmt.Errorf("missing required flag: -def_name when -macro is specified")
+	}
+	if a.outputFile == "" {
+		return nil, fmt.Errorf("missing required flag: -output")
+	}
+	return a, nil
+}
+
+func run(a mainArgs, stderr io.Writer) error {
+	var w *rule.File
+	var err error
+	if a.macroPath != "" {
+		w, err = rule.LoadMacroFile(a.macroPath, "", a.defName)
+		if err != nil {
+			return err
+		}
+	} else {
+		w, err = rule.LoadWorkspaceFile(a.workspace, "")
+		if err != nil {
+			return err
+		}
+	}
+	repos, _, err := repo.ListRepositories(w)
+	if err != nil {
+		return err
+	}
+	sort.Slice(repos, func(i, j int) bool {
+		return repos[i].Name() < repos[j].Name()
+	})
+
+	var outputOverrides []*rule.Rule
+
+	// Iterate over all repositories and convert them to override rules
+	// The repos are ordered by "name", and the sets are sorted, so the output
+	// will be deterministic.
+	for _, r := range repos {
+		if r.Kind() == "go_repository" {
+			repoOverrides := goRepositoryToOverrideSet(r)
+			outputOverrides = append(outputOverrides, setToOverridesSlice(repoOverrides)...)
+		}
+	}
+
+	if len(outputOverrides) == 0 {
+		fmt.Fprintln(stderr, "no overrides are needed for these repos!")
+		return nil
+	}
+
+	f, err := rule.LoadData(a.outputFile, "", []byte(fmt.Sprintf(_goDepsf, a.gazelleRepoName)))
+	if err != nil {
+		return err
+	}
+	for _, o := range outputOverrides {
+		o.Insert(f)
+	}
+
+	if err := f.Save(a.outputFile); err != nil {
+		return fmt.Errorf("error saving file: %w", err)
+	}
+
+	return nil
+}
+
+func goRepositoryToOverrideSet(r *rule.Rule) overrideSet {
+	// each repo has its own override set, and can't have multiple
+	// duplicate overrides. This set is created to be populated and read
+	set := make(overrideSet)
+	importPath := r.AttrString("importpath")
+
+	// Load the attribute keys from the rule.
+	attrs := r.AttrKeys()
+	for _, attr := range attrs {
+		if _, ok := _mapAttrToOverride[attr]; !ok {
+			continue
+		}
+
+		attrValue := r.Attr(attr)
+		if attrValue == nil || attr == _buildFileProtoModeAttr {
+			continue
+		}
+
+		kind := _mapAttrToOverride[attr]
+		override := rule.NewRule(kind, "")
+		if o, ok := set[kind]; ok {
+			override = o
+		}
+		override.SetAttr("path", importPath)
+		val := r.Attr(attr)
+
+		// Special case for certain renamed attributes like "build_directives"
+		// attribute to convert to "directives" attribute.
+		if k, ok := _attrOverrideKeys[attr]; ok {
+			attr = k
+		}
+
+		if def, ok := _defaultValues[attr]; def == r.AttrString(attr) && ok {
+			continue
+		}
+
+		if val != nil {
+			switch v := val.(type) {
+			case *build.StringExpr:
+				override.SetAttr(attr, v)
+			case *build.ListExpr:
+				// Special case for "patch_args" attribute to convert to
+				// "patch_strip" attribute.
+				if attr == _patchArgsAttr {
+					setPatchArgs(r.AttrStrings(_patchArgsAttr), override)
+				} else {
+					override.SetAttr(attr, v)
+				}
+			}
+		}
+
+		set[kind] = override
+	}
+
+	// Since "build_file_proto_mode" is added to the "directives", we need
+	// to run it after the fact to make sure that "directives" is set.
+	applyBuildFileProtoMode(r, set)
+	return set
+}
+
+func applyBuildFileProtoMode(r *rule.Rule, set overrideSet) {
+	if r.Attr(_buildFileProtoModeAttr) == nil {
+		return
+	}
+
+	if def, ok := _defaultValues[_buildFileProtoModeAttr]; def == r.AttrString(_buildFileProtoModeAttr) && ok {
+		return
+	}
+
+	directive := "gazelle:proto " + r.AttrString(_buildFileProtoModeAttr)
+	kind := _gazelleOverride
+	override := rule.NewRule(kind, "")
+	if o, ok := set[kind]; ok {
+		override = o
+	}
+	directives := override.AttrStrings(_directivesAttr)
+	directives = append(directives, directive)
+	override.SetAttr(_directivesAttr, directives)
+	set[kind] = override
+}
+
+func setPatchArgs(patchArgs []string, override *rule.Rule) {
+	for _, arg := range patchArgs {
+		if !strings.HasPrefix(arg, "-p") {
+			continue
+		}
+		numStr := strings.TrimPrefix(arg, "-p")
+		if num, err := strconv.Atoi(numStr); err == nil {
+			override.SetAttr("patch_strip", num)
+			return
+		}
+	}
+}
+
+func setToOverridesSlice(set overrideSet) []*rule.Rule {
+	// Check if both archive and module overrides exist
+	if archiveOverride, archiveExists := set[_archiveOverride]; archiveExists {
+		if moduleOverride, moduleExists := set[_moduleOverride]; moduleExists {
+			// Merge attributes from module override into archive override
+			mergeAttributes(moduleOverride, archiveOverride)
+			// Remove the module override as its attributes are now merged
+			delete(set, _moduleOverride)
+		}
+	}
+
+	// Create a sorted slice of the remaining override keys
+	var keys []string
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Create a slice of overrides based on the sorted keys
+	var overrides []*rule.Rule
+	for _, k := range keys {
+		overrides = append(overrides, set[k])
+	}
+	return overrides
+}
+
+func mergeAttributes(source, destination *rule.Rule) {
+	for _, attr := range source.AttrKeys() {
+		if val := source.Attr(attr); val != nil {
+			destination.SetAttr(attr, val)
+		}
+	}
+}

--- a/tools/override-generator/main_test.go
+++ b/tools/override-generator/main_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBzlmodOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+		want string
+	}{
+		{
+			name: "simple no override",
+			give: `load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+			go_repository(
+				name = "com_github_apache_thrift",
+				build_file_generation = "auto",
+				build_file_proto_mode = "default",
+				importpath = "github.com/apache/thrift",
+				sum = "h1:cMd2aj52n+8VoAtvSvLn4kDC3aZ6IAkBuqWQ2IDu7wo=",
+				version = "v0.17.0",
+			)`,
+			want: "",
+		},
+		{
+			name: "simple override",
+			give: `load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+			go_repository(
+				name = "com_github_apache_thrift",
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "on",
+				build_file_proto_mode = "disable",
+				importpath = "github.com/apache/thrift",
+				sum = "h1:cMd2aj52n+8VoAtvSvLn4kDC3aZ6IAkBuqWQ2IDu7wo=",
+				version = "v0.17.0",
+			)`,
+			want: `go_deps = use_extension("//:extensions.bzl", "go_deps")
+
+			go_deps.gazelle_override(
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "on",
+				directives = ["gazelle:proto disable"],
+				path = "github.com/apache/thrift",
+			)`,
+		},
+		{
+			name: "module override and gazelle",
+			give: `load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+			go_repository(
+				name = "com_github_bazelbuild_bazel_watcher",
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "off",  # keep
+				build_file_proto_mode = "disable",
+				importpath = "github.com/bazelbuild/bazel-watcher",
+				patch_args = ["-p1"],
+				patches = [
+					# Remove it after they release this PR https://github.com/bazelbuild/bazel-watcher/pull/627
+					"//patches:com_github_bazelbuild_bazel_watcher-go-embed.patch",
+				],
+				sum = "h1:EfJzkMxJuNBGMVdEvkhiW7pAMwhaegbmAMaFCjLjyTw=",
+				version = "v0.23.7",
+			)`,
+			want: `go_deps = use_extension("//:extensions.bzl", "go_deps")
+
+			go_deps.gazelle_override(
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "off",
+				directives = ["gazelle:proto disable"],
+				path = "github.com/bazelbuild/bazel-watcher",
+			)
+
+			go_deps.module_override(
+				patch_strip = 1,
+				patches = [
+					# Remove it after they release this PR https://github.com/bazelbuild/bazel-watcher/pull/627
+					"//patches:com_github_bazelbuild_bazel_watcher-go-embed.patch",
+				],
+				path = "github.com/bazelbuild/bazel-watcher",
+			)`,
+		},
+		{
+			name: "directives and proto args",
+			give: `go_repository(
+				name = "com_github_clickhouse_clickhouse_go_v2",
+				build_directives = [
+					"gazelle:resolve go github.com/ClickHouse/clickhouse-go/v2/external @com_github_clickhouse_clickhouse_go_v2//external",
+				],
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "on",
+				build_file_proto_mode = "disable",
+				importpath = "github.com/ClickHouse/clickhouse-go/v2",
+				sum = "h1:Nbl/NZwoM6LGJm7smNBgvtdr/rxjlIssSW3eG/Nmb9E=",
+				version = "v2.0.12",
+			)`,
+			want: `go_deps = use_extension("//:extensions.bzl", "go_deps")
+
+			go_deps.gazelle_override(
+				build_extra_args = ["-go_naming_convention_external=go_default_library"],
+				build_file_generation = "on",
+				directives = [
+					"gazelle:resolve go github.com/ClickHouse/clickhouse-go/v2/external @com_github_clickhouse_clickhouse_go_v2//external",
+					"gazelle:proto disable",
+				],
+				path = "github.com/ClickHouse/clickhouse-go/v2",
+			)`,
+		},
+		{
+			name: "archive overrides",
+			give: `go_repository(
+				name = "org_golang_x_tools_cmd_goimports",
+				build_extra_args = [
+					"-go_prefix=golang.org/x/tools",
+					"-exclude=**/testdata",
+				],
+				build_file_generation = "on",
+				build_file_proto_mode = "disable",
+				importpath = "golang.org/x/tools/cmd/goimports",
+				patch_args = ["-p1"],
+				strip_prefix = "golang.org/x/tools@v0.0.0-20200512131952-2bc93b1c0c88",
+				sha256 = "4a6497e0bf1f19c8089dd02e7ba1351ba787f434d62971ff14fb627e57914939",
+				patches = [
+					"//patches:org_golang_x_tools_cmd_goimports.patch",
+				],
+				urls = [
+					"https://goproxy.uberinternal.com/golang.org/x/tools/@v/v0.0.0-20200512131952-2bc93b1c0c88.zip",
+				],
+			)`,
+			want: `go_deps = use_extension("//:extensions.bzl", "go_deps")
+
+			go_deps.archive_override(
+				patch_strip = 1,
+				patches = [
+					"//patches:org_golang_x_tools_cmd_goimports.patch",
+				],
+				path = "golang.org/x/tools/cmd/goimports",
+				sha256 = "4a6497e0bf1f19c8089dd02e7ba1351ba787f434d62971ff14fb627e57914939",
+				strip_prefix = "golang.org/x/tools@v0.0.0-20200512131952-2bc93b1c0c88",
+				urls = [
+					"https://goproxy.uberinternal.com/golang.org/x/tools/@v/v0.0.0-20200512131952-2bc93b1c0c88.zip",
+				],
+			)
+
+			go_deps.gazelle_override(
+				build_extra_args = [
+					"-go_prefix=golang.org/x/tools",
+					"-exclude=**/testdata",
+				],
+				build_file_generation = "on",
+				directives = ["gazelle:proto disable"],
+				path = "golang.org/x/tools/cmd/goimports",
+			)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := t.TempDir()
+			testWorkspace := filepath.Join(w, "WORKSPACE")
+			if err := os.WriteFile(testWorkspace, []byte(removeTabsAndTrimLines(tt.give)), 0644); err != nil {
+				t.Errorf("error writing test workspace file: %v", err)
+			}
+
+			args := &mainArgs{
+				workspace:  testWorkspace,
+				outputFile: filepath.Join(w, "output.bzl"),
+			}
+
+			if err := run(*args, io.Discard); err != nil {
+				t.Errorf("run() error = %v, want no error", err)
+			}
+
+			if tt.want == "" {
+				return
+			}
+
+			content, err := os.ReadFile(args.outputFile)
+			if err != nil {
+				t.Errorf("error reading output file: %v", err)
+			}
+
+			if !isEqualContent(string(content), tt.want) {
+				fmt.Fprintf(os.Stderr, "output = %v, want %v", string(content), tt.want)
+				t.Errorf("output = %v, want %v", string(content), tt.want)
+			}
+		})
+	}
+}
+
+func isEqualContent(str1, str2 string) bool {
+	cleanStr1 := removeTabsAndTrimLines(str1)
+	cleanStr2 := removeTabsAndTrimLines(str2)
+
+	return cleanStr1 == cleanStr2
+}
+
+// removeTabsAndTrimLines removes tabs, trims leading and trailing spaces on each line,
+// and trims leading and trailing newlines from the entire string.
+func removeTabsAndTrimLines(str string) string {
+	lines := strings.Split(str, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(strings.ReplaceAll(line, "\t", ""))
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}


### PR DESCRIPTION
This PR creates a tool that converts either a repository macro file or a WORKSPACE into a set of `go_deps.{}_overrides`. This is supposed to ease the migration to Bzlmod.

For example, if you were to run on this `go_repository` rule:

```
    go_repository(
        name = "com_github_bazelbuild_bazel_watcher",
        build_extra_args = ["-go_naming_convention_external=go_default_library"],
        build_file_generation = "off",  # keep
        build_file_proto_mode = "disable",
        importpath = "github.com/bazelbuild/bazel-watcher",
        patch_args = ["-p1"],
        patches = [
            # Remove it after they release this PR https://github.com/bazelbuild/bazel-watcher/pull/627
            "//patches:com_github_bazelbuild_bazel_watcher-go-embed.patch",
        ],
        sum = "h1:EfJzkMxJuNBGMVdEvkhiW7pAMwhaegbmAMaFCjLjyTw=",
        version = "v0.23.7",
    )
```

It would output
```
go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")

go_deps.gazelle_override(
    build_extra_args = ["-go_naming_convention_external=go_default_library"],
    build_file_generation = "off",
    directives = ["gazelle:proto disable"],
    path = "github.com/bazelbuild/bazel-watcher",
)

go_deps.module_override(
    patch_strip = 1,
    patches = [
        # Remove it after they release this PR https://github.com/bazelbuild/bazel-watcher/pull/627
        "//patches:com_github_bazelbuild_bazel_watcher-go-embed.patch",
    ],
    path = "github.com/bazelbuild/bazel-watcher",
)
```

Fixes #1675 