### PR TITLE
Support timeout and size in gazelle_test

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -227,7 +227,7 @@ def gazelle(name, **kwargs):
         data = kwargs["data"] if "data" in kwargs else [],
     )
 
-def gazelle_test(name, **kwargs):
+def gazelle_test(name, size = None, timeout = None, **kwargs):
     runner_name, visibility = _gazelle_kwargs_prepare(name, kwargs)
 
     _gazelle_test_runner(
@@ -247,6 +247,8 @@ def gazelle_test(name, **kwargs):
         srcs = [runner_name],
         visibility = visibility,
         tags = tags,
+        size = size,
+        timeout = timeout,
         deps = ["@bazel_tools//tools/bash/runfiles"],
         data = kwargs["data"] if "data" in kwargs else [],
     )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

bazel's gazelle_test

**What does this PR do? Why is it needed?**

Supports removing noisy warnings like:

```
  WARNING: //:gazelle_test: Test execution time (0.1s excluding execution overhead) outside of range for MODERATE tests. Consider setting timeout="short" or size="small".
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
