### PR TITLE
Warn if integrity not specified for archive_override

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -136,7 +136,7 @@ def _go_repository_impl(ctx):
         for key in ("commit", "tag", "vcs", "remote", "version", "sum", "replace"):
             if getattr(ctx.attr, key):
                 fail("cannot specifiy both urls and %s" % key, key)
-        ctx.download_and_extract(
+        result = ctx.download_and_extract(
             url = ctx.attr.urls,
             sha256 = ctx.attr.sha256,
             canonical_id = ctx.attr.canonical_id,
@@ -144,6 +144,11 @@ def _go_repository_impl(ctx):
             type = ctx.attr.type,
             auth = use_netrc(read_user_netrc(ctx), ctx.attr.urls, ctx.attr.auth_patterns),
         )
+        if not ctx.attr.sha256:
+            print("For Go module \"{path}\", integrity not specified, calculated sha256 = \"{sha256}\"".format(
+                path = ctx.attr.importpath,
+                sha256 = result.sha256,
+            ))
     elif ctx.attr.commit or ctx.attr.tag:
         # repository mode
         if ctx.attr.commit:


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

This PR adds a warning for not specified sha256 for archive in the go_repository rule which provides the correct checksum.
It simplifies finding and fixing such cases. It is important for reproducible builds and caching.

**Which issues(s) does this PR fix?**

It is a small change, not sure if issue is needed.
