### PR TITLE
Ensure the Gazelle binary is built for the right platform

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -130,7 +130,7 @@ _gazelle_runner = rule(
             allow_single_file = True,
             default = "//cmd/gazelle",
             executable = True,
-            cfg = "exec",
+            cfg = "target",
         ),
         "command": attr.string(
             values = [


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Right now we pick Gazelle for the "exec" platform. This isn't correct, because we are not running Gazelle as part of a build action. Instead, we are emitting a shell script that *invokes* Gazelle. That's why we need to make sure it's built for the target platform.

This addresses an issue where Bazel ends up invoking a copy of Gazelle for Linux on my Mac, if I invoke bazel with
--extra_execution_platforms=//my_linux_platform,//my_mac_platform.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**
