### PR TITLE
Handle arm64 host platform for MacOS

### DIFF
--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -135,6 +135,12 @@ def _detect_host_platform(ctx):
 
     elif ctx.os.name == "mac os x":
         host = "darwin_amd64"
+        res = ctx.execute(["uname", "-m"])
+        if res.return_code == 0:
+            uname = res.stdout.strip()
+            if uname == "arm64":
+                host = "darwin_arm64"
+                
     elif ctx.os.name.startswith("windows"):
         host = "windows_amd64"
     elif ctx.os.name == "freebsd":


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

>
> internal

**What does this PR do? Why is it needed?**
Handles arm64 host platform in `go_repository_cache` repository rule

**Which issues(s) does this PR fix?**

Fixes #1816 

**Other notes for review**
It might be possible to use this https://bazel.build/rules/lib/builtins/repository_os.html#arch instead of `uname` like rules_go does, but not sure if it breaks Bazel version compatibility. Either way, I kept it similar to existing code to avoid refactor.
