### PR TITLE
CI: sync BCR and presubmit tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,6 +3,7 @@ matrix:
   platform:
     - ubuntu2204
     - macos
+    - windows
   bazel: [6.*, 7.*, 8.*]
   bcr_variant:
     - tests/bcr/go_work
@@ -39,6 +40,7 @@ tasks:
     - "-//internal:bazel_test"
     - "-//cmd/gazelle:gazelle_test"
   bcr_tests:
+    # Keep in sync with .bcr/presubmit.yml
     name: BCR test module
     platform: ${{ platform }}
     bazel: ${{ bazel }}
@@ -59,34 +61,6 @@ tasks:
     # Specify these targets explicitly to verify that Gazelle generates them correctly.
     - "//pkg:pkg_test"
     - "//proto:proto_test"
-    - "//..."
-    - "@test_dep//..."
-  bcr_test_windows:
-    name: BCR test on Windows
-    platform: windows
-    bazel: ${{ bazel }}
-    working_directory: ${{ bcr_variant }}
-    shell_commands:
-    # Regenerate the BUILD file for the test module using Gazelle.
-    # Also verify -repo_config are generated correctly in gazelle.bash
-    - rm pkg/BUILD.bazel
-    - bazel run //:gazelle -- pkg
-    - bazel run //:gazelle -- update pkg
-      # Verify that bazel mod tidy doesn't remove use_repos required to build and test.
-    - bazel mod tidy || true # Unsupported on Bazel 6
-    build_flags:
-    # Since go_sdk is platform-dependent, the lockfile will differ between
-    # platforms. We will skip the check on windows.
-    - "--lockfile_mode=update"
-    test_flags:
-    # See above.
-    - "--lockfile_mode=update"
-    build_targets:
-    - "//..."
-    - "//:gazelle"
-    test_targets:
-    # Specify this target explicitly to verify that Gazelle generated it correctly.
-    - "//pkg:pkg_test"
     - "//..."
     - "@test_dep//..."
   macos_arm64_bzlmod:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,30 +1,32 @@
-bcr_test_module:
-  module_path: tests/bcr/go_mod
-  matrix:
-    platform:
-      - debian10
-      - ubuntu2004
-      - macos
-      - windows
-    bazel: [6.*, 7.*, 8.*]
-  tasks:
-    run_test_module:
-      name: Run test module
-      platform: ${{ platform }}
-      bazel: ${{ bazel }}
-      shell_commands:
-      # Regenerate the BUILD files for the test module using Gazelle.
-      - rm pkg/BUILD.bazel proto/BUILD.bazel
-      - bazel run //:gazelle -- update pkg proto
-      - bazel run //:gazelle -- pkg proto
-      # Verify that bazel mod tidy doesn't remove use_repos required to build and test.
-      - bazel mod tidy || true # Unsupported on Bazel 6
-      build_targets:
-      - //...
-      - //:gazelle
-      test_targets:
-      # Specify these targets explicitly to verify that Gazelle generates them correctly.
-      - "//pkg:pkg_test"
-      - "//proto:proto_test"
-      - "//..."
-      - "@test_dep//..."
+matrix:
+  platform:
+    - ubuntu2004
+    - macos
+    - windows
+  bazel: [6.*, 7.*, 8.*]
+  bcr_variant:
+    - tests/bcr/go_work
+    - tests/bcr/go_mod
+tasks:
+  run_test_module:
+    # Keep in sync with .bazelci/presubmit.yml
+    name: Run test module
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    working_directory: ${{ bcr_variant }}
+    shell_commands:
+    # Regenerate the BUILD files for the test module using Gazelle.
+    - rm pkg/BUILD.bazel proto/BUILD.bazel
+    - bazel run //:gazelle -- pkg proto
+    - bazel run //:gazelle -- update pkg proto
+    # Verify that bazel mod tidy doesn't remove use_repos required to build and test.
+    - bazel mod tidy || true # Unsupported on Bazel 6
+    build_targets:
+    - //...
+    - //:gazelle
+    test_targets:
+    # Specify these targets explicitly to verify that Gazelle generates them correctly.
+    - "//pkg:pkg_test"
+    - "//proto:proto_test"
+    - "//..."
+    - "@test_dep//..."


### PR DESCRIPTION
**What type of PR is this?**

Test

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

- BCR: Drop support for Debian 10. It's old, we don't test it in presubmit, and protoc has compile errors there.
- BCR: test both go_work and go_mod since we test both in presubmit.
- Presubmit: squash windows and non-windows tests. They're not separated on BCR, and they're nearly identical.

**Which issues(s) does this PR fix?**

For #2208

**Other notes for review**
