### PR TITLE
Remove special resolution of go_proto imports

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -275,9 +275,6 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		}
 		rules = append(rules, lib)
 		g.maybePublishToolLib(lib, pkg)
-		if r := g.maybeGenerateExtraLib(lib, pkg); r != nil {
-			rules = append(rules, r)
-		}
 		if r := g.maybeGenerateAlias(pkg, libName); r != nil {
 			g.maybePublishToolLib(r, pkg)
 			rules = append(rules, r)
@@ -570,66 +567,6 @@ func (g *generator) maybePublishToolLib(lib *rule.Rule, pkg *goPackage) {
 		// Imported by nogo main. We add a visibility exception.
 		lib.SetAttr("visibility", []string{"//visibility:public"})
 	}
-}
-
-// maybeGenerateExtraLib generates extra equivalent library targets for
-// certain protobuf libraries. These "_gen" targets depend on Well Known Types
-// built with go_proto_library and are used together with go_proto_library.
-// The original targets are used when proto rule generation is disabled.
-func (g *generator) maybeGenerateExtraLib(lib *rule.Rule, pkg *goPackage) *rule.Rule {
-	gc := getGoConfig(g.c)
-	if gc.prefix != "github.com/golang/protobuf" || gc.prefixRel != "" {
-		return nil
-	}
-
-	var r *rule.Rule
-	switch pkg.importPath {
-	case "github.com/golang/protobuf/descriptor":
-		r = rule.NewRule("go_library", "go_default_library_gen")
-		r.SetAttr("srcs", pkg.library.sources.buildFlat())
-		r.SetAttr("importpath", pkg.importPath)
-		r.SetAttr("visibility", []string{"//visibility:public"})
-		r.SetAttr("deps", []string{
-			"//proto:go_default_library",
-			"@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
-			"@org_golang_google_protobuf//reflect/protodesc:go_default_library",
-			"@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-			"@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-		})
-
-	case "github.com/golang/protobuf/jsonpb":
-		r = rule.NewRule("alias", "go_default_library_gen")
-		r.SetAttr("actual", ":go_default_library")
-		r.SetAttr("visibility", []string{"//visibility:public"})
-
-	case "github.com/golang/protobuf/protoc-gen-go/generator":
-		r = rule.NewRule("go_library", "go_default_library_gen")
-		r.SetAttr("srcs", pkg.library.sources.buildFlat())
-		r.SetAttr("importpath", pkg.importPath)
-		r.SetAttr("visibility", []string{"//visibility:public"})
-		r.SetAttr("deps", []string{
-			"//proto:go_default_library",
-			"//protoc-gen-go/generator/internal/remap:go_default_library",
-			"@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
-			"@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
-		})
-
-	case "github.com/golang/protobuf/ptypes":
-		r = rule.NewRule("go_library", "go_default_library_gen")
-		r.SetAttr("srcs", pkg.library.sources.buildFlat())
-		r.SetAttr("importpath", pkg.importPath)
-		r.SetAttr("visibility", []string{"//visibility:public"})
-		r.SetAttr("deps", []string{
-			"//proto:go_default_library",
-			"@io_bazel_rules_go//proto/wkt:any_go_proto",
-			"@io_bazel_rules_go//proto/wkt:duration_go_proto",
-			"@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
-			"@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-			"@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
-		})
-	}
-
-	return r
 }
 
 func (g *generator) setCommonAttrs(r *rule.Rule, pkgRel string, visibility []string, target goTarget, embed string) {

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -830,46 +830,18 @@ go_proto_library(name = "wkts_go_proto")
 go_library(
     name = "wkts_go_lib",
     deps = [
-        "@com_github_golang_protobuf//protoc-gen-go/descriptor",
-        "@com_github_golang_protobuf//protoc-gen-go/plugin",
-        "@com_github_golang_protobuf//ptypes/any",
-        "@com_github_golang_protobuf//ptypes/duration",
-        "@com_github_golang_protobuf//ptypes/empty",
-        "@com_github_golang_protobuf//ptypes/struct",
-        "@com_github_golang_protobuf//ptypes/timestamp",
-        "@com_github_golang_protobuf//ptypes/wrappers",
-        "@org_golang_google_genproto//protobuf/api",
-        "@org_golang_google_genproto//protobuf/field_mask",
-        "@org_golang_google_genproto//protobuf/ptype",
-        "@org_golang_google_genproto//protobuf/source_context",
-    ],
-)
-`,
-		}, {
-			desc: "proto_special_cross_resolve",
-			old: buildFile{content: `
-go_library(
-    name = "go_default_library",
-    _imports = [
-        "github.com/golang/protobuf/proto",
-        "github.com/golang/protobuf/jsonpb",
-        "github.com/golang/protobuf/descriptor",
-        "github.com/golang/protobuf/protoc-gen-go/generator",
-        "github.com/golang/protobuf/ptypes",
-        "google.golang.org/grpc",
-    ],
-)
-`},
-			want: `
-go_library(
-    name = "go_default_library",
-    deps = [
-        "@com_github_golang_protobuf//descriptor:go_default_library_gen",
-        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
-        "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library_gen",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@org_golang_google_grpc//:go_default_library",
+        "//vendor/github.com/golang/protobuf/protoc-gen-go/descriptor",
+        "//vendor/github.com/golang/protobuf/protoc-gen-go/plugin",
+        "//vendor/github.com/golang/protobuf/ptypes/any",
+        "//vendor/github.com/golang/protobuf/ptypes/duration",
+        "//vendor/github.com/golang/protobuf/ptypes/empty",
+        "//vendor/github.com/golang/protobuf/ptypes/struct",
+        "//vendor/github.com/golang/protobuf/ptypes/timestamp",
+        "//vendor/github.com/golang/protobuf/ptypes/wrappers",
+        "//vendor/google.golang.org/genproto/protobuf/api",
+        "//vendor/google.golang.org/genproto/protobuf/field_mask",
+        "//vendor/google.golang.org/genproto/protobuf/ptype",
+        "//vendor/google.golang.org/genproto/protobuf/source_context",
     ],
 )
 `,

--- a/language/proto/resolve.go
+++ b/language/proto/resolve.go
@@ -176,30 +176,5 @@ func (*protoLang) CrossResolve(c *config.Config, ix *resolve.RuleIndex, imp reso
 			return []resolve.FindResult{{Label: l}}
 		}
 	}
-	if imp.Lang == "go" && pc.Mode.ShouldUseKnownImports() {
-		// These are commonly used libraries that depend on Well Known Types.
-		// They depend on the generated versions of these protos to avoid conflicts.
-		// However, since protoc-gen-go depends on these libraries, we generate
-		// its rules in disable_global mode (to avoid cyclic dependency), so the
-		// "go_default_library" versions of these libraries depend on the
-		// pre-generated versions of the proto libraries.
-		switch imp.Imp {
-		case "github.com/golang/protobuf/proto":
-			return []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "proto", "go_default_library")}}
-		case "github.com/golang/protobuf/jsonpb":
-			return []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "jsonpb", "go_default_library_gen")}}
-		case "github.com/golang/protobuf/descriptor":
-			return []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "descriptor", "go_default_library_gen")}}
-		case "github.com/golang/protobuf/ptypes":
-			return []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "ptypes", "go_default_library_gen")}}
-		case "github.com/golang/protobuf/protoc-gen-go/generator":
-			return []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "protoc-gen-go/generator", "go_default_library_gen")}}
-		case "google.golang.org/grpc":
-			return []resolve.FindResult{{Label: label.New("org_golang_google_grpc", "", "go_default_library")}}
-		}
-		if l, ok := knownGoProtoImports[imp.Imp]; ok {
-			return []resolve.FindResult{{Label: l}}
-		}
-	}
 	return nil
 }

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -466,13 +466,6 @@ func TestCrossResolve(t *testing.T) {
 			want:      nil,
 		},
 		{
-			desc:      "go known import",
-			protoMode: DefaultMode,
-			imp:       resolve.ImportSpec{Lang: "go", Imp: "github.com/golang/protobuf/proto"},
-			lang:      "go",
-			want:      []resolve.FindResult{{Label: label.New("com_github_golang_protobuf", "proto", "go_default_library")}},
-		},
-		{
 			desc:      "go unknown import",
 			protoMode: DefaultMode,
 			imp:       resolve.ImportSpec{Lang: "go", Imp: "foo"},


### PR DESCRIPTION
Gazelle used to resolve all generated Go packages from well-known types of proto to their `go_proto_library` targets. This is no longer the case. Even targets like `@io_bazel_rules_go//proto/wkt:descriptor_go_proto` are merely alias to the `go_library` targets of pre-generated code.

This PR:

1. Makes `go_default_library_gen` targets aliases to their `go_default_library` targets. Those targets exist only to resolve the well-known types to their old `go_proto_library` targets under `@io_bazel_rules_go//proto/wkt`
2. Stops Gazelle from resolving to those `go_default_library_gen` targets
3. Stops using `knownGoProtoImports`. They no longer point to `go_proto_library` targets. Their current label are regular Go packages.

I will further remove `knownGoProtoImports` as a follow up PR, because it requires changes to `language/proto/gen/gen_known_imports.go` to stop generating them.