### PR TITLE
go_deps should fail with a clear message when 2 modules that only differ in case are used

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -592,6 +592,7 @@ def _go_deps_impl(module_ctx):
                 ),
             )
 
+    repos_processed = {}
     for path, module in module_resolutions.items():
         if hasattr(module, "module_name"):
             # Do not create a go_repository for a Go module provided by a bazel_dep.
@@ -602,6 +603,10 @@ def _go_deps_impl(module_ctx):
             # Do not create a go_repository for a dep shared with the non-isolated instance of
             # go_deps.
             continue
+        if module.repo_name in repos_processed:
+            continue
+
+        repos_processed[module.repo_name] = True
         go_repository_args = {
             "name": module.repo_name,
             # Compared to the name attribute, the content of this attribute does not go through repo

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -604,9 +604,9 @@ def _go_deps_impl(module_ctx):
             # go_deps.
             continue
         if module.repo_name in repos_processed:
-            continue
+            fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle (yet). Please ensure you only use one of these modules in your go.mod(s)")
 
-        repos_processed[module.repo_name] = True
+        repos_processed[module.repo_name] = path
         go_repository_args = {
             "name": module.repo_name,
             # Compared to the name attribute, the content of this attribute does not go through repo

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -605,9 +605,9 @@ def _go_deps_impl(module_ctx):
             continue
         if module.repo_name in repos_processed:
             fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle (yet). Please ensure you only use one of these modules in your go.mod(s)".format(
-                prev_path=repos_processed[module.repo_name],
-                path=path,
-                name=module.repo_name
+                prev_path = repos_processed[module.repo_name],
+                path = path,
+                name = module.repo_name,
             ))
 
         repos_processed[module.repo_name] = path

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -604,7 +604,11 @@ def _go_deps_impl(module_ctx):
             # go_deps.
             continue
         if module.repo_name in repos_processed:
-            fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle (yet). Please ensure you only use one of these modules in your go.mod(s)")
+            fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle (yet). Please ensure you only use one of these modules in your go.mod(s)".format(
+                prev_path=repos_processed[module.repo_name],
+                path=path,
+                name=module.repo_name
+            ))
 
         repos_processed[module.repo_name] = path
         go_repository_args = {


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What package or component does this PR mostly affect?**
> go_deps

**What does this PR do? Why is it needed?**
Replaces https://github.com/bazelbuild/bazel-gazelle/pull/1949
