### PR TITLE
update-repos: guard against pure bzlmod projects

### DIFF
--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -181,8 +181,10 @@ func updateRepos(wd string, args []string) (err error) {
 	}()
 
 	// Fix the workspace file with each language.
-	for _, lang := range filterLanguages(c, languages) {
-		lang.Fix(c, uc.workspace)
+	if !c.Bzlmod {
+		for _, lang := range filterLanguages(c, languages) {
+			lang.Fix(c, uc.workspace)
+		}
 	}
 
 	// Generate rules from command language arguments or by importing a file.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Pure bzlmod projects can't use update-repos otherwise

**Which issues(s) does this PR fix?**

Fixes #1895

**Other notes for review**
