### PR TITLE
Add is_bazel_module to deps.bzl.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,6 +112,7 @@ bzl_library(
         "//internal:go_repository_cache",
         "//internal:go_repository_config",
         "//internal:go_repository_tools",
+        "//internal:is_bazel_module",
         "@bazel_tools//tools/build_defs/repo:git.bzl",
     ],
 )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository


**What does this PR do? Why is it needed?**

Fixes: 

> Stardoc documentation generation failed: File /home/coder/.cache/bazel/_bazel_coder/c91ea700cafcab35837a5ae95cae9020/sandbox/linux-sandbox/33/execroot/services/bazel-out/k8-opt-exec-2B5CBBC6/bin/bazel/docs/rules/java/image_stardoc.runfiles/bazel_gazelle/deps.bzl imported '//internal:is_bazel_module.bzl', yet /home/coder/.cache/bazel/_bazel_coder/c91ea700cafcab35837a5ae95cae9020/sandbox/linux-sandbox/33/execroot/services/bazel-out/k8-opt-exec-2B5CBBC6/bin/bazel/docs/rules/java/image_stardoc.runfiles/bazel_gazelle/internal/is_bazel_module.bzl was not found.


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
