### PR TITLE
Add default gazelle override for github.com/cockroachdb/errors.

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -28,6 +28,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/envoyproxy/protoc-gen-validate": [
         "gazelle:build_file_name BUILD.bazel",
     ],
+    "github.com/cockroachdb/errors": [
+        "gazelle:proto disable",
+    ],
     "github.com/gogo/googleapis": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
`github.com/cockroachdb/errors` contains pre-generated codes for protos.

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

bzlmod

**What does this PR do? Why is it needed?**

disable proto for module `github.com/cockroachdb/errors`.

