### PR TITLE
Fix partial execution with mapped kinds

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -327,6 +327,9 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		// directory, just index the build file and move on.
 		if !update {
 			if c.IndexLibraries && f != nil {
+				for _, repl := range c.KindMap {
+					mrslv.MappedKind(rel, repl)
+				}
 				for _, r := range f.Rules {
 					ruleIndex.AddRule(c, r, f)
 				}


### PR DESCRIPTION
Previously, if mapped kinds were in use (i.e. `go_library` -> `go_custom_library`), and `gazelle update` was being run on just one directory, Gazelle's indexing system would fail to correctly index build rules of the mapped-to kind in directories that were not being re-built.

This is because the logic to handle mapped kinds was triggered only when Generate() was run, not for Imports().

This PR solves the issue with the smallest fix. The whole kind-mapping system is honestly kinda messy, and I didn't want to propose a major refactor.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

**Other notes for review**
