### PR TITLE
feat(bzlmod): allow `default_gazelle_attributes` for `go_deps` extension

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -128,7 +128,7 @@ def _get_override_or_default(specific_overrides, gazelle_default_attributes, def
     # 2nd. Check for default attributes provided by the user. This must be done before checking for
     # gazelle's defaults path overrides to prevent Gazelle from overriding a user-specified flag.
     #
-    # This will also cause "build_file_generation" to default to "on" if default attirbutes are found.
+    # This will also cause "build_file_generation" to default to "on" if default attributes are found.
     global_override_value = getattr(gazelle_default_attributes, attribute_name, None)
     if global_override_value:
         return global_override_value

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -24,6 +24,31 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 
 # Validate a go.mod replace directive works.
 go_deps.from_file(go_mod = "//:go.mod")
+go_deps.gazelle_default_attributes(
+    build_file_generation = "on",
+    directives = [
+        "gazelle:proto disable",
+    ],
+)
+
+# By defining `gazelle_default_attributes`, we also must individually
+# specify certain overrides from internal/bzlmod/default_gazelle_overrides.bzl
+#
+# "build_file_generation" defaults to "on" because we provided a "gazelle_override"
+# (which contains either directives or build extra args).
+go_deps.gazelle_override(
+    directives = [
+        "gazelle:build_file_name BUILD.bazel",
+        "gazelle:build_file_proto_mode disable_global",
+    ],
+    path = "github.com/google/safetext",
+)
+go_deps.gazelle_override(
+    directives = [
+        "gazelle:build_file_name BUILD.bazel",
+    ],
+    path = "github.com/envoyproxy/protoc-gen-validate",
+)
 
 # Verify that the gazelle:go_naming_convention directive in an override is
 # respected.
@@ -56,16 +81,16 @@ go_deps.gazelle_override(
     path = "github.com/bazelbuild/buildtools",
 )
 go_deps.archive_override(
-    urls = [
-        "https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz",
-    ],
     patch_strip = 1,
     patches = [
         "//patches:buildtools.patch",
     ],
-    strip_prefix = "buildtools-ae8e3206e815d086269eb208b01f300639a4b194",
     path = "github.com/bazelbuild/buildtools",
     sha256 = "05d7c3d2bd3cc0b02d15672fefa0d6be48c7aebe459c1c99dced7ac5e598508f",
+    strip_prefix = "buildtools-ae8e3206e815d086269eb208b01f300639a4b194",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/ae8e3206e815d086269eb208b01f300639a4b194.tar.gz",
+    ],
 )
 
 # Transitive dependencies have to be listed here explicitly.
@@ -76,12 +101,12 @@ go_deps.module(
     version = "v3.0.1",
 )
 go_deps.gazelle_override(
-    path = "gopkg.in/yaml.v3",
     directives = [
         # Verify that the build naming convention is picked up by Gazelle when it
         # emits references to this repo.
         "gazelle:go_naming_convention go_default_library",
     ],
+    path = "gopkg.in/yaml.v3",
 )
 go_deps.module(
     indirect = True,


### PR DESCRIPTION
This PR creates a new tag class `default_gazelle_attributes` which allow the root module to provide default values for the gazelle attributes used to create the `go_deps` repos.

This includes the attributes: `"build_file_generation"`, `"build_extra_args"`, and `"directives"`. 

Default attributes will be applied to an attribute only if there is no `gazelle_override` value. 

If `default_gazelle_attributes` is provided, it will override all path-specific overrides created in `internal/bzlmod/default_gazelle_overrides.bzl`, so users may need to reapply these with `gazelle_override`s.

If a repo has either a `gazelle_override` or there is a `default_gazelle_attributes`, the `"build_file_generation"` attribute will be set to `"on"` unless explicitly set to a different value. This is because `"build_extra_args"`, and `"directives"` anticipate build file generation being enabled.

If any value is provided for attrs in a `gazelle_override`, it will override (and not append to) any default attributes. Users must re-add any `"directives"` that were in `default_gazelle_attributes`

Additional refactoring was done to remove duplication of the handling of these attributes.