### PR TITLE
go_deps: ignore go.work toolchain directive

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -99,6 +99,8 @@ def parse_go_work(content, go_work_label):
                 continue
             else:
                 state["use"].append(tokens[1])
+        elif tokens[0] == "toolchain":
+            continue
         else:
             fail("{}:{}: unexpected directive '{}'".format(go_work_label.name, line_no, tokens[0]))
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**


Bug fix

**What package or component does this PR mostly affect?**

go_repository


**What does this PR do? Why is it needed?**

Gazelle can now read `go.work` files. However, it is unable to parse them if they contain a `toolchain` directive. In go.mod files, those directives are already ignored.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**
