### PR TITLE
[cmd/fetch_repo] make cache corruption failures more clear

### DIFF
--- a/cmd/fetch_repo/copy_tree.go
+++ b/cmd/fetch_repo/copy_tree.go
@@ -37,23 +37,23 @@ func copyTree(destRoot, srcRoot string) error {
 
 		if info.IsDir() {
 			return os.Mkdir(dest, 0o777)
-		} else {
-			r, err := os.Open(src)
-			if err != nil {
-				return err
-			}
-			defer r.Close()
-			w, err := os.Create(dest)
-			if err != nil {
-				return err
-			}
-			defer func() {
-				if cerr := w.Close(); err == nil && cerr != nil {
-					err = cerr
-				}
-			}()
-			_, err = io.Copy(w, r)
+		}
+
+		r, err := os.Open(src)
+		if err != nil {
 			return err
 		}
+		defer r.Close()
+		w, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if cerr := w.Close(); err == nil && cerr != nil {
+				err = cerr
+			}
+		}()
+		_, err = io.Copy(w, r)
+		return err
 	})
 }


### PR DESCRIPTION
This failure was confusing to our users. We should make more clear error messages in cases when a `GOMODCACHE` might be corrupt.

Resolves #1774

Example failure:
```
ERROR: /home/user/go-code/WORKSPACE:69:26: fetching go_repository rule //external:com_github_bazelbuild_remote_apis: Traceback (most recent call last):
        File "/home/user/.cache/bazel/_bazel_tfrench/b97476d719d716accead0f2d5b93104f/external/bazel_gazelle/internal/go_repository.bzl", line 263, column 17, in _go_repository_impl
                fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
Error in fail: failed to fetch com_github_bazelbuild_remote_apis: fetch_repo: resulting module with sum h1:xhO5v3Ac039HesaPqoVUwOy4WhRRJbmo9om245kp+AY=; expected sum h1:xhO5v3Ac039HesaPqoVUwOy4WhRRJbmo9om245kp+AY=, Please try clearing your module cache directory "/home/user/go-code/pkg/mod"
ERROR: Error computing the main repository mapping: no such package '@@com_github_bazelbuild_remote_apis//': failed to fetch com_github_bazelbuild_remote_apis: fetch_repo: resulting module with sum h1:xhO5v3Ac039HesaPqoVUwOy4WhRRJbmo9om245kp+AY=; expected sum h1:xhO5v3Ac039HesaPqoVUwOy4WhRRJbmo9om245kp+AY=, Please try clearing your module cache directory "/home/user/go-code/pkg/mod"
INFO: Build Event Protocol files produced successfully.
Computing main repo mapping: 
WARNING:Bazel failed with exit code 1
```