### PR TITLE
fix: support leading ./ in .bazelignore

### DIFF
--- a/walk/config.go
+++ b/walk/config.go
@@ -135,8 +135,12 @@ func (c *Configurer) loadBazelIgnore(repoRoot string, wc *walkConfig) error {
 			log.Printf("the .bazelignore exclusion pattern must not be a glob %s", ignore)
 			continue
 		}
-		// Ensure we remove trailing slashes or the exclude matching won't work correctly
-		wc.excludes = append(wc.excludes, strings.TrimSuffix(ignore, "/"))
+
+		// Clean the path to remove any extra '.', './' etc otherwise
+		// the exclude matching won't work correctly.
+		ignore = path.Clean(ignore)
+
+		wc.excludes = append(wc.excludes, ignore)
 	}
 	return nil
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -205,6 +205,10 @@ foo/*
 
 # Random comment followed by a line
 a.file
+
+# Paths can have a ./ prefix
+./b.file
+././blah/../ugly/c.file
 `,
 		},
 		{Path: ".dot"},       // not ignored
@@ -228,6 +232,8 @@ a.file
 		{Path: "dir2/a/b"},        // ignored by .bazelignore 'dir2/a/b'
 		{Path: "dir3/g/h"},        // ignored by .bazelignore 'dir3/'
 		{Path: "a.file"},          // ignored by .bazelignore 'a.file'
+		{Path: "b.file"},          // ignored by .bazelignore './b.file'
+		{Path: "ugly/c.file"},     // ignored by .bazelignore '././blah/../ugly/c.file'
 	})
 	defer cleanup()
 


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

Bazel supports leading ./ in .bazelignore, so should gazelle

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
