### PR TITLE
Ignore `purego` build constraint

### DIFF
--- a/language/go/build_constraints.go
+++ b/language/go/build_constraints.go
@@ -307,13 +307,13 @@ func matchAuto(tokens []string) (*buildTags, error) {
 	return newBuildTags(x)
 }
 
-// isIgnoredTag returns whether the tag is "cgo" or is a release tag.
+// isIgnoredTag returns whether the tag is "cgo", "purego", "race", "msan"  or is a release tag.
 // Release tags match the pattern "go[0-9]\.[0-9]+".
 // Gazelle won't consider whether an ignored tag is satisfied when evaluating
 // build constraints for a file and will instead defer to the compiler at compile
 // time.
 func isIgnoredTag(tag string) bool {
-	if tag == "cgo" || tag == "race" || tag == "msan" {
+	if tag == "cgo" || tag == "purego" || tag == "race" || tag == "msan" {
 		return true
 	}
 	if len(tag) < 5 || !strings.HasPrefix(tag, "go") {


### PR DESCRIPTION
`purego` is a proposed[1] de-facto build constraint to denote building _only_ Go code.

We must ignore this constraint to make sure that files that toggle on `purego` are added to the Bazel target `srcs` and let the compiler decide if they should be compiled or not.

[1]: https://github.com/golang/go/issues/23172

This is required to land bazelbuild/rules_go#3901 which will enable the de-facto `purego` build constraint to be picked up in the Bazel Go ecosystem automatically when `pure = "on"` is defined in a `go_binary`, etc.