### PR TITLE
fix: only return requested dirinfo on GetDirInfo error

### DIFF
--- a/walk/cache.go
+++ b/walk/cache.go
@@ -110,8 +110,10 @@ func GetDirInfo(rel string) (DirInfo, error) {
 	// configuration may exclude rel.
 	var prevCfg *walkConfig = nil
 	var di DirInfo
+	var d string
 	var err error
 	pathtools.Prefixes(rel)(func(prefix string) bool {
+		d = prefix
 		if prevCfg != nil && prevCfg.isExcludedDir(prefix) {
 			di = DirInfo{}
 			err = fmt.Errorf("directory %q is excluded", prefix)
@@ -121,5 +123,12 @@ func GetDirInfo(rel string) (DirInfo, error) {
 		prevCfg = di.config
 		return err == nil
 	})
+
+	if err != nil {
+		if d != rel {
+			di = DirInfo{}
+		}
+	}
+
 	return di, err
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

Ensure `GetDirInfo()` only returns `DirInfo` for the requested dir, or empty on error.

**Which issues(s) does this PR fix?**

If there is an error loading a directory such as a syntax error in a BUILD file then `GetDirInfo` will detect that error and return without recursing further into the `GetDirInfo(rel)`. It will return the error but also the `DirInfo` for the directory containing the error.

If we are doing `GetDirInfo("a/b/c")` and `a/b/c/BUILD` had a syntax error, it is non-intuitive for `GetDirInfo("a/b/c")` to return the `DirInfo` for `a/b`.

**Other notes for review**

In my case I was recursing into subdirectories and when `GetDirInfo` returns the info of a parent directory it caused infinite recursion. This should probably by solved on my part by not recursing on error, but I think this change within gazelle makes return result on error clearer?

The alternative is `GetDirInfo` should return the directory the `DirInfo` is for. Maybe change the signature to `GetDirInfo(rel string) (string, DirInfo, error)` or adding `DirInfo.Pkg`.