### PR TITLE
Normalise newlines on Windows

### DIFF
--- a/testtools/files.go
+++ b/testtools/files.go
@@ -127,13 +127,13 @@ func CheckFiles(t *testing.T, dir string, files []FileSpec) {
 				t.Errorf("not a directory: %s", f.Path)
 			}
 		} else {
-			want := strings.TrimSpace(f.Content)
+			want := normalizeSpace(f.Content)
 			gotBytes, err := os.ReadFile(filepath.Join(dir, f.Path))
 			if err != nil {
 				t.Errorf("could not read %s: %v", f.Path, err)
 				continue
 			}
-			got := strings.TrimSpace(string(gotBytes))
+			got := normalizeSpace(string(gotBytes))
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("%s diff (-want,+got):\n%s", f.Path, diff)
 			}
@@ -224,7 +224,7 @@ func TestGazelleGenerationOnPath(t *testing.T, args *TestGazelleGenerationArgs) 
 
 			// Read in expected stdout, stderr, and exit code files.
 			if d.Name() == argumentsFilename {
-				config.Args = strings.Split(string(content), "\n")
+				config.Args = strings.Split(normalizeSpace(string(content)), "\n")
 				return nil
 			}
 			if d.Name() == expectedStdoutFilename {
@@ -353,13 +353,13 @@ Run %s to update BUILD.out and expected{Stdout,Stderr,ExitCode}.txt files.
 			}
 		}
 		actualStdout := redactWorkspacePath(stdout.String(), workspaceRoot)
-		if strings.TrimSpace(config.Stdout) != strings.TrimSpace(actualStdout) {
+		if normalizeSpace(config.Stdout) != normalizeSpace(actualStdout) {
 			errs = append(errs, fmt.Errorf("expected gazelle stdout: %s\ngot: %s",
 				config.Stdout, actualStdout,
 			))
 		}
 		actualStderr := redactWorkspacePath(stderr.String(), workspaceRoot)
-		if strings.TrimSpace(config.Stderr) != strings.TrimSpace(actualStderr) {
+		if normalizeSpace(config.Stderr) != normalizeSpace(actualStderr) {
 			errs = append(errs, fmt.Errorf("expected gazelle stderr: %s\ngot: %s",
 				config.Stderr, actualStderr,
 			))
@@ -423,4 +423,8 @@ func updateExpectedConfig(t *testing.T, expected string, actual string, srcTestD
 // output reproducible.
 func redactWorkspacePath(s, wsPath string) string {
 	return strings.ReplaceAll(s, wsPath, "%WORKSPACEPATH%")
+}
+
+func normalizeSpace(s string) string {
+	return strings.TrimSpace(strings.ReplaceAll(s, "\r\n", "\n"))
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

testtools

**What does this PR do? Why is it needed?**

Normalise newlines on Windows

Otherwise assorted things go wrong when running tests using this infrastructure on Windows where \r\n line endings confuse things.

We've been trying to get the Java gazelle plugin's CI working on Windows, and this is our last blocker.