### PR TITLE
Allow passing Gazelle binary as a file

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -127,6 +127,7 @@ _gazelle_runner = rule(
     implementation = _gazelle_runner_impl,
     attrs = {
         "gazelle": attr.label(
+            allow_single_file = True,
             default = "//cmd/gazelle",
             executable = True,
             cfg = "exec",


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**

Gazelle runner

**What does this PR do? Why is it needed?**
This allows Gazelle runner to take Gazelle binary as a single file, so we can pass a pre-built Gazelle binary.

