### PR TITLE
fix: wrap generation test labels with Label()

### DIFF
--- a/internal/generationtest/generationtest.bzl
+++ b/internal/generationtest/generationtest.bzl
@@ -59,7 +59,7 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
         srcs = [Label("//internal/generationtest:generation_test.go")],
         deps = [
             Label("//testtools"),
-            "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+            Label("@io_bazel_rules_go//go/tools/bazel:go_default_library"),
         ],
         args = [
             "-gazelle_binary_path=$(rootpath %s)" % gazelle_binary,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

internal/generationtest

**What does this PR do? Why is it needed?**

Using an hardcoded label in `generationtest.bzl` would prevent users that are using the `gazelle_generation_test` macro from using it without explicitly set `repo_name = io_bazel_rules_go` in `MODULE.bazel`.

At the moment, running without `repo_name`:
```bzl
bazel_dep(name = "rules_go", version = "0.46.0")
```
```sh
$ bazel test //...
ERROR: no such package '@@[unknown repo 'io_bazel_rules_go' requested from @@]//go/tools/bazel': The repository '
@@[unknown repo 'io_bazel_rules_go' requested from @@]' could not be resolved: No repository visible as '@io_baze
l_rules_go' from main repository
ERROR: /home/barco/repos/pedrobarco/gazelle_oci/testdata/BUILD.bazel:4:28: no such package '@@[unknown repo 'io_b
azel_rules_go' requested from @@]//go/tools/bazel': The repository '@@[unknown repo 'io_bazel_rules_go' requested
 from @@]' could not be resolved: No repository visible as '@io_bazel_rules_go' from main repository and referenc
ed by '//testdata:oci_go_image'
```

And running with `repo_name`:
```bzl
bazel_dep(name = "rules_go", version = "0.46.0", repo_name = "io_bazel_rules_go")
```
```sh
$ bazel test //...
INFO: Analyzed 5 targets (126 packages loaded, 12013 targets configured).
INFO: Found 4 targets and 1 test target...
INFO: Elapsed time: 0.907s, Critical Path: 0.08s
INFO: 7 processes: 6 internal, 1 linux-sandbox.
INFO: Build completed successfully, 7 total actions
//testdata:oci_go_image                                                  PASSED in 0.0s
```

With this fix, bzlmod users can drop the `repo_name` and still be able to use this macro.

```bzl
bazel_dep(name = "rules_go", version = "0.46.0")
bazel_dep(name = "gazelle", version = "0.35.0")
local_path_override(
    module_name = "gazelle",
    path = "../../bazelbuild/bazel-gazelle",
)
```
```sh
$ bazel test //...
INFO: Analyzed 5 targets (126 packages loaded, 12013 targets configured).
INFO: Found 4 targets and 1 test target...
INFO: Elapsed time: 0.907s, Critical Path: 0.08s
INFO: 7 processes: 6 internal, 1 linux-sandbox.
INFO: Build completed successfully, 7 total actions
//testdata:oci_go_image                                                  PASSED in 0.0s
```

**Which issues(s) does this PR fix?**

There's no issue right now, but I've created a [slack thread](https://bazelbuild.slack.com/archives/C01HMGN77Q8/p1708825043207429) to address this issue
