### PR TITLE
Use host module cache whithout build cache and verify it

### DIFF
--- a/cmd/fetch_repo/BUILD.bazel
+++ b/cmd/fetch_repo/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/cmd/fetch_repo",
     visibility = ["//visibility:private"],
-    deps = ["@org_golang_x_tools_go_vcs//:vcs"],
+    deps = [
+        "@org_golang_x_mod//sumdb/dirhash",
+        "@org_golang_x_tools_go_vcs//:vcs",
+    ],
 )
 
 go_binary(

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -26,7 +26,7 @@ internal cache within Bazel's cache. It may be cleared with `bazel clean --expun
 By setting the environment variable `GO_REPOSITORY_USE_HOST_CACHE=1`, you can
 force `go_repository` to use the module cache on the host system in the location
 returned by `go env GOPATH`. Alternatively, by setting the environment variable
-`GO_REPOSITORY_USE_HOST_CACHE=1`, you can force `go_repository` to use only
+`GO_REPOSITORY_USE_HOST_MODCACHE=1`, you can force `go_repository` to use only
 the module cache on the host system in the location returned by `go env GOMODCACHE`.
 
 **Example**

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -25,7 +25,9 @@ When `go_repository` is in module mode, it saves downloaded modules in a shared,
 internal cache within Bazel's cache. It may be cleared with `bazel clean --expunge`.
 By setting the environment variable `GO_REPOSITORY_USE_HOST_CACHE=1`, you can
 force `go_repository` to use the module cache on the host system in the location
-returned by `go env GOPATH`.
+returned by `go env GOPATH`. Alternatively, by setting the environment variable
+`GO_REPOSITORY_USE_HOST_CACHE=1`, you can force `go_repository` to use only
+the module cache on the host system in the location returned by `go env GOMODCACHE`.
 
 **Example**
 

--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -39,6 +39,12 @@ def _go_repository_cache_impl(ctx):
     go_path = str(ctx.path("."))
     go_cache = str(ctx.path("gocache"))
     go_mod_cache = ""
+    if ctx.os.environ.get("GO_REPOSITORY_USE_HOST_MODCACHE", "") == "1":
+        extension = executable_extension(ctx)
+        go_tool = go_root + "/bin/go" + extension
+        go_mod_cache = read_go_env(ctx, go_tool, "GOMODCACHE")
+        if not go_mod_cache:
+            fail("GOMODCACHE must be set when GO_REPOSITORY_USE_HOST_MODCACHE is enabled.")
     if ctx.os.environ.get("GO_REPOSITORY_USE_HOST_CACHE", "") == "1":
         extension = executable_extension(ctx)
         go_tool = go_root + "/bin/go" + extension

--- a/repository.md
+++ b/repository.md
@@ -115,7 +115,9 @@ When `go_repository` is in module mode, it saves downloaded modules in a shared,
 internal cache within Bazel's cache. It may be cleared with `bazel clean --expunge`.
 By setting the environment variable `GO_REPOSITORY_USE_HOST_CACHE=1`, you can
 force `go_repository` to use the module cache on the host system in the location
-returned by `go env GOPATH`.
+returned by `go env GOPATH`. Alternatively, by setting the environment variable
+`GO_REPOSITORY_USE_HOST_CACHE=1`, you can force `go_repository` to use only
+the module cache on the host system in the location returned by `go env GOMODCACHE`.
 
 **Example**
 

--- a/repository.md
+++ b/repository.md
@@ -116,7 +116,7 @@ internal cache within Bazel's cache. It may be cleared with `bazel clean --expun
 By setting the environment variable `GO_REPOSITORY_USE_HOST_CACHE=1`, you can
 force `go_repository` to use the module cache on the host system in the location
 returned by `go env GOPATH`. Alternatively, by setting the environment variable
-`GO_REPOSITORY_USE_HOST_CACHE=1`, you can force `go_repository` to use only
+`GO_REPOSITORY_USE_HOST_MODCACHE=1`, you can force `go_repository` to use only
 the module cache on the host system in the location returned by `go env GOMODCACHE`.
 
 **Example**

--- a/vendor/golang.org/x/mod/sumdb/dirhash/hash.go
+++ b/vendor/golang.org/x/mod/sumdb/dirhash/hash.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dirhash defines hashes over directory trees.
+// These hashes are recorded in go.sum files and in the Go checksum database,
+// to allow verifying that a newly-downloaded module has the expected content.
+package dirhash
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DefaultHash is the default hash function used in new go.sum entries.
+var DefaultHash Hash = Hash1
+
+// A Hash is a directory hash function.
+// It accepts a list of files along with a function that opens the content of each file.
+// It opens, reads, hashes, and closes each file and returns the overall directory hash.
+type Hash func(files []string, open func(string) (io.ReadCloser, error)) (string, error)
+
+// Hash1 is the "h1:" directory hash function, using SHA-256.
+//
+// Hash1 is "h1:" followed by the base64-encoded SHA-256 hash of a summary
+// prepared as if by the Unix command:
+//
+//	sha256sum $(find . -type f | sort) | sha256sum
+//
+// More precisely, the hashed summary contains a single line for each file in the list,
+// ordered by sort.Strings applied to the file names, where each line consists of
+// the hexadecimal SHA-256 hash of the file content,
+// two spaces (U+0020), the file name, and a newline (U+000A).
+//
+// File names with newlines (U+000A) are disallowed.
+func Hash1(files []string, open func(string) (io.ReadCloser, error)) (string, error) {
+	h := sha256.New()
+	files = append([]string(nil), files...)
+	sort.Strings(files)
+	for _, file := range files {
+		if strings.Contains(file, "\n") {
+			return "", errors.New("dirhash: filenames with newlines are not supported")
+		}
+		r, err := open(file)
+		if err != nil {
+			return "", err
+		}
+		hf := sha256.New()
+		_, err = io.Copy(hf, r)
+		r.Close()
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%x  %s\n", hf.Sum(nil), file)
+	}
+	return "h1:" + base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+// HashDir returns the hash of the local file system directory dir,
+// replacing the directory name itself with prefix in the file names
+// used in the hash function.
+func HashDir(dir, prefix string, hash Hash) (string, error) {
+	files, err := DirFiles(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	osOpen := func(name string) (io.ReadCloser, error) {
+		return os.Open(filepath.Join(dir, strings.TrimPrefix(name, prefix)))
+	}
+	return hash(files, osOpen)
+}
+
+// DirFiles returns the list of files in the tree rooted at dir,
+// replacing the directory name dir with prefix in each name.
+// The resulting names always use forward slashes.
+func DirFiles(dir, prefix string) ([]string, error) {
+	var files []string
+	dir = filepath.Clean(dir)
+	err := filepath.Walk(dir, func(file string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		} else if file == dir {
+			return fmt.Errorf("%s is not a directory", dir)
+		}
+
+		rel := file
+		if dir != "." {
+			rel = file[len(dir)+1:]
+		}
+		f := filepath.Join(prefix, rel)
+		files = append(files, filepath.ToSlash(f))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// HashZip returns the hash of the file content in the named zip file.
+// Only the file names and their contents are included in the hash:
+// the exact zip file format encoding, compression method,
+// per-file modification times, and other metadata are ignored.
+func HashZip(zipfile string, hash Hash) (string, error) {
+	z, err := zip.OpenReader(zipfile)
+	if err != nil {
+		return "", err
+	}
+	defer z.Close()
+	var files []string
+	zfiles := make(map[string]*zip.File)
+	for _, file := range z.File {
+		files = append(files, file.Name)
+		zfiles[file.Name] = file
+	}
+	zipOpen := func(name string) (io.ReadCloser, error) {
+		f := zfiles[name]
+		if f == nil {
+			return nil, fmt.Errorf("file %q not found in zip", name) // should never happen
+		}
+		return f.Open()
+	}
+	return hash(files, zipOpen)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,6 +29,7 @@ golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/modfile
 golang.org/x/mod/module
 golang.org/x/mod/semver
+golang.org/x/mod/sumdb/dirhash
 # golang.org/x/sync v0.5.0
 ## explicit; go 1.18
 golang.org/x/sync/errgroup


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository_cache

**What does this PR do? Why is it needed?**

This PR adds an environment variable GO_REPOSITORY_USE_HOST_MODCACHE, which enables use of only GOMODCACHE without affecting GOPATH and GOCACHE.
And adds a sum verification to fetch_repo tool, since `go mod download` do not verify modules taken from cache.

**Which issues(s) does this PR fix?**

Fixes #1754
