### PR TITLE
Don't call dict.pop() with named arguments

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -205,7 +205,7 @@ def _gazelle_kwargs_prepare(name, kwargs):
         kwargs["extra_args"] = kwargs["args"]
         kwargs.pop("args")
 
-    visibility = kwargs.pop("visibility", default = None)
+    visibility = kwargs.pop("visibility", None)
     return name + "-runner", visibility
 
 def gazelle(name, **kwargs):

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -595,8 +595,8 @@ def _go_deps_impl(module_ctx):
     for path, module in module_resolutions.items():
         if hasattr(module, "module_name"):
             # Do not create a go_repository for a Go module provided by a bazel_dep.
-            root_module_direct_deps.pop(_repo_name(path), default = None)
-            root_module_direct_dev_deps.pop(_repo_name(path), default = None)
+            root_module_direct_deps.pop(_repo_name(path), None)
+            root_module_direct_dev_deps.pop(_repo_name(path), None)
             continue
         if getattr(module_ctx, "is_isolated", False) and path in _SHARED_REPOS:
             # Do not create a go_repository for a dep shared with the non-isolated instance of


### PR DESCRIPTION

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

I'm doing some experiments, where I'm trying to parse/analyze some existing Bazel rules using Go Starlark. This seems to be mostly successful, though I am noticing some small breakages.

**Which issues(s) does this PR fix?**

It fixes an issue where dict.pop() is called with named arguments in a couple of places, even though it's only supposed to be called with positional arguments.

**Other notes for review**
