### PR TITLE
Add default directives for github.com/containerd

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -31,6 +31,15 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/cockroachdb/errors": [
         "gazelle:proto disable",
     ],
+    "github.com/containerd/containerd": [
+        "gazelle:proto disable",
+    ],
+    "github.com/containerd/containerd/api": [
+        "gazelle:proto disable",
+    ],
+    "github.com/containerd/ttrpc": [
+        "gazelle:proto disable",
+    ],
     "github.com/gogo/googleapis": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

internal/bzlmod

**What does this PR do? Why is it needed?**

Disable github.com/containerd proto generation in default directives as [suggested in `rules_go` documentation](https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md#gazelle-directives).

**Which issues(s) does this PR fix?**

**Other notes for review**
