### PR TITLE
rule: add accessor for attribute comments

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -957,6 +957,16 @@ func (r *Rule) SetAttr(key string, value interface{}) {
 	r.updated = true
 }
 
+// GetAttrComments returns the comments for an attribute.
+// It can be used to attach comments like "do not sort".
+func (r *Rule) GetAttrComments(key string) *bzl.Comments {
+	attr, ok := r.attrs[key]
+	if !ok {
+		return nil
+	}
+	return attr.expr.Comment()
+}
+
 // PrivateAttrKeys returns a sorted list of private attribute names.
 func (r *Rule) PrivateAttrKeys() []string {
 	keys := make([]string, 0, len(r.private))


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

rule/rule.go

**What does this PR do? Why is it needed?**

This allows user to attach comments like "# do not sort" to the assignment expressions maintained by rule.go.

rule.Format() calls into buildtools/build.Format() which in turn calls Rewrite(). Rewrite() by default sorts certain label arguments like "deps" and "hdrs". To preventing this sorting it is possible to provide the comment "# do not sort". However this comment needs to be attached to the assignment expression.
In rule.go the assignment expressions are not exposed to the user, making it impossible to attach the comment to it.

See https://github.com/bazelbuild/bazel-gazelle/issues/237#issuecomment-399476945


**Which issues(s) does this PR fix?**

Fixes #237