### PR TITLE
Skip over godebug lines in go.mod/go.work files

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -80,6 +80,8 @@ def parse_go_work(content, go_work_label):
                 state["use"].append(tokens[0])
             elif current_directive == "replace":
                 _parse_replace_directive(state, tokens, go_work_label.name, line_no)
+            elif current_directive == "godebug":
+                pass
             else:
                 fail("{}:{}: unexpected directive '{}'".format(go_work_label.name, line_no, current_directive))
         elif tokens[0] == "go":
@@ -101,6 +103,9 @@ def parse_go_work(content, go_work_label):
                 state["use"].append(tokens[1])
         elif tokens[0] == "toolchain":
             continue
+        elif tokens[0] == "godebug":
+            if tokens[1] == "(":
+                current_directive = tokens[0]
         else:
             fail("{}:{}: unexpected directive '{}'".format(go_work_label.name, line_no, tokens[0]))
 
@@ -210,7 +215,7 @@ def parse_go_mod(content, path):
             continue
 
         if not current_directive:
-            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain"]:
+            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain", "godebug"]:
                 fail("{}:{}: unexpected token '{}' at start of line".format(path, line_no, tokens[0]))
             if len(tokens) == 1:
                 fail("{}:{}: expected another token after '{}'".format(path, line_no, tokens[0]))

--- a/tests/bzlmod/go_mod_test.bzl
+++ b/tests/bzlmod/go_mod_test.bzl
@@ -57,6 +57,13 @@ _GO_MOD_21_CONTENT = """go 1.21.0rc1
 module example.com
 
 toolchain go1.22.2
+
+godebug (
+    default=go1.21
+    panicnil=1
+    asynctimerchan=0
+)
+godebug tlsrsakex=1
 """
 
 _EXPECTED_GO_MOD_21_PARSE_RESULT = struct(
@@ -114,6 +121,13 @@ use (
 replace github.com/go-fsnotify/fsnotify => github.com/fsnotify/fsnotify v1.4.2
 replace github.com/bmatcuk/doublestar/v4 v4.0.2 => github.com/bmatcuk/doublestar/v4 v4.0.3
 replace example.org/hello => ../fixtures/hello
+
+godebug (
+    default=go1.21
+    panicnil=1
+    asynctimerchan=0
+)
+godebug tlsrsakex=1
 """
 
 _EXPECTED_GO_WORK_PARSE_RESULT = struct(


### PR DESCRIPTION
Go 1.21 introduced support for godebug lines in go.mod and go.work files. Skip over these lines instead of failing

Related #1945

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
