### PR TITLE
gazelle_runner: allow usage of transitive runfiles

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -112,7 +112,7 @@ def _gazelle_runner_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.gazelle,
         go_tool,
-    ] + ([repo_config] if repo_config else [])).merge(
+    ] + ctx.files._bash_runfile_helpers + ([repo_config] if repo_config else [])).merge(
         ctx.attr.gazelle[DefaultInfo].default_runfiles,
     )
     for d in ctx.attr.data:
@@ -152,6 +152,9 @@ _gazelle_runner = rule(
         "extra_args": attr.string_list(),
         "data": attr.label_list(allow_files = True),
         "env": attr.string_dict(),
+        "_bash_runfile_helpers": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
         "_repo_config": attr.label(
             default = "@bazel_gazelle_go_repository_config//:WORKSPACE" if GAZELLE_IS_BAZEL_MODULE else None,
             allow_single_file = True,

--- a/internal/gazelle.bash.in
+++ b/internal/gazelle.bash.in
@@ -27,7 +27,19 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 
 @@GENERATED_MESSAGE@@
 
-set -euo pipefail
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+# Export runfile vars so sub-processes can access them
+runfiles_export_envvars
 
 GAZELLE_PATH=@@GAZELLE_PATH@@
 ARGS=@@ARGS@@


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

The gazelle bash runner.

**What does this PR do? Why is it needed?**

This is a rebase of the work from @greenboxal to support the gazelle java extension use of runfiles to pull in the Java parser.

**Other notes for review**

Closes https://github.com/bazelbuild/bazel-gazelle/pull/828