### PR TITLE
refactor: embed gazelle generation_test_binary in gazelle_generation_test instead of recompiling

### DIFF
--- a/internal/generationtest/BUILD.bazel
+++ b/internal/generationtest/BUILD.bazel
@@ -1,11 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 # gazelle:exclude generation_test.go
-
-exports_files([
-    "generation_test.go",
-    "generation_test_manifest.yaml.tpl",
-])
 
 filegroup(
     name = "all_files",
@@ -22,4 +18,15 @@ bzl_library(
     srcs = ["generationtest.bzl"],
     visibility = ["//:__subpackages__"],
     deps = ["@io_bazel_rules_go//go:def"],
+)
+
+go_library(
+    name = "generationtest_test",
+    testonly = True,
+    srcs = ["generation_test.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//testtools",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
 )

--- a/internal/generationtest/generationtest.bzl
+++ b/internal/generationtest/generationtest.bzl
@@ -56,11 +56,7 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
     """
     go_test(
         name = name,
-        srcs = [Label("//internal/generationtest:generation_test.go")],
-        deps = [
-            Label("//testtools"),
-            Label("@io_bazel_rules_go//go/tools/bazel:go_default_library"),
-        ],
+        embed = [Label(":generationtest_test")],
         args = [
             "-gazelle_binary_path=$(rootpath %s)" % gazelle_binary,
             "-build_in_suffix=%s" % build_in_suffix,


### PR DESCRIPTION
**What type of PR is this?**
Other

**What package or component does this PR mostly affect?**
all

**What does this PR do? Why is it needed?**

Try to reduce the re-compiling of the same go files for every single test. I think using `embed` is no faster because it is linking that is slow? Still seems like a step in the right direction though.