### PR TITLE
go_repository_tools: build v2/cmd/gazelle

### DIFF
--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -96,7 +96,7 @@ def _go_repository_tools_impl(ctx):
         "-w -s",
         "-gcflags",
         "-trimpath",
-        "github.com/bazelbuild/bazel-gazelle/cmd/gazelle",
+        "github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle",
         "github.com/bazelbuild/bazel-gazelle/cmd/fetch_repo",
         "github.com/bazelbuild/bazel-gazelle/cmd/generate_repo_config",
     ]


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What package or component does this PR mostly affect?**

> go_repository_tools

**What does this PR do? Why is it needed?**

`go_repository_tools` now builds `v2/cmd/gazelle` instead of `cmd/gazelle`. This should cause no observable difference in behavior, it's just the new entry point for the same code.

**Which issues(s) does this PR fix?**

For #2272

**Other notes for review**
