### PR TITLE
fix: genproto google apis conflict fix

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -102,6 +102,10 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:go_generate_proto false",
         "gazelle:proto_import_prefix k8s.io/apimachinery",
     ],
+    "google.golang.org/genproto/googleapis/api/annotations": [
+         "gazelle:resolve go google.golang.org/genproto/googleapis/api/annotations @org_golang_google_genproto//googleapis/api/annotations",
+         "gazelle:resolve go google.golang.org/genproto/googleapis/api @org_golang_google_genproto//googleapis/api",
+    ],
 }
 
 DEFAULT_BUILD_EXTRA_ARGS_BY_PATH = {


### PR DESCRIPTION
The PR addresses [rules_go issue 1877](https://github.com/bazelbuild/rules_go/issues/1877). 
[This](https://github.com/bazelbuild/rules_go/issues/1877#issuecomment-1867067658) is a fairly good description of what's happening: the target dependency isn't accurate.

As suggested by @fmeum I added the default behaviour to prevent this issue from happening.