### PR TITLE
Don't hard fail if there's a second request to bazelize the same Go module

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -592,6 +592,7 @@ def _go_deps_impl(module_ctx):
                 ),
             )
 
+    repos_processed = {}
     for path, module in module_resolutions.items():
         if hasattr(module, "module_name"):
             # Do not create a go_repository for a Go module provided by a bazel_dep.
@@ -602,6 +603,10 @@ def _go_deps_impl(module_ctx):
             # Do not create a go_repository for a dep shared with the non-isolated instance of
             # go_deps.
             continue
+        if module.repo_name in repos_processed:
+            continue
+
+        repos_processed[module.repo_name] = True
         go_repository_args = {
             "name": module.repo_name,
             # Compared to the name attribute, the content of this attribute does not go through repo


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment one line below and remove others.
Bug fix

**What package or component does this PR mostly affect?**
> go_deps

**What does this PR do? Why is it needed?**
It's possible that a go.mod file may contain a (module, version) pair listed both as a direct and indirect requirement. In such cases, the module extension attempts to create a second `go_repository` rule which fails with an error like this:
```
ERROR: Traceback (most recent call last):
        File "/private/var/tmp/<some_path>/gazelle~/internal/bzlmod/go_deps.bzl", line 646, column 22, in _go_deps_impl
                go_repository(**go_repository_args)
Error in repository_rule: A repo named <some_repo> is already generated by this module extension at /private/var/tmp/<some_path>/gazelle~/internal/bzlmod/go_deps.bzl:646:22
```

This PR fixes such an error by simply keeping track of the modules that were already processed.

**Which issues(s) does this PR fix?**
I'm happy to create an issue but the instructions said I could skip if it's a small fix
