### PR TITLE
Add gazelle overrides to enable building rclone

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -102,10 +102,23 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:go_generate_proto false",
         "gazelle:proto_import_prefix k8s.io/apimachinery",
     ],
+    "storj.io/common": [
+        "gazelle:proto legacy",
+    ],
+    "storj.io/eventkit": [
+        "gazelle:proto legacy",
+    ],
+    "storj.io/picobuf": [
+        "gazelle:proto legacy",
+    ],
 }
 
 DEFAULT_BUILD_EXTRA_ARGS_BY_PATH = {
     "github.com/census-instrumentation/opencensus-proto": [
         "-exclude=src",
+    ],
+    "github.com/cronokirby/saferith": [
+        # This test file declares `package big` rather than `package saferith`.
+        "-exclude=arith_s390x_test.go",
     ],
 }


### PR DESCRIPTION
I was just toying around with Gazelle and the rclone project (see https://github.com/rclone/rclone/issues/8093). These changes were necessary, but not sufficient, to build `//:rclone` with Gazelle-generated BUILD files.

I also needed to make a change for hdfs in my MODULE.bazel, but someone already beat me to it in https://github.com/bazelbuild/bazel-gazelle/pull/1867. I solved my problem with `gazelle:proto legacy`, but it looks like the existing override does something different.


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation

Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

bzlmod

**What does this PR do? Why is it needed?**

Adds default overrides for some Go dependencies of the rclone project.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
