### PR TITLE
refactor: add nil assignments to verify interface implementations

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -71,6 +71,8 @@ func getUpdateConfig(c *config.Config) *updateConfig {
 	return c.Exts[updateName].(*updateConfig)
 }
 
+var _ config.Configurer = (*updateConfigurer)(nil)
+
 type updateConfigurer struct {
 	mode           string
 	recursive      bool

--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -77,7 +77,7 @@ type inverseMapKindResolver struct {
 	delegate resolve.Resolver
 }
 
-var _ resolve.Resolver = inverseMapKindResolver{}
+var _ resolve.Resolver = (*inverseMapKindResolver)(nil)
 
 func (imkr inverseMapKindResolver) Name() string {
 	return imkr.delegate.Name()

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -50,6 +50,8 @@ func getUpdateReposConfig(c *config.Config) *updateReposConfig {
 	return c.Exts[updateReposName].(*updateReposConfig)
 }
 
+var _ config.Configurer = (*updateReposConfigurer)(nil)
+
 type updateReposConfigurer struct{}
 
 type macroFlag struct {

--- a/config/config.go
+++ b/config/config.go
@@ -195,6 +195,8 @@ type Configurer interface {
 	Configure(c *Config, rel string, f *rule.File)
 }
 
+var _ Configurer = (*CommonConfigurer)(nil)
+
 // CommonConfigurer handles language-agnostic command-line flags and directives,
 // i.e., those that apply to Config itself and not to Config.Exts.
 type CommonConfigurer struct {

--- a/internal/gazellebinarytest/xlang.go
+++ b/internal/gazellebinarytest/xlang.go
@@ -29,6 +29,8 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
+var _ config.Configurer = (*xlang)(nil)
+
 type xlang struct{}
 
 func NewLanguage() language.Language {

--- a/resolve/config.go
+++ b/resolve/config.go
@@ -114,6 +114,8 @@ func getResolveConfig(c *config.Config) *resolveConfig {
 	return c.Exts[resolveName].(*resolveConfig)
 }
 
+var _ config.Configurer = (*Configurer)(nil)
+
 type Configurer struct{}
 
 func (*Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -514,7 +514,7 @@ type rulesByKindAndName struct {
 }
 
 // type checking
-var _ sort.Interface = rulesByKindAndName{}
+var _ sort.Interface = (*rulesByKindAndName)(nil)
 
 func (s rulesByKindAndName) Len() int {
 	return len(s.rules)
@@ -539,7 +539,7 @@ type loadsByName struct {
 }
 
 // type checking
-var _ sort.Interface = loadsByName{}
+var _ sort.Interface = (*loadsByName)(nil)
 
 func (s loadsByName) Len() int {
 	return len(s.loads)
@@ -1144,7 +1144,7 @@ func CheckInternalVisibility(rel, visibility string) string {
 
 type byAttrName []KeyValue
 
-var _ sort.Interface = byAttrName{}
+var _ sort.Interface = (*byAttrName)(nil)
 
 func (s byAttrName) Len() int {
 	return len(s)

--- a/rule/value.go
+++ b/rule/value.go
@@ -141,13 +141,13 @@ func (s SelectStringListValue) BzlExpr() bzl.Expr {
 // ExprFromValue converts a value into an expression that can be written into
 // a Bazel build file. The following types of values can be converted:
 //
-//   * bools, integers, floats, strings.
-//   * labels (converted to strings).
-//   * slices, arrays (converted to lists).
-//   * maps (converted to select expressions; keys must be rules in
+//   - bools, integers, floats, strings.
+//   - labels (converted to strings).
+//   - slices, arrays (converted to lists).
+//   - maps (converted to select expressions; keys must be rules in
 //     @io_bazel_rules_go//go/platform).
-//   * GlobValue (converted to glob expressions).
-//   * PlatformStrings (converted to a concatenation of a list and selects).
+//   - GlobValue (converted to glob expressions).
+//   - PlatformStrings (converted to a concatenation of a list and selects).
 //
 // Converting unsupported types will cause a panic.
 func ExprFromValue(val interface{}) bzl.Expr {
@@ -216,7 +216,7 @@ func mapKeyString(k reflect.Value) string {
 
 type byString []reflect.Value
 
-var _ sort.Interface = byString{}
+var _ sort.Interface = (*byString)(nil)
 
 func (s byString) Len() int {
 	return len(s)

--- a/walk/config.go
+++ b/walk/config.go
@@ -62,6 +62,8 @@ func (wc *walkConfig) shouldFollow(rel, base string) bool {
 	return matchAnyGlob(wc.follow, path.Join(rel, base))
 }
 
+var _ config.Configurer = (*Configurer)(nil)
+
 type Configurer struct{}
 
 func (*Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -329,6 +329,8 @@ func testConfig(t *testing.T, dir string) (*config.Config, []config.Configurer) 
 	return c, cexts
 }
 
+var _ config.Configurer = (*testConfigurer)(nil)
+
 type testConfigurer struct {
 	configure func(c *config.Config, rel string, f *rule.File)
 }


### PR DESCRIPTION
Just something I find useful both for the assertion and devx when browsing the code. Now each struct explicitly declares which interface it's implementing and you'll get an error directly beside that struct if something is wrong.

**What type of PR is this?**
> Other

**What package or component does this PR mostly affect?**
all

**What does this PR do? Why is it needed?**

Minor cleanup

