### PR TITLE
Disable proto library generation for protocompile

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -38,6 +38,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
     "github.com/authzed/spicedb": [
         "gazelle:proto disable",
     ],
+    "github.com/bufbuild/protocompile": [
+        "gazelle:proto disable",
+    ],
     "github.com/census-instrumentation/opencensus-proto": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

`github.com/bufbuild/protocompile` bundles well-known .proto files under `wellknownimports/google/`, which is conflicting with the `go_proto_library` targets that Gazelle wanted to generate.

**Which issues(s) does this PR fix?**

Addresses https://github.com/bazel-contrib/bazel-gazelle/issues/2029 although that issue technically was asking for something else.

**Other notes for review**
