### PR TITLE
Invalidate go_repository_cache when host env vars change

### DIFF
--- a/internal/common.bzl
+++ b/internal/common.bzl
@@ -43,3 +43,11 @@ def watch(ctx, path):
     # explicitly here, duplicate watches are no-ops.
     if hasattr(ctx, "watch"):
         ctx.watch(path)
+
+def getenv(repo_ctx, name, default = ""):
+    # Use repo_ctx.getenv if it exists (after Bazel 7.1.0) to also invalidate
+    # the repository rule when the env var changes.
+    # We can remove this wrapper after the minimal supported Bazel version is >= 7.1.0.
+    if hasattr(repo_ctx, "getenv"):
+        return repo_ctx.getenv(name, default)
+    return repo_ctx.os.environ.get(name, default)

--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//internal:common.bzl", "executable_extension", "watch")
+load("//internal:common.bzl", "executable_extension", "getenv", "watch")
 
 # Change to trigger cache invalidation: 1
 
@@ -39,13 +39,13 @@ def _go_repository_cache_impl(ctx):
     go_path = str(ctx.path("."))
     go_cache = str(ctx.path("gocache"))
     go_mod_cache = ""
-    if ctx.getenv("GO_REPOSITORY_USE_HOST_MODCACHE", "") == "1":
+    if getenv(ctx, "GO_REPOSITORY_USE_HOST_MODCACHE") == "1":
         extension = executable_extension(ctx)
         go_tool = go_root + "/bin/go" + extension
         go_mod_cache = read_go_env(ctx, go_tool, "GOMODCACHE")
         if not go_mod_cache:
             fail("GOMODCACHE must be set when GO_REPOSITORY_USE_HOST_MODCACHE is enabled.")
-    if ctx.getenv("GO_REPOSITORY_USE_HOST_CACHE", "") == "1":
+    if getenv(ctx, "GO_REPOSITORY_USE_HOST_CACHE") == "1":
         extension = executable_extension(ctx)
         go_tool = go_root + "/bin/go" + extension
         go_mod_cache = read_go_env(ctx, go_tool, "GOMODCACHE")
@@ -95,8 +95,8 @@ go_repository_cache = repository_rule(
 
 def read_go_env(ctx, go_tool, var):
     watch(ctx, go_tool)
-    # watch var too.
-    ctx.getenv(var)
+    # watch var too if possible.
+    getenv(ctx, var)
     res = ctx.execute([go_tool, "env", var])
     if res.return_code:
         fail("failed to read go environment: " + res.stderr)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**
go_repository


**What does this PR do? Why is it needed?**
This PR calls `repository_ctx.getenv` to get `GO_REPOSITORY_USE_HOST_CACHE` and all Go env vars, so when these variables changes, the go_repository_cache is invalidated and updated.

**Which issues(s) does this PR fix?**

Fixes #2182

**Other notes for review**
