### PR TITLE
Go: upgrade to 1.24.12

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,12 +37,6 @@ gazelle_binary(
     ],
 )
 
-go_cross_binary(
-    name = "gazelle_local_go1.22",
-    sdk_version = "1.22",
-    target = ":gazelle_local",
-)
-
 nogo(
     name = "nogo",
     vet = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,10 +54,7 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependenc
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 go_sdk_dev = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-go_sdk_dev.download(version = "1.23.3")
-
-# Used by compatibility tests, keep as low as possible.
-go_sdk_dev.download(version = "1.22.9")
+go_sdk_dev.download(version = "1.24.12")
 
 # Known to exist since it is instantiated by rules_go itself.
 use_repo(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,11 +27,11 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_nogo", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.23.3")
+go_register_toolchains(version = "1.24.12")
 
 go_register_nogo(
     excludes = [
@@ -40,18 +40,6 @@ go_register_nogo(
         "@//cmd/gazelle:__pkg__",
     ],
     nogo = "@bazel_gazelle//:nogo",
-)
-
-# Go 1.22 is needed since the non-hermeticity of GoToolchainBinaryBuild results in it downloading
-# Go 1.23 on Windows to build the builder, which then messes up Go version build tag filtering.
-# Go 1.21 is needed to support the toolchain directive in go.mod, which is non-hermetically read
-# by GoToolchainBinaryBuild on Windows.
-# Go 1.20 is needed so support nogo's use of token.File.FileStart.
-# Go 1.19 is needed for recent versions of golang.org/x/tools.
-# TODO: Fix rules_go and set this back to 1.19.
-go_download_sdk(
-    name = "go_compat_sdk",
-    version = "1.22.9",
 )
 
 # Load recent versions of core rulesets for compatibility with Bazel 8.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bazelbuild/bazel-gazelle
 
-go 1.22.9
+go 1.24.12
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Still a pretty old version, but a year newer than what we had before. This gives us fancy range loops.

Removed some apparently unused compatibility definitions referencing multiple versions of Go.

**Which issues(s) does this PR fix?**

For #2272

**Other notes for review**
