### PR TITLE
Add check in `update-repos` to omit reading `WORKSPACE` on bzlmod only repos.

### DIFF
--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -108,7 +108,11 @@ func (*updateReposConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) err
 	workspacePath := wspace.FindWORKSPACEFile(c.RepoRoot)
 	uc.workspace, err = rule.LoadWorkspaceFile(workspacePath, "")
 	if err != nil {
-		return fmt.Errorf("loading WORKSPACE file: %v", err)
+		if c.Bzlmod {                                                                                                                                                                                                                  
+			return nil                                                                                                                                                                                                                 
+		} else {                                                                                                                                                                                                                       
+			return fmt.Errorf("loading WORKSPACE file: %v", err)                                                                                                                                                                       
+		} 
 	}
 	c.Repos, uc.repoFileMap, err = repo.ListRepositories(uc.workspace)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle/update-repos

**What does this PR do? Why is it needed?**

`update-repos` fails to execute when no `WORKSPACE` file is used (bzlmod only repo).

PR adds a check to omit reading the `WORKSPACE` repositories into configuration if bzlmode argument is set.
If both `WORKSPACE` and `MODULES.bazel` are used together, it will still read the repositories from `WORKSPACE`. 

**Which issues(s) does this PR fix?**

Fixes #1726

**Other notes for review**