### PR TITLE
(docs) Note that an extension is required for default_visibility

### DIFF
--- a/gazelle-reference.md
+++ b/gazelle-reference.md
@@ -203,6 +203,8 @@ Comma-separated list of visibility specifications. This directive adds the visib
 # gazelle:default_visibility //foo:__subpackages__,//src:__subpackages__
 ```
 
+You must include the extension `@gazelle//language/bazel/visibility` to use this directive.
+
 ### `WORKSPACE` directives
 
 Gazelle also reads directives from the WORKSPACE file. They may be used to discover custom repository names and known prefixes. The `fix` and `update` commands use these directives for dependency resolution. `update-repos` uses them to learn about repository rules defined in alternate locations.


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
all

**What does this PR do? Why is it needed?**

Adds a note that an extension is required in order to use the default_visibility directive. I was unaware of this and that led to #2285. I do not see the extension referenced in any other documentation in the repo.

**Which issues(s) does this PR fix?**

Fixes #2285.

**Other notes for review**

This file only references language extensions, and from a user perspective my thinking was, "I have the Go extension installed, so what more do I need?"

If it would be better to add some kind of `**Required Extension:** to each directive, I can do that, especially with help to figure out which extension each one requires.