### PR TITLE
Support MODULE.bazel test cases for gazelle_generation_test.

### DIFF
--- a/extend.md
+++ b/extend.md
@@ -152,7 +152,7 @@ The generation test expects a file structure like the following:
 ```
 |-- <testDataPath>
     |-- some_test
-        |-- WORKSPACE
+        |-- WORKSPACE and/or MODULE.bazel -> Indicates the directory is a test case.
         |-- README.md --> README describing what the test does.
         |-- arguments.txt --> newline delimited list of arguments to pass in (ignored if empty).
         |-- expectedStdout.txt --> Expected stdout for this test.

--- a/internal/generationtest/generation_test.go
+++ b/internal/generationtest/generation_test.go
@@ -48,7 +48,7 @@ func TestFullGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not convert gazelle binary path %s to absolute path. Error: %v", *gazelleBinaryPath, err)
 	}
-	testNames := map[string]bool{}
+	testNames := map[string]struct{}{}
 	for _, f := range runfiles {
 		// Look through runfiles for WORKSPACE or MODULE.bazel files. Each such file specifies a test case.
 		if filepath.Base(f.Path) == "WORKSPACE" || filepath.Base(f.Path) == "MODULE.bazel" {
@@ -64,10 +64,10 @@ func TestFullGeneration(t *testing.T) {
 
 			// Don't add a test if it was already added. That could be the case if a directory has
 			// both a WORKSPACE and a MODULE.bazel file in it.
-			if testNames[name] {
+			if _, exists := testNames[name]; exists {
 				continue
 			}
-			testNames[name] = true
+			testNames[name] = struct{}{}
 
 			tests = append(tests, &testtools.TestGazelleGenerationArgs{
 				Name:                 name,

--- a/internal/generationtest/generation_test.go
+++ b/internal/generationtest/generation_test.go
@@ -48,9 +48,10 @@ func TestFullGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not convert gazelle binary path %s to absolute path. Error: %v", *gazelleBinaryPath, err)
 	}
+	testNames := map[string]bool{}
 	for _, f := range runfiles {
-		// Look through runfiles for WORKSPACE files. Each WORKSPACE is a test case.
-		if filepath.Base(f.Path) == "WORKSPACE" {
+		// Look through runfiles for WORKSPACE or MODULE.bazel files. Each such file specifies a test case.
+		if filepath.Base(f.Path) == "WORKSPACE" || filepath.Base(f.Path) == "MODULE.bazel" {
 			// absolutePathToTestDirectory is the absolute
 			// path to the test case directory. For example, /home/<user>/wksp/path/to/test_data/my_test_case
 			absolutePathToTestDirectory := filepath.Dir(f.Path)
@@ -60,6 +61,13 @@ func TestFullGeneration(t *testing.T) {
 			// name is the name of the test directory. For example, my_test_case.
 			// The name of the directory doubles as the name of the test.
 			name := filepath.Base(absolutePathToTestDirectory)
+
+			// Don't add a test if it was already added. That could be the case if a directory has
+			// both a WORKSPACE and a MODULE.bazel file in it.
+			if testNames[name] {
+				continue
+			}
+			testNames[name] = true
 
 			tests = append(tests, &testtools.TestGazelleGenerationArgs{
 				Name:                 name,

--- a/internal/generationtest/generationtest.bzl
+++ b/internal/generationtest/generationtest.bzl
@@ -27,7 +27,7 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
     ```
     |-- <testDataPath>
         |-- some_test
-            |-- WORKSPACE
+            |-- WORKSPACE and/or MODULE.bazel -> Indicates the directory is a test case.
             |-- README.md --> README describing what the test does.
             |-- arguments.txt --> newline delimited list of arguments to pass in (ignored if empty).
             |-- expectedStdout.txt --> Expected stdout for this test.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,6 +4,8 @@ load(
     "gazelle_generation_test",
 )
 load("//tests:tools.bzl", "get_binary")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 
 # Exclude this entire directly from having anything gnerated by Gazelle. That
 # way the test cases won't be fixed by `bazel run //:gazelle` when run in this
@@ -46,14 +48,21 @@ gazelle_binary(
 
 [gazelle_generation_test(
     # Name the test the path to the directory containing the WORKSPACE file.
-    name = file[0:-len("/WORKSPACE")],
-    gazelle_binary = get_binary(file),
+    name = test_dir,
+    gazelle_binary = get_binary(test_dir),
     # This is a noop as the default is False. However, it does confirm that
     # gazelle_generation_test accepts setting common test attributes.
     local = False,
     test_data = glob(
-        include = [file[0:-len("/WORKSPACE")] + "/**"],
+        include = [test_dir + "/**"],
     ),
-) for file in glob(
-    include = ["**/WORKSPACE"],
-)]
+) for test_dir in sets.to_list(sets.make([
+        paths.dirname(p)
+        # Note that glob matches "this package's directories and non-subpackage
+        # subdirectories," so any directory with a BUILD or BUILD.bazel file
+        # will not match, but those with BUILD.in and BUILD.out will.
+        for p in glob([
+            "**/WORKSPACE",
+            "**/MODULE.bazel",
+        ])
+    ]))]

--- a/tests/bazelignore/BUILD.out
+++ b/tests/bazelignore/BUILD.out
@@ -3,7 +3,7 @@ filegroup(
     testonly = True,
     srcs = [
         ".bazelignore",
-        "WORKSPACE",
+        "MODULE.bazel",
         "//sub2:all_files",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
**What type of PR is this?**

Feature (testing enhancement for extension developers)

**What package or component does this PR mostly affect?**

gazelle_generation_test

**What does this PR do? Why is it needed?**

gazelle_generation_test uses the existence of a WORKSPACE file to indicate a directory is a test case. This PR extends gazelle_generation_test to also look for directories with a MODULE.bazel file.

A test case is modified to check the logic.

**Which issues(s) does this PR fix?**

Fixes # 1947

**Other notes for review**

Added as part of kotlin gazelle development.