### PR TITLE
Add `go_deps.config(env = ...)` as a replacement for `gazelle_dependencies(go_env = ...)`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,11 @@ bazel_dep(name = "rules_go", version = "0.44.0", repo_name = "io_bazel_rules_go"
 bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-
-# Known to exist since it is instantiated by rules_go itself.
 use_repo(
     go_sdk,
+    # Known to exist since they are instantiated by rules_go itself.
     "go_host_compatible_sdk_label",
+    "io_bazel_rules_go_go_env",
 )
 
 non_module_deps = use_extension("//internal/bzlmod:non_module_deps.bzl", "non_module_deps")
@@ -55,7 +55,6 @@ use_repo(
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
-
 
 go_sdk_dev = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,11 @@ bazel_dep(name = "rules_go", version = "0.44.0", repo_name = "io_bazel_rules_go"
 bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+
+# Known to exist since it is instantiated by rules_go itself.
 use_repo(
     go_sdk,
-    # Known to exist since they are instantiated by rules_go itself.
     "go_host_compatible_sdk_label",
-    "io_bazel_rules_go_go_env",
 )
 
 non_module_deps = use_extension("//internal/bzlmod:non_module_deps.bzl", "non_module_deps")

--- a/internal/bzlmod/non_module_deps.bzl
+++ b/internal/bzlmod/non_module_deps.bzl
@@ -29,7 +29,7 @@ load(
     "HOST_COMPATIBLE_SDK",
 )
 load(
-    "@io_bazel_rules_go_go_env//:go_env.bzl",
+    "@bazel_gazelle_go_repository_config//:go_env.bzl",
     "GO_ENV",
 )
 

--- a/internal/bzlmod/non_module_deps.bzl
+++ b/internal/bzlmod/non_module_deps.bzl
@@ -28,6 +28,10 @@ load(
     "@go_host_compatible_sdk_label//:defs.bzl",
     "HOST_COMPATIBLE_SDK",
 )
+load(
+    "@io_bazel_rules_go_go_env//:go_env.bzl",
+    "GO_ENV",
+)
 
 visibility("//")
 
@@ -36,7 +40,7 @@ def _non_module_deps_impl(_):
         name = "bazel_gazelle_go_repository_cache",
         # Label.workspace_name is always a canonical name, so use a canonical label.
         go_sdk_name = "@" + HOST_COMPATIBLE_SDK.workspace_name,
-        go_env = {},
+        go_env = GO_ENV,
     )
     go_repository_tools(
         name = "bazel_gazelle_go_repository_tools",

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -2,14 +2,11 @@ module(
     name = "gazelle_bcr_tests",
 )
 
-
 bazel_dep(name = "gazelle", version = "")
 local_path_override(
     module_name = "gazelle",
     path = "../..",
 )
-
-local_path_override(module_name = "rules_go", path = "../../../rules_go")
 
 bazel_dep(name = "test_dep", version = "1.0.0")
 local_path_override(
@@ -22,13 +19,17 @@ bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "my_rules_go")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2", repo_name = "my_rules_proto")
 
 go_sdk = use_extension("@my_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.env(name = "GOPRIVATE", value = "example.com")
 
 # This bazel_dep provides the Go dependency github.com/cloudflare/circl, which requires custom
 # patches beyond what Gazelle can generate.
 bazel_dep(name = "circl", version = "1.3.7")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.config(
+    go_env = {
+        "GOPRIVATE": "example.com/*",
+    },
+)
 
 # Validate a go.mod replace directive works.
 go_deps.from_file(go_mod = "//:go.mod")

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -2,11 +2,14 @@ module(
     name = "gazelle_bcr_tests",
 )
 
+
 bazel_dep(name = "gazelle", version = "")
 local_path_override(
     module_name = "gazelle",
     path = "../..",
 )
+
+local_path_override(module_name = "rules_go", path = "../../../rules_go")
 
 bazel_dep(name = "test_dep", version = "1.0.0")
 local_path_override(
@@ -17,6 +20,9 @@ local_path_override(
 bazel_dep(name = "protobuf", version = "23.1", repo_name = "my_protobuf")
 bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "my_rules_go")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2", repo_name = "my_rules_proto")
+
+go_sdk = use_extension("@my_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.env(name = "GOPRIVATE", value = "example.com")
 
 # This bazel_dep provides the Go dependency github.com/cloudflare/circl, which requires custom
 # patches beyond what Gazelle can generate.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

> go_repository

**What does this PR do? Why is it needed?**

With this PR, `go_deps.config(go_env = {...})` can be used to specify environment variables for go_repository, replacing gazelle_dependencies(go_env = ...). They are exported in a way that makes them usable for `@rules_go//go`, which will be done in a follow-up change to rules_go.

I will add documentation after the rules_go change has been merged.

**Which issues(s) does this PR fix?**

Work towards https://github.com/bazelbuild/rules_go/issues/3814

**Other notes for review**

This is an alternative to https://github.com/bazelbuild/rules_go/pull/3879, on which @linzhp remarked that there is a potential of confusion as `go_env` can't and shouldn't be used for variables that affect compilation. By moving the setting to `go_deps`, it hopefully becomes clearer that this only affects deps fetching.
