### PR TITLE
Set go_naming_convention for cel-go

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -37,6 +37,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/gogo/protobuf": [
         "gazelle:proto disable",
     ],
+    "github.com/google/cel-go": [
+        "gazelle:go_naming_convention go_default_library",
+    ],
     "github.com/google/gnostic": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Set the go_naming_convention for github.com/google/cel-go

**What package or component does this PR mostly affect?**

default_gazelle_overrides

**What does this PR do? Why is it needed?**

I'm not sure why this isn't being auto detected, but I needed to add the override directive for Gazelle to write the imports correctly.

**Which issues(s) does this PR fix?**

Fixes # (not filed)

**Other notes for review**

I am applying a patch to the repo to change a package visibility, which could be causing the auto detect failure:

```
go_deps.module_override(
    path = "github.com/google/cel-go",
    patch_strip = 1,
    patches = [
        "//:build/0001-cel-go-Change-visibility-of-ast-to-public.patch",
    ],
)
go_deps.gazelle_override(
    directives = [
        "gazelle:go_naming_convention go_default_library",
    ],
    path = "github.com/google/cel-go",
)
```