### PR TITLE
[Proto] Require space between 'service' and service name in regex matching

### DIFF
--- a/language/proto/fileinfo.go
+++ b/language/proto/fileinfo.go
@@ -106,7 +106,7 @@ func buildProtoRegexp() *regexp.Regexp {
 	importStmt := `\bimport\s*(?:public|weak)?\s*(?P<import>` + strLit + `)\s*;`
 	packageStmt := `\bpackage\s*(?P<package>` + fullIdent + `)\s*;`
 	optionStmt := `\boption\s*(?P<optkey>` + fullIdent + `)\s*=\s*(?P<optval>` + strLit + `)\s*;`
-	serviceStmt := `(?P<service>service\s*` + ident + `\s*{)`
+	serviceStmt := `(?P<service>service\s+` + ident + `\s*{)`
 	comment := `//[^\n]*`
 	protoReSrc := strings.Join([]string{importStmt, packageStmt, optionStmt, serviceStmt, comment}, "|")
 	return regexp.MustCompile(protoReSrc)

--- a/language/proto/fileinfo_test.go
+++ b/language/proto/fileinfo_test.go
@@ -110,10 +110,35 @@ import "second.proto";`,
 			want: FileInfo{
 				HasServices: true,
 			},
-		}, {
+		},
+		{
+			desc:  "service multiple spaces",
+			name:  "service.proto",
+			proto: `service      ChatService   {}`,
+			want: FileInfo{
+				HasServices: true,
+			},
+		},
+		{
+			desc:  "service no space for bracket after service name",
+			name:  "service.proto",
+			proto: `service      ChatService{}`,
+			want: FileInfo{
+				HasServices: true,
+			},
+		},
+		{
+			desc:  "service no space before service name not matched",
+			name:  "service.proto",
+			proto: `serviceChatService {}`,
+			want: FileInfo{
+				HasServices: false,
+			},
+		},
+		{
 			desc:  "service as name",
 			name:  "service.proto",
-			proto: `message ServiceAccount { string service = 1; }`,
+			proto: `message serviceAccount { string service = 1; }`,
 			want: FileInfo{
 				HasServices: false,
 			},


### PR DESCRIPTION
Prior to this commit, the regex for determining whether a file had services did not require a space between the word "service" and the service name. This could lead to false alarms, like "message serviceABC". In this commit, we update the regex to only match if there is at least one space between service and the service name.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/proto

**What does this PR do? Why is it needed?**

Fixes a bug where the HasServices regex could incorrectly match messages that have "service" at the beginning of its name.

**Which issues(s) does this PR fix?**

None, small bug fix

**Other notes for review**
