### PR TITLE
Add proto compiler for grpc libraries

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -771,7 +771,10 @@ proto_library(
 
 go_proto_library(
     name = "repo_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "example.com/repo",
     proto = ":repo_proto",
     visibility = ["//visibility:public"],
@@ -2033,7 +2036,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_proto_library(
     name = "service_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+		"@io_bazel_rules_go//proto:go_proto",
+		"@io_bazel_rules_go//proto:go_grpc_v2",
+	],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -156,7 +156,7 @@ const (
 
 var (
 	defaultGoProtoCompilers = []string{"@io_bazel_rules_go//proto:go_proto"}
-	defaultGoGrpcCompilers  = []string{"@io_bazel_rules_go//proto:go_grpc_v2"}
+	defaultGoGrpcCompilers  = []string{"@io_bazel_rules_go//proto:go_proto", "@io_bazel_rules_go//proto:go_grpc_v2"}
 )
 
 func (m testMode) String() string {

--- a/language/go/constants.go
+++ b/language/go/constants.go
@@ -31,10 +31,6 @@ const (
 	// mode for libraries that contained .pb.go files and .proto files.
 	legacyProtoFilegroupName = "go_default_library_protos"
 
-	// grpcCompilerLabel is the label for the gRPC compiler plugin, used in the
-	// "compilers" attribute of go_proto_library rules.
-	grpcCompilerLabel = "@io_bazel_rules_go//proto:go_grpc_v2"
-
 	// goProtoSuffix is the suffix applied to the labels of all generated
 	// go_proto_library targets.
 	goProtoSuffix = "_go_proto"

--- a/language/go/fix.go
+++ b/language/go/fix.go
@@ -179,7 +179,7 @@ func migrateGrpcCompilers(c *config.Config, f *rule.File) {
 			continue
 		}
 		r.SetKind("go_proto_library")
-		r.SetAttr("compilers", []string{grpcCompilerLabel})
+		r.SetAttr("compilers", defaultGoGrpcCompilers)
 	}
 }
 

--- a/language/go/fix_test.go
+++ b/language/go/fix_test.go
@@ -581,7 +581,10 @@ proto_library(
 
 go_proto_library(
     name = "foo_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "example.com/repo",
     proto = ":foo_proto",
     visibility = ["//visibility:public"],

--- a/language/go/reference.md
+++ b/language/go/reference.md
@@ -33,7 +33,7 @@ Tells Gazelle how to generate rules for _test.go files. Valid values are:
 * `file`: A distinct `go_test` rule will be generated for each `_test.go` file in the package directory.
 
 **Directive:** `# gazelle:go_grpc_compilers compiler1,compiler2,...`<br>
-**Default:** `@io_bazel_rules_go//proto:go_grpc_v2`<br>
+**Default:** `@io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2`<br>
 The protocol buffers compiler(s) to use for building go bindings for gRPC. Multiple compilers, separated by commas, may be specified. Omit the directive value to reset `go_grpc_compilers` back to the default. See [Predefined plugins](https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#predefined-plugins) for available options; commonly used options include `@io_bazel_rules_go//proto:gofast_grpc` and `@io_bazel_rules_go//proto:gogofaster_grpc`.
 
 **Directive:** `# gazelle:go_naming_convention mode`<br>
@@ -79,7 +79,7 @@ By default, internal packages are only visible to its siblings. This directive a
 Determines how Gazelle resolves Go import paths that cannot be resolved in the current repository. May be :value:`external`, :value:`static` or :value:`vendored`. See [Dependency resolution](#dependency-resolution).
 
 **Flag:** `-go_grpc_compiler=label`<br>
-**Default:** `@io_bazel_rules_go//proto:go_grpc_v2`<br>
+**Default:** `@io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2`<br>
 The protocol buffers compiler to use for building go bindings for gRPC. May be repeated. See [Predefined plugins](https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#predefined-plugins) for available options; commonly used options include `@io_bazel_rules_go//proto:gofast_grpc` and `@io_bazel_rules_go//proto:gogofaster_grpc`.
 
 **Flag:** `-go_naming_convention`<br>
@@ -184,7 +184,7 @@ The following transformations are performed:
 
 **Migrate library to embed (fix and update):** Gazelle replaces `library` attributes with `embed` attributes.
 
-**Migrate gRPC compilers (fix and update):** Gazelle converts `go_grpc_library` rules to `go_proto_library` rules with `compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"]`.
+**Migrate gRPC compilers (fix and update):** Gazelle converts `go_grpc_library` rules to `go_proto_library` rules with `compilers = ["@io_bazel_rules_go//proto:go_proto", "@io_bazel_rules_go//proto:go_grpc_v2"]`.
 
 **Flatten srcs (fix and update):** Gazelle converts `srcs` attributes that use OS and architecture-specific `select` expressions to flat lists. rules_go filters these sources anyway.
 

--- a/language/go/testdata/proto_file_mode/abc/BUILD.want
+++ b/language/go/testdata/proto_file_mode/abc/BUILD.want
@@ -21,7 +21,10 @@ go_proto_library(
         "abc/a.proto",
         "xyz/x.proto",
     ],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "example.com/repo/proto_file_mode/abc",
     protos = [
         ":a_proto",

--- a/language/go/testdata/service/BUILD.want
+++ b/language/go/testdata/service/BUILD.want
@@ -18,7 +18,10 @@ go_proto_library(
         "google/protobuf/any.proto",
         "service/sub/sub.proto",
     ],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
@@ -12,7 +12,10 @@ proto_library(
 go_proto_library(
     name = "protos_gogo_go_proto",
     _gazelle_imports = [],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "example.com/repo/protos_gogo",
     proto = ":protos_gogo_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

The go_grpc compiler generated both proto and grpc bindings. The go_grpc_v2 compiler only generates the grpc bindings but requires explicit use of go_proto for the proto bindings.

This change in behavior was missed in #2071.

**Which issues(s) does this PR fix?**

**Other notes for review**
