### PR TITLE
refactor: reduce path.join while walking repo

### DIFF
--- a/walk/config.go
+++ b/walk/config.go
@@ -49,12 +49,12 @@ func getWalkConfig(c *config.Config) *walkConfig {
 	return c.Exts[walkName].(*walkConfig)
 }
 
-func (wc *walkConfig) isExcluded(rel, base string) bool {
-	return matchAnyGlob(wc.excludes, path.Join(rel, base))
+func (wc *walkConfig) isExcluded(p string) bool {
+	return matchAnyGlob(wc.excludes, p)
 }
 
-func (wc *walkConfig) shouldFollow(rel, base string) bool {
-	return matchAnyGlob(wc.follow, path.Join(rel, base))
+func (wc *walkConfig) shouldFollow(p string) bool {
+	return matchAnyGlob(wc.follow, p)
 }
 
 var _ config.Configurer = (*Configurer)(nil)


### PR DESCRIPTION
**What type of PR is this?**

refactor / perf

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Reduce duplicate `path.Join` invocations. Remove duplicate `isBazelIgnored` invocations (it is not needed on the root dir, it is invoked before recursing).

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
