### PR TITLE
revert #1873

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -490,7 +490,7 @@ func runFixUpdate(wd string, cmd command, args []string) (err error) {
 	for _, v := range visits {
 		for i, r := range v.rules {
 			from := label.New(c.RepoName, v.pkgRel, r.Name())
-			if rslv := mrslv.Resolver(r.Kind(), v.pkgRel); rslv != nil {
+			if rslv := mrslv.Resolver(r, v.pkgRel); rslv != nil {
 				rslv.Resolve(v.c, ruleIndex, rc, r, v.imports[i], from)
 			}
 		}

--- a/cmd/gazelle/metaresolver.go
+++ b/cmd/gazelle/metaresolver.go
@@ -53,9 +53,9 @@ func (mr *metaResolver) MappedKind(pkgRel string, kind config.MappedKind) {
 // Resolver returns a resolver for the given rule and package, and a bool
 // indicating whether one was found. Empty string may be passed for pkgRel,
 // which results in consulting the builtin kinds only.
-func (mr *metaResolver) Resolver(ruleKind string, pkgRel string) resolve.Resolver {
+func (mr *metaResolver) Resolver(r *rule.Rule, pkgRel string) resolve.Resolver {
 	for _, mappedKind := range mr.mappedKinds[pkgRel] {
-		if mappedKind.KindName == ruleKind {
+		if mappedKind.KindName == r.Kind() {
 			fromKindResolver := mr.builtins[mappedKind.FromKind]
 			if fromKindResolver == nil {
 				return nil
@@ -66,7 +66,7 @@ func (mr *metaResolver) Resolver(ruleKind string, pkgRel string) resolve.Resolve
 			}
 		}
 	}
-	return mr.builtins[ruleKind]
+	return mr.builtins[r.Kind()]
 }
 
 // inverseMapKindResolver applies an inverse of the map_kind

--- a/language/go/resolve_test.go
+++ b/language/go/resolve_test.go
@@ -973,7 +973,7 @@ go_proto_library(
 			}
 			ix.Finish()
 			for i, r := range f.Rules {
-				mrslv.Resolver(r.Kind(), "").Resolve(c, ix, rc, r, imports[i], label.New("", tc.old.rel, r.Name()))
+				mrslv.Resolver(r, "").Resolve(c, ix, rc, r, imports[i], label.New("", tc.old.rel, r.Name()))
 			}
 			f.Sync()
 			got := strings.TrimSpace(string(bzl.Format(f.File)))
@@ -1319,6 +1319,6 @@ func convertImportsAttr(r *rule.Rule) interface{} {
 
 type mapResolver map[string]resolve.Resolver
 
-func (mr mapResolver) Resolver(ruleKind, f string) resolve.Resolver {
-	return mr[ruleKind]
+func (mr mapResolver) Resolver(r *rule.Rule, f string) resolve.Resolver {
+	return mr[r.Kind()]
 }

--- a/language/proto/resolve_test.go
+++ b/language/proto/resolve_test.go
@@ -511,6 +511,6 @@ func convertImportsAttr(r *rule.Rule) interface{} {
 
 type mapResolver map[string]resolve.Resolver
 
-func (mr mapResolver) Resolver(ruleKind, f string) resolve.Resolver {
-	return mr[ruleKind]
+func (mr mapResolver) Resolver(r *rule.Rule, f string) resolve.Resolver {
+	return mr[r.Kind()]
 }


### PR DESCRIPTION
We need access to `rule.Name()` as well as `rule.Kind()` in mapped resolver.

