### PR TITLE
Add default overrides for spicedb support

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -31,6 +31,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:proto disable",
         "gazelle:go_naming_convention import_alias",
     ],
+    "github.com/authzed/cel-go": [
+        "gazelle:go_naming_convention go_default_library",
+    ],
     "github.com/authzed/spicedb": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Other 

**What package or component does this PR mostly affect?**

internal/bzlmod

**What does this PR do? Why is it needed?**

https://github.com/authzed/spicedb does not have Bazel support. It is using proto importing googleapis protos which cannot be resolved by Gazelle when generating build files, so this PR disables proto generation. 

Proto Bazel support is not needed as they are using `buf` to compile protos and vendor the pb.go into the repo directly (https://github.com/authzed/spicedb/tree/main/pkg/proto/).

Additionally, spicedb is using a fork of `google/cel-go` which has the same issue as the upstream version below and explained in https://github.com/bazel-contrib/bazel-gazelle/pull/1746.

**Which issues(s) does this PR fix?**

**Other notes for review**
