### PR TITLE
Remove some usage of deprecated ioutil

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -493,7 +492,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 		}
 	}
 	if uc.patchPath != "" {
-		if err := ioutil.WriteFile(uc.patchPath, uc.patchBuffer.Bytes(), 0o666); err != nil {
+		if err := os.WriteFile(uc.patchPath, uc.patchBuffer.Bytes(), 0o666); err != nil {
 			return err
 		}
 	}
@@ -676,12 +675,12 @@ func findOutputPath(c *config.Config, f *rule.File) string {
 	}
 	outputDir := filepath.Join(baseDir, filepath.FromSlash(f.Pkg))
 	defaultOutputPath := filepath.Join(outputDir, c.DefaultBuildFileName())
-	files, err := ioutil.ReadDir(outputDir)
+	ents, err := os.ReadDir(outputDir)
 	if err != nil {
 		// Ignore error. Directory probably doesn't exist.
 		return defaultOutputPath
 	}
-	outputPath := rule.MatchBuildFileName(outputDir, c.ValidBuildFileNames, files)
+	outputPath := rule.MatchBuildFile(outputDir, c.ValidBuildFileNames, ents)
 	if outputPath == "" {
 		return defaultOutputPath
 	}

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -726,7 +725,7 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 		// Bazel has already fetched io_bazel_rules_go. We can read its version
 		// from //go:def.bzl.
 		defBzlPath := filepath.Join(rulesGoPath, "go", "def.bzl")
-		defBzlContent, err := ioutil.ReadFile(defBzlPath)
+		defBzlContent, err := os.ReadFile(defBzlPath)
 		if err != nil {
 			return nil, err
 		}
@@ -799,7 +798,7 @@ func detectNamingConvention(c *config.Config, rootFile *rule.File) namingConvent
 		var f *rule.File
 		for _, name := range c.ValidBuildFileNames {
 			fpath := filepath.Join(dir, name)
-			data, err := ioutil.ReadFile(fpath)
+			data, err := os.ReadFile(fpath)
 			if err != nil {
 				continue
 			}
@@ -821,15 +820,15 @@ func detectNamingConvention(c *config.Config, rootFile *rule.File) namingConvent
 		}
 	}
 
-	infos, err := ioutil.ReadDir(c.RepoRoot)
+	ents, err := os.ReadDir(c.RepoRoot)
 	if err != nil {
 		return importNamingConvention
 	}
-	for _, info := range infos {
-		if !info.IsDir() {
+	for _, ent := range ents {
+		if !ent.IsDir() {
 			continue
 		}
-		dirName := info.Name()
+		dirName := ent.Name()
 		dirNC := detectInDir(filepath.Join(c.RepoRoot, dirName), dirName)
 		if dirNC == unknownNamingConvention {
 			continue


### PR DESCRIPTION
**What type of PR is this?**
> Other
Optimization and removal of deprecated API usage

**What package or component does this PR mostly affect?**
> all

**What does this PR do? Why is it needed?**
`ioutil` is deprecated, usage should be migrated to `os`.
In particular, `os.Readdir` is faster than `ioutil.Readdir` because it does not `stat` all the files to gather extra data which we don't need. On a fairly large repo, a no-op run of Gazelle drops from 2.2s to 1.7s with this patch.

I only changes the `ioutil` usages in the files I was touching anyway, but can change the rest in this PR if it's preferred.
 
**Which issues(s) does this PR fix?**
A TODO in the code
