### PR TITLE
[Gazelle] Fix Duplicate Load Bug

### DIFF
--- a/merger/fix.go
+++ b/merger/fix.go
@@ -123,6 +123,7 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 			if load != nil {
 				index := newLoadIndex(f, known.After)
 				load.Insert(f, index)
+				loads = append(loads, load)
 			}
 		}
 	}

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -38,6 +38,11 @@ func TestFixLoads(t *testing.T) {
 			Symbols: []string{
 				"foo_binary",
 				"foo_library",
+			},
+		},
+		{
+			Name: "@foo",
+			Symbols: []string{
 				"foo_test",
 			},
 		},
@@ -173,8 +178,8 @@ foo_library(name = "a_lib")
     name = "a",
 )
 `,
-			want: `load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@foo", "foo_binary")
+			want: `load("@foo", "foo_binary")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 maybe(
     foo_binary,
@@ -227,7 +232,7 @@ selects.config_setting_group(
 			f.Sync()
 
 			want := strings.TrimSpace(tc.want)
-			got := strings.TrimSpace(string(bzl.Format(f.File)))
+			got := strings.TrimSpace(string(bzl.FormatWithoutRewriting(f.File)))
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("FixLoads() mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
If two extensions both import Kinds from the same file, and no load statement for those Kinds is already in the BUILD.bazel file, then Gazelle will add the load statement twice.

In this commit, we fix the issue by updating the tracked loads when a new load is inserted into the index. This will cause future iterations to update the existing load instead of creating a duplicate.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle


**What does this PR do? Why is it needed?**

This PR fixes a bug where is two extensions each load a statement from the same file, and the file has no load statements at all, duplicate load statements will be added to the top of the file.

**Which issues(s) does this PR fix?**

None, its a small bug fix and the above directions say one isn't needed.


**Other notes for review**

None
