### PR TITLE
Error if build_directives are specified but ignored

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -333,6 +333,8 @@ def _go_repository_impl(ctx):
         if ctx.attr.debug_mode and result.stderr:
             print("%s gazelle.stdout: %s" % (ctx.name, result.stdout))
             print("%s gazelle.stderr: %s" % (ctx.name, result.stderr))
+    elif len(ctx.attr.build_directives) > 0:
+        fail("%s: build_directives were specified but are being ignored - perhaps the repo already has BUILD files present. Try setting build_file_generation = \"on\"" % ctx.name)
 
     # Apply patches if necessary.
     patch(ctx)

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -334,7 +334,7 @@ def _go_repository_impl(ctx):
             print("%s gazelle.stdout: %s" % (ctx.name, result.stdout))
             print("%s gazelle.stderr: %s" % (ctx.name, result.stderr))
     elif len(ctx.attr.build_directives) > 0:
-        fail("%s: build_directives were specified but are being ignored - perhaps the repo already has BUILD files present. Try setting build_file_generation = \"on\"" % ctx.name)
+        fail("%s: build_directives were specified but are being ignored - perhaps the repo already has BUILD files present.\nIf you're using bzlmod, you may want to use a gazelle_override to set build_file_generation = \"on\" for this dependency.\nIf you're not using bzlmod, you may want to set set build_file_generation = \"on\" for this go_repository." % ctx.name)
 
     # Apply patches if necessary.
     patch(ctx)

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -50,6 +50,7 @@ go_deps.module_override(
 
 # Test an archive override from a known archive.
 go_deps.gazelle_override(
+    build_file_generation = "on",
     directives = [
         "gazelle:go_naming_convention go_default_library",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

Error if build_directives are specified but ignored

It can be frustrating to debug why a build directive isn't taking
effect, only to realise that the repo already has BUILD files checked in
so gazelle isn't going to apply them.