### PR TITLE
Fix exports_files and package conflicts

### DIFF
--- a/merger/merger.go
+++ b/merger/merger.go
@@ -233,12 +233,14 @@ func match(rules []*rule.Rule, x *rule.Rule, info rule.KindInfo, wantError bool,
 		if xkind == y.Kind() || xkind == aliasedKinds[y.Kind()] {
 			return y, nil
 		}
-		if !wantError {
-			return nil, nil
+		if xname != "" {
+			if !wantError {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("could not merge %s(%s): a rule of the same name has kind %s", xkind, xname, y.Kind())
 		}
-		return nil, fmt.Errorf("could not merge %s(%s): a rule of the same name has kind %s", xkind, xname, y.Kind())
 	}
-	if len(nameMatches) > 1 {
+	if len(nameMatches) > 1 && xname != "" {
 		if !wantError {
 			return nil, nil
 		}

--- a/merger/merger_test.go
+++ b/merger/merger_test.go
@@ -973,6 +973,38 @@ go_library(
 			"my_go_library": "go_library",
 		},
 	},
+	{
+		desc: "empty name rules with different kinds should not conflict",
+		previous: `
+exports_files(["foo.txt"])
+`,
+		current: `
+package(default_visibility = ["//visibility:public"])
+`,
+		expected: `
+exports_files(["foo.txt"])
+
+package(default_visibility = ["//visibility:public"])
+`,
+	},
+	{
+		desc: "empty name rules with different kinds should not conflict",
+		previous: `
+exports_files(["foo.txt"])
+
+exports_files(["bar.txt"])
+`,
+		current: `
+package(default_visibility = ["//visibility:public"])
+`,
+		expected: `
+exports_files(["foo.txt"])
+
+exports_files(["bar.txt"])
+
+package(default_visibility = ["//visibility:public"])
+`,
+	},
 }
 
 func TestMergeFile(t *testing.T) {


### PR DESCRIPTION
This was caused because both rules have an empty name. Now the empty
name is ignored for deduping.

Fixes https://github.com/bazel-contrib/bazel-gazelle/issues/2246
