### PR TITLE
upgrade go to 1.25

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.23.3")
+go_register_toolchains(version = "1.24.3")
 
 go_register_nogo(
     excludes = [
@@ -51,7 +51,7 @@ go_register_nogo(
 # TODO: Fix rules_go and set this back to 1.19.
 go_download_sdk(
     name = "go_compat_sdk",
-    version = "1.22.9",
+    version = "1.24.3",
 )
 
 # Load recent versions of core rulesets for compatibility with Bazel 8.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

This fixes [an issue](https://github.com/bazel-contrib/bazel-gazelle/issues/2266)
where MacOS Tahoe on Apple Silicon/ARM fails with errors like:

```
INFO: Running command line: bazel-bin/gazelle
dyld[87388]: missing LC_UUID load command in /private/var/tmp/_bazel_ryanking/d8ac047f153e496614ffde78e4b36c1a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/external/gazelle+/cmd/gazelle/gazelle_/gazelle
dyld[87388]: missing LC_UUID load command
/private/var/tmp/_bazel_ryanking/d8ac047f153e496614ffde78e4b36c1a/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/gazelle: line 112: 87388 Abort trap: 6           "$gazelle_path" "${ARGS[@]}"
```

**Which issues(s) does this PR fix?**

<https://github.com/bazel-contrib/bazel-gazelle/issues/2266>

**Other notes for review**

Please let me know if there is a different / better way.
