### PR TITLE
feat: include package URL in package_info

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ bazel_dep(name = "bazel_features", version = "1.9.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.47.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "rules_license", version = "0.0.8")
+bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/deps.bzl
+++ b/deps.bzl
@@ -58,10 +58,10 @@ def gazelle_dependencies(
         http_archive,
         name = "rules_license",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
         ],
-        sha256 = "241b06f3097fd186ff468832150d6cc142247dc42a32aaefb56d0099895fd229",
+        sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
     )
 
     if go_sdk:

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -392,10 +392,10 @@ def _generate_package_info(*, importpath, version):
     # See specification:
     # https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
     # scheme:type/namespace/name@version?qualifiers#subpath
-    purl = "pkg:golang/{namespace_and_name}{version}".format(
+    purl = "pkg:golang/{namespace_and_name}@{version}".format(
         namespace_and_name = importpath,
-        version = "@{}".format(version) if version else "",
-    )
+        version = version,
+    ) if version else None
 
     return """
 load("@rules_license//rules:package_info.bzl", "package_info")

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -365,6 +365,7 @@ def _go_repository_impl(ctx):
         # Do not override a REPO.bazel patched in by users. This also provides a
         # way for users to opt out of Gazelle-generated package_info.
         repo_file = ctx.path("REPO.bazel")
+        print("REPO.bazel exists?", repo_file.exists)
         if not repo_file.exists:
             ctx.file("REPO.bazel", """\
 repo(default_package_metadata = ["//:gazelle_generated_package_info"])
@@ -387,8 +388,16 @@ def _generate_package_info(*, importpath, version):
     package_name = importpath
 
     # TODO: Consider adding support for custom remotes.
-    package_url = "https://" + importpath if version else None
+    package_url = "https://{}".format(importpath) if version else None
     package_version = version.removeprefix("v") if version else None
+    # See specification:
+    # https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
+    # scheme:type/namespace/name@version?qualifiers#subpath
+    purl = "pkg:golang/{namespace_and_name}{version}".format(
+        namespace_and_name = importpath,
+        version = "@{}".format(version) if version else "",
+    )
+
     return """
 load("@rules_license//rules:package_info.bzl", "package_info")
 
@@ -397,12 +406,14 @@ package_info(
     package_name = {package_name},
     package_url = {package_url},
     package_version = {package_version},
+    purl = {purl},
     visibility = ["//:__subpackages__"],
 )
 """.format(
         package_name = repr(package_name),
         package_url = repr(package_url),
         package_version = repr(package_version),
+        purl = repr(purl),
     )
 
 go_repository = repository_rule(

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -365,7 +365,6 @@ def _go_repository_impl(ctx):
         # Do not override a REPO.bazel patched in by users. This also provides a
         # way for users to opt out of Gazelle-generated package_info.
         repo_file = ctx.path("REPO.bazel")
-        print("REPO.bazel exists?", repo_file.exists)
         if not repo_file.exists:
             ctx.file("REPO.bazel", """\
 repo(default_package_metadata = ["//:gazelle_generated_package_info"])

--- a/tests/bcr/go_mod/MODULE.bazel
+++ b/tests/bcr/go_mod/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
 bazel_dep(name = "bazel_features", version = "1.14.0")
 bazel_dep(name = "protobuf", version = "23.1", repo_name = "my_protobuf")
 bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "my_rules_go")
-bazel_dep(name = "rules_license", version = "0.0.8")
+bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2", repo_name = "my_rules_proto")
 bazel_dep(name = "rules_testing", version = "0.6.0")
 

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -26,6 +26,7 @@ def _test_package_info_impl(env, target):
     subject.package_name().equals("github.com/fmeum/dep_on_gazelle")
     subject.package_version().equals("1.0.0")
     subject.package_url().equals("https://github.com/fmeum/dep_on_gazelle")
+    subject.purl().equals("pkg:golang/github.com/fmeum/dep_on_gazelle@v1.0.0")
 
 def _package_info_aspect_impl(_, ctx):
     if hasattr(ctx.rule.attr, "applicable_licenses"):
@@ -51,6 +52,7 @@ _PackageInfoSubjectFactory = struct(
             "package_name": subjects.str,
             "package_version": subjects.str,
             "package_url": subjects.str,
+            "purl": subjects.str,
         },
     ),
 )


### PR DESCRIPTION
Requires upgrade to the 1.0.0 release of rules_license, which is more appropriate than a pre-release anyway.

Follow-up to #1852

Note that I'm still unable to gather the resulting data from an end-user point of view using the aspects provided by rules_license. Will look for some help on Slack to see if there's still missing plumbing.