### PR TITLE
walk: assert that RelsToIndex strings are clean and relative

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -19,6 +19,7 @@ package walk
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"log"
 	"os"
@@ -229,6 +230,12 @@ func Walk2(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode
 
 		// Make sure to visit prefixes of relToVisit as well so we apply
 		// configuration directives.
+		if path.IsAbs(relToVisit) {
+			panic(fmt.Sprintf("relToVisit must not be absolute: %q", relToVisit))
+		}
+		if relToVisit != "" && relToVisit != path.Clean(relToVisit) {
+			panic(fmt.Sprintf("relToVisit is not clean: %q", relToVisit))
+		}
 		pathtools.Prefixes(relToVisit)(func(rel string) bool {
 			if _, ok := w.visits[rel]; !ok {
 				// Never visited this directory.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> walk

**What does this PR do? Why is it needed?**

Assertions make it a bit easier to track down bugs like EngFlow/gazelle_cc#165.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**
