### PR TITLE
CI: upgrade rules_go for BCR tests

### DIFF
--- a/tests/bcr/go_mod/MODULE.bazel
+++ b/tests/bcr/go_mod/MODULE.bazel
@@ -27,7 +27,7 @@ go_sdk.download(version = "1.24.2")
 
 # This bazel_dep provides the Go dependency github.com/cloudflare/circl, which requires custom
 # patches beyond what Gazelle can generate.
-bazel_dep(name = "circl", version = "1.3.7")
+bazel_dep(name = "circl", version = "1.3.8")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.config(

--- a/tests/bcr/go_mod/go.mod
+++ b/tests/bcr/go_mod/go.mod
@@ -10,10 +10,10 @@ require (
 	example.org/hello v1.0.0
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/bazelbuild/buildtools v0.0.0-20251031164759-f48b23493530
-	github.com/bazelbuild/rules_go v0.58.3
+	github.com/bazelbuild/rules_go v0.59.0
 	// NOTE: keep <4.7.0 to test the 'replace'
 	github.com/bmatcuk/doublestar/v4 v4.6.0
-	github.com/cloudflare/circl v1.3.7
+	github.com/cloudflare/circl v1.3.8
 	github.com/envoyproxy/protoc-gen-validate v1.2.1
 	github.com/fmeum/dep_on_gazelle v1.0.0
 	github.com/google/go-jsonnet v0.20.0

--- a/tests/bcr/go_mod/go.sum
+++ b/tests/bcr/go_mod/go.sum
@@ -6,12 +6,12 @@ github.com/bazelbuild/bazel-gazelle v0.30.0 h1:q9XLWQSCA5NZPJ98WFqicHkq6fxrDPnfv
 github.com/bazelbuild/bazel-gazelle v0.30.0/go.mod h1:6RxhjM1v/lTpD3JlMpKUCcdus4tvdqsqdfbjYi+czYs=
 github.com/bazelbuild/buildtools v0.0.0-20251031164759-f48b23493530 h1:1eLp2tJnZQrdCh+aCS/ndQdJqX2N32QcMiEL1DzDGO8=
 github.com/bazelbuild/buildtools v0.0.0-20251031164759-f48b23493530/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
-github.com/bazelbuild/rules_go v0.58.3 h1:2Mdry2oCIzc+h9M2qRmK7S560vh8wOHh+al2MO+kbb8=
-github.com/bazelbuild/rules_go v0.58.3/go.mod h1:Pn30cb4M513fe2rQ6GiJ3q8QyrRsgC7zhuDvi50Lw4Y=
+github.com/bazelbuild/rules_go v0.59.0 h1:RLhOwYIqeMgBpKelHEWTfIPjA37so3oa/rX+/qqq/P4=
+github.com/bazelbuild/rules_go v0.59.0/go.mod h1:Pn30cb4M513fe2rQ6GiJ3q8QyrRsgC7zhuDvi50Lw4Y=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.3.8 h1:j+V8jJt09PoeMFIu2uh5JUyEaIHTXVOHslFoLNAKqwI=
+github.com/cloudflare/circl v1.3.8/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/bcr/go_work/MODULE.bazel
+++ b/tests/bcr/go_work/MODULE.bazel
@@ -23,7 +23,7 @@ go_sdk.download(version = "1.23.3")
 
 # This bazel_dep provides the Go dependency github.com/cloudflare/circl, which requires custom
 # patches beyond what Gazelle can generate.
-bazel_dep(name = "circl", version = "1.3.7")
+bazel_dep(name = "circl", version = "1.3.8")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.config(


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

tests/bcr

**What does this PR do? Why is it needed?**

Bazel 9.x requires the cc_common module to be loaded explicitly. bazel-contrib/rules_go#4508 added the required load statement, and this fix was released in rules_go 0.59.0.

This change upgrades the tests/bcr/go_mod and go_work test modules to require rules_go 0.59.0 so they can be tested with Bazel 9.x. Gazelle itself doesn't require the fix, so this change doesn't touch MODULE.bazel, avoiding a forced upgrade.

**Which issues(s) does this PR fix?**

Fixes #2234

**Other notes for review**
