### PR TITLE
Add sorting of load statements in BUILD files

### DIFF
--- a/merger/fix.go
+++ b/merger/fix.go
@@ -148,6 +148,8 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 			}
 		}
 	}
+
+	f.SortLoads()
 }
 
 // fixLoad updates a load statement with the given symbols. If load is nil,


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Previously, gazelle was emitting unsorted load statements which conflicts with buildifier's enforced sorted load order (the out-of-order-load rule), causing buildifier to fail if BUILD files were not explicitly formatted after running gazelle.  Add sort_loads.patch that introduces a SortLoads() method on rule.File and calls it at the end of merger.FixLoads() so gazelle produces loads in sorted order natively.  We match buildifier's definition of the sort order.

**Which issues(s) does this PR fix?**

This is part of
https://github.com/bazel-contrib/bazel-gazelle/issues/19, although it doesn't address all of the possible features mentioned there, just ordering within blocks of loads.

**Other notes for review**

Should this be gated behind some configuration?  I'm not sure if there's any reason you'd need to disable this