### PR TITLE
rule: unset attribute if src is nil and no keep annotation in dst when merge

### DIFF
--- a/rule/merge.go
+++ b/rule/merge.go
@@ -169,8 +169,6 @@ func shouldKeepRecursively(e bzl.Expr) bool {
 		if shouldKeepRecursively(e.X) || shouldKeepRecursively(e.Y) {
 			return true
 		}
-	default:
-		fmt.Printf("unexpected expression type %T\n", e)
 	}
 	return false
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

This change will allow merging a non-existing attribute to any dst attribute not annotated with `# keep`.

The current merge logic requires the dst attribute to be a scaler to unset, which prevents Gazelle from removing an attribute using `glob()`.

**Which issues(s) does this PR fix?**

Fixes #1989
