### PR TITLE
bzlmod: support go.mod replace directives with a version qualifier on the left

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -341,6 +341,14 @@ def _go_deps_impl(module_ctx):
     # in the module resolutions and swapping out the entry.
     for path, replace in replace_map.items():
         if path in module_resolutions:
+
+            # If the replace directive specified a version then we only
+            # apply it if the versions match.
+            if replace.from_version:
+                comparable_from_version = semver.to_comparable(replace.from_version)
+                if module_resolutions[path].version != comparable_from_version:
+                    continue
+
             new_version = semver.to_comparable(replace.version)
             module_resolutions[path] = with_replaced_or_new_fields(
                 module_resolutions[path],

--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -141,7 +141,7 @@ def _parse_directive(state, directive, tokens, comment, path, line_no):
     elif directive == "replace":
         # A replace directive might use a local file path beginning with ./ or ../
         # These are not supported with gazelle~go_deps.
-        if len(tokens) == 3 and tokens[2][0] == ".":
+        if (len(tokens) == 3 and tokens[2][0] == ".") or (len(tokens) > 3 and tokens[3][0] == "."):
             fail("{}:{}: local file path not supported in replace directive: '{}'".format(path, line_no, tokens[2]))
 
         # pattern: replace from_path => to_path to_version

--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -144,16 +144,19 @@ def _parse_directive(state, directive, tokens, comment, path, line_no):
         if (len(tokens) == 3 and tokens[2][0] == ".") or (len(tokens) > 3 and tokens[3][0] == "."):
             fail("{}:{}: local file path not supported in replace directive: '{}'".format(path, line_no, tokens[2]))
 
+        # replacements key off of the from_path
+        from_path = tokens[0]
+
         # pattern: replace from_path => to_path to_version
         if len(tokens) == 4 and tokens[1] == "=>":
-            state["replace"][tokens[0]] = struct(
+            state["replace"][from_path] = struct(
                 from_version = None,
                 to_path = tokens[2],
                 version = _canonicalize_raw_version(tokens[3]),
             )
         # pattern: replace from_path from_version => to_path to_version
         elif len(tokens) == 5 and tokens[2] == "=>":
-            state["replace"][tokens[0]] = struct(
+            state["replace"][from_path] = struct(
                 from_version = _canonicalize_raw_version(tokens[1]),
                 to_path = tokens[3],
                 version = _canonicalize_raw_version(tokens[4]),

--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -144,13 +144,26 @@ def _parse_directive(state, directive, tokens, comment, path, line_no):
         if len(tokens) == 3 and tokens[2][0] == ".":
             fail("{}:{}: local file path not supported in replace directive: '{}'".format(path, line_no, tokens[2]))
 
-        if len(tokens) != 4 or tokens[1] != "=>":
-            fail("{}:{}: replace directive must follow pattern: 'replace from_path => to_path version' ".format(path, line_no))
-        from_path = tokens[0]
-        state["replace"][from_path] = struct(
-            to_path = tokens[2],
-            version = _canonicalize_raw_version(tokens[3]),
-        )
+        # pattern: replace from_path => to_path to_version
+        if len(tokens) == 4 and tokens[1] == "=>":
+            state["replace"][tokens[0]] = struct(
+                from_version = None,
+                to_path = tokens[2],
+                version = _canonicalize_raw_version(tokens[3]),
+            )
+        # pattern: replace from_path from_version => to_path to_version
+        elif len(tokens) == 5 and tokens[2] == "=>":
+            state["replace"][tokens[0]] = struct(
+                from_version = _canonicalize_raw_version(tokens[1]),
+                to_path = tokens[3],
+                version = _canonicalize_raw_version(tokens[4]),
+            )
+        else:
+            fail(
+                "{}:{}: replace directive must follow pattern: ".format(path, line_no) + 
+                "'replace from_path from_version => to_path to_version' or " +
+                "'replace from_path => to_path to_version'"
+            )
 
     # TODO: Handle exclude.
 

--- a/tests/bzlmod/go_mod_test.bzl
+++ b/tests/bzlmod/go_mod_test.bzl
@@ -13,6 +13,7 @@ github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 )
 
 replace github.com/go-fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.2
+replace github.com/bmatcuk/doublestar/v4 v4.0.2 => github.com/bmatcuk/doublestar/v4 v4.0.3
 
 module github.com/bazelbuild/bazel-gazelle
 
@@ -28,7 +29,10 @@ require golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
 _EXPECTED_GO_MOD_PARSE_RESULT = struct(
     go = (1, 18),
     module = "github.com/bazelbuild/bazel-gazelle",
-    replace_map = {"github.com/go-fsnotify/fsnotify": struct(to_path = "github.com/fsnotify/fsnotify", version = "1.4.2")},
+    replace_map = {
+        "github.com/go-fsnotify/fsnotify": struct(from_version = None, to_path = "github.com/fsnotify/fsnotify", version = "1.4.2"),
+        "github.com/bmatcuk/doublestar/v4": struct(from_version = "4.0.2", to_path = "github.com/bmatcuk/doublestar/v4", version = "4.0.3"),
+    },
     require = (
         struct(indirect = False, path = "github.com/bazelbuild/buildtools", version = "v0.0.0-20220531122519-a43aed7014c8"),
         struct(indirect = False, path = "github.com/bazelbuild/rules_go", version = "v0.n\\\"33.0"),


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix / Feature

**What package or component does this PR mostly affect?**

bzlmod support for Go

**What does this PR do? Why is it needed?**

This adds support for `go.mod` replace directives with a version qualifier as described by https://go.dev/ref/mod#go-mod-file-replace.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
