### PR TITLE
fix(rule): IsEmpty should be false `# keep` on `NonEmptyAttrs`

### DIFF
--- a/merger/merger.go
+++ b/merger/merger.go
@@ -121,6 +121,9 @@ func MergeFile(oldFile *rule.File, emptyRules, genRules []*rule.Rule, phase Phas
 			if oldRule.ShouldKeep() {
 				continue
 			}
+			if oldRule.ShouldKeepAttrs(kinds[oldRule.Kind()]) {
+				continue
+			}
 			rule.MergeRules(emptyRule, oldRule, getMergeAttrs(emptyRule), oldFile.Path)
 			if oldRule.IsEmpty(kinds[oldRule.Kind()]) {
 				oldRule.Delete()

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -1025,6 +1025,17 @@ func (r *Rule) IsEmpty(info KindInfo) bool {
 	return true
 }
 
+// ShouldKeepAttrs checks if any attributes in the info.NonEmptyAttrs
+// have a `# keep` statement.
+func (r *Rule) ShouldKeepAttrs(info KindInfo) bool {
+	for k := range info.NonEmptyAttrs {
+		if attr, ok := r.attrs[k]; ok && attr.expr != nil && ShouldKeep(attr.expr) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Rule) sync() {
 	r.syncComments()
 	if !r.updated {


### PR DESCRIPTION
Rules like this should not be deleted and marked as empty:
```
go_test(
    name = "rule_test",
    srcs = [
        "@something//some_file", // # keep
    ],
    embed = [":rule"],
)
```
If an attr is a part of the `NonEmptyAttrs`, a user's explicit `# keep` on the attribute should prevent the rule from being removed.
