### PR TITLE
Add remote-apis-sdks to DEFAULT_BUILD_FILE_GENERATION_BY_PATH

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -16,6 +16,7 @@ visibility("private")
 
 DEFAULT_BUILD_FILE_GENERATION_BY_PATH = {
     "cel.dev/expr": "on",
+    "github.com/bazelbuild/remote-apis-sdks": "on",
     "github.com/cncf/xds/go": "on",
     "github.com/envoyproxy/protoc-gen-validate": "on",
     "github.com/google/safetext": "on",


### PR DESCRIPTION
This repository contains references to @go_googleapis, which is no longer pulled in by rules_go as of v0.41.0. Other rules seem to be outdated as well, and I have been unable to fix this with a simple inject_repo.

A gazelle_override with `build_file_generation = "on"` fixes the problem for us by paving over the outdated BUILD.bazel files with new, functional ones.

We have other repos which need to depend on our module, so the local gazelle_override is not viable. We either need to fix the BUILD.bazel files upstream (it looks like this has been attempted at least a couple of times) or add this setting to the defaults.

**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
internal/bzlmod/default_gazelle_overrides.bzl

**What does this PR do? Why is it needed?**
Causes build_file_generation to be enabled for github.com/bazelbuild/remote-apis-sdks.  The repository already contains BUILD.bazel files, but they are outdated and broken with newer versions of rules_go.

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
