### PR TITLE
Add a pointer to bzlmod guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,6 +607,9 @@ used to add new repository rules or update existing rules to the specified
 version. It can also import repository rules from a ``go.mod`` or a ``go.work``
 file.
 
+WARNING: This command is mainly used for managing external Go dependencies in Bazel's WORKSPACE mode.
+For managing external Go dependencies in Bazel's BzlMod mode, please check: https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md#external-dependencies
+
 .. code:: bash
 
   # Add or update a repository to latest version by import path


### PR DESCRIPTION
It's a bit confusing for newer users onboarding Gazelle that the only doc available are for WORKSPACE mode.

Add a pointer to BzlMod documentation.

In the longer run, we should start adding `WARNING` log to `update-repos` command to let people know that it should not be used with bzlmod enabled.