### PR TITLE
Always check files in generation tests

### DIFF
--- a/testtools/files.go
+++ b/testtools/files.go
@@ -368,7 +368,7 @@ Run %s to update BUILD.out and expected{Stdout,Stderr,ExitCode}.txt files.
 			for _, err := range errs {
 				t.Log(err)
 			}
-			t.FailNow()
+			t.Fail()
 		}
 
 		CheckFiles(t, testdataDir, goldens)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Bug fix/ Feature

**What package or component does this PR mostly affect?**

> gazelle_generation_test

**What does this PR do? Why is it needed?**
When iterating on new language plugins, it is helpful to have the CheckFiles validation run so that any mismatched BUILD file output can be shown.

Replacing `FailNow` with `Fail` allows for this

**Other notes for review**

Open to making this configurable, but this seems like a better default from the initial implementation 
https://github.com/bazelbuild/bazel-gazelle/commit/62afca5f276a56c1aa40804055a3a121295f53d8#diff-6ced8e81668a603f2efffea7938a66f16185221acdaab6e16f112377e663fbe5R343
