### PR TITLE
rule: allow usage of Label struct with Rule APIs

### DIFF
--- a/rule/BUILD.bazel
+++ b/rule/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     embed = [":rule"],
     deps = [
+        "//label",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_google_go_cmp//cmp",
     ],

--- a/rule/value.go
+++ b/rule/value.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/bazel-gazelle/label"
 )
 
 // KeyValue represents a key-value pair. This gets converted into a
@@ -125,6 +126,7 @@ func (s SelectStringListValue) BzlExpr() bzl.Expr {
 // a Bazel build file. The following types of values can be converted:
 //
 //   * bools, integers, floats, strings.
+//   * labels (converted to strings).
 //   * slices, arrays (converted to lists).
 //   * maps (converted to select expressions; keys must be rules in
 //     @io_bazel_rules_go//go/platform).
@@ -198,6 +200,8 @@ func ExprFromValue(val interface{}) bzl.Expr {
 				X:    &bzl.LiteralExpr{Token: "glob"},
 				List: globArgs,
 			}
+		case label.Label:
+			return &bzl.StringExpr{Value: val.String()}
 		}
 	}
 

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -89,6 +90,10 @@ func TestExprFromValue(t *testing.T) {
 					&bzl.StringExpr{Value: "//:b"},
 				},
 			},
+		},
+		"labels": {
+			val:  label.New("repo", "pkg", "name"),
+			want: &bzl.StringExpr{Value: "@repo//pkg:name"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

rule

**What does this PR do? Why is it needed?**

The Label is a convenient structure for custom logic. Allow its use with the Rule APIs so the user can directly feed structured data back into Gazelle.