### PR TITLE
bzlmod/go_work: support relative paths

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -27,6 +27,17 @@ def _validate_go_version(path, state, tokens, line_no):
         fail("{}:{}: unexpected token '{}' after '{}'".format(path, line_no, tokens[2], tokens[1]))
 
 def use_spec_to_label(repo_name, use_directive):
+    # Strip all leading ../ assuming they point into the existing repo
+    if use_directive.startswith("../"):
+        segments = []
+        done = False
+        for segment in use_directive.split("/"):
+            if not done and segment == "..":
+                continue
+            segments.append(segment)
+            done = True
+        use_directive = "/".join(segments)
+
     if use_directive.startswith("../") or "/../" in use_directive or use_directive.endswith("/.."):
         fail("go.work use directive: '{}' contains '..' which is not currently supported.".format(use_directive))
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_deps.from_file for bzlmod

**What does this PR do? Why is it needed?**

We have a use case where we have multiple go modules in a single repo,
but adding go.work breaks some existing tooling, if it's added to the
root. We want to add it to another location like: bazel/thirdparty
but then we need to support having entries in go.work that look like:
`../../src/go/rpk`. This patch allows leading parent segments (..) in
go.work files to support our use case.

**Which issues(s) does this PR fix?**

Did not file an issue (I can if desired).

**Other notes for review**

This doesn't guard against relative paths that point outside the repo.
I think if desired we could calculate the maximum number of parent segments
and limit them. I also have no desire to do full path normalization...
