### PR TITLE
temporarily disable `//internal:bazel_test` on Mac to fix CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -107,6 +107,9 @@ tasks:
     - "..."
     test_targets:
     - "..."
+    # TODO: This is currently timing out due to infrastructure issues. We should
+    # unblock development by temporarily disabling on MacOS.
+    - "-//internal:bazel_test"
   macos_bzlmod:
     name: Mac OS with Bzlmod
     platform: macos


### PR DESCRIPTION
Builds ([example](https://buildkite.com/bazel/bazel-gazelle/builds/4022#01909d11-a3eb-4f13-bfd9-aa98755ba7d2)) are failing because this test is timing out on Mac OS.

Let's temporarily disable this large test to unblock development.

The `//internal:bazel_test` is still run on `ubuntu2204`