### PR TITLE
fix: make language agnostic kinds generic

### DIFF
--- a/internal/go_repository_tools_srcs.bzl
+++ b/internal/go_repository_tools_srcs.bzl
@@ -160,6 +160,7 @@ GO_REPOSITORY_TOOLS_SRCS = [
     Label("//v2/rule:BUILD.bazel"),
     Label("//v2/rule:directives.go"),
     Label("//v2/rule:expr.go"),
+    Label("//v2/rule:kinds.go"),
     Label("//v2/rule:merge.go"),
     Label("//v2/rule:platform.go"),
     Label("//v2/rule:platform_strings.go"),

--- a/language/go/kinds.go
+++ b/language/go/kinds.go
@@ -22,14 +22,6 @@ import (
 )
 
 var goKinds = map[string]rule.KindInfo{
-	"alias": {
-		NonEmptyAttrs:  map[string]bool{"actual": true},
-		MergeableAttrs: map[string]bool{"actual": true},
-	},
-	"filegroup": {
-		NonEmptyAttrs:  map[string]bool{"srcs": true},
-		MergeableAttrs: map[string]bool{"srcs": true},
-	},
 	"go_binary": {
 		MatchAny: true,
 		NonEmptyAttrs: map[string]bool{

--- a/v2/cmd/gazelle/update/update.go
+++ b/v2/cmd/gazelle/update/update.go
@@ -320,6 +320,9 @@ func Run(
 
 	mrslv := newMetaResolver()
 	kinds := make(map[string]rule.KindInfo)
+	for kind, info := range rule.GenericKinds {
+		kinds[kind] = info
+	}
 	loads := genericLoads
 	exts := make([]interface{}, 0, len(languages))
 	for _, lang := range languages {

--- a/v2/rule/BUILD.bazel
+++ b/v2/rule/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "directives.go",
         "expr.go",
+        "kinds.go",
         "merge.go",
         "platform.go",
         "platform_strings.go",
@@ -46,6 +47,7 @@ filegroup(
         "directives.go",
         "directives_test.go",
         "expr.go",
+        "kinds.go",
         "merge.go",
         "merge_test.go",
         "platform.go",

--- a/v2/rule/kinds.go
+++ b/v2/rule/kinds.go
@@ -1,0 +1,29 @@
+/* Copyright 2026 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+// GenericKinds is the KindInfo for native.* bazel rules not owned by any
+// specific language extension.
+var GenericKinds = map[string]KindInfo{
+	"alias": {
+		NonEmptyAttrs:  map[string]bool{"actual": true},
+		MergeableAttrs: map[string]bool{"actual": true},
+	},
+	"filegroup": {
+		NonEmptyAttrs:  map[string]bool{"srcs": true},
+		MergeableAttrs: map[string]bool{"srcs": true},
+	},
+}

--- a/v2/rule/rule.go
+++ b/v2/rule/rule.go
@@ -1064,7 +1064,15 @@ func (r *Rule) InsertAt(f *File, index int) {
 // IsEmpty returns true when the rule contains none of the attributes in attrs
 // for its kind. attrs should contain attributes that make the rule buildable
 // like srcs or deps and not descriptive attributes like name or visibility.
+//
+// If info.NonEmptyAttrs is nil, IsEmpty falls back to metadata for Bazel
+// built-in kinds (e.g. "alias", "filegroup") so that language extensions
+// that generate these kinds without declaring them are still classified
+// correctly.
 func (r *Rule) IsEmpty(info KindInfo) bool {
+	if info.NonEmptyAttrs == nil {
+		info = GenericKinds[r.Kind()]
+	}
 	if info.NonEmptyAttrs == nil {
 		return false
 	}


### PR DESCRIPTION
The generation of these kinds should not depend on the go language being enabled.

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go
cmd/gazelle
all

**What does this PR do? Why is it needed?**

Allows any language to generate `filegroup`s without redeclaring the kinds.
