### PR TITLE
Add -version flag to print the current version

### DIFF
--- a/internal/bzlmod/non_module_deps.bzl
+++ b/internal/bzlmod/non_module_deps.bzl
@@ -40,6 +40,12 @@ load(
 visibility("//")
 
 def _non_module_deps_impl(module_ctx):
+    gazelle_version = ""
+    for module in module_ctx.modules:
+        if module.name == "gazelle":
+            gazelle_version = module.version
+            break
+
     go_repository_cache(
         name = "bazel_gazelle_go_repository_cache",
         # Label.repo_name is always a canonical name, so use a canonical label.
@@ -49,10 +55,13 @@ def _non_module_deps_impl(module_ctx):
     go_repository_tools(
         name = "bazel_gazelle_go_repository_tools",
         go_cache = Label("@bazel_gazelle_go_repository_cache//:go.env"),
+        is_bazel_module = True,
+        gazelle_version = gazelle_version,
     )
     is_bazel_module(
         name = "bazel_gazelle_is_bazel_module",
         is_bazel_module = True,
+        module_version = gazelle_version,
     )
     return extension_metadata(module_ctx, reproducible = True)
 

--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -87,14 +87,22 @@ def _go_repository_tools_impl(ctx):
 
     # Build the tools.
     ctx.file("bin/empty", "")  # HACK: we want mkdir, but repository_ctx doesn't have it
+    gazelle_version = ctx.attr.gazelle_version if ctx.attr.gazelle_version != None else ""
+    ldflags = [
+        "-w",
+        "-s",
+        "-X",
+        "github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle/update.BazelModuleVersion=" + gazelle_version,
+        "-X",
+        "github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle/update.IsBazelModule=" + str(ctx.attr.is_bazel_module),
+    ]
     args = [
         go_tool,
         "build",
         "-o",
         bin_dir,
         "-ldflags",
-        "-w -s",
-        "-gcflags",
+        " ".join(ldflags),
         "-trimpath",
         "github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle",
         "github.com/bazelbuild/bazel-gazelle/cmd/fetch_repo",
@@ -125,6 +133,16 @@ go_repository_tools = repository_rule(
         "go_cache": attr.label(
             mandatory = True,
             allow_single_file = True,
+            doc = """The go.env file within the bazel_gazelle_go_repository_cache repo.
+
+go_repository_tools builds gazelle and other binaries using the go tool. This file
+sets GOCACHE and other environment variables.""",
+        ),
+        "is_bazel_module": attr.bool(
+            doc = "whether Bazel is building in module mode (with Bzlmod)",
+        ),
+        "gazelle_version": attr.string(
+            doc = "The Gazelle module version according to Bzlmod, if known",
         ),
         "_go_repository_tools_srcs": attr.label_list(
             default = GO_REPOSITORY_TOOLS_SRCS,

--- a/v2/cmd/gazelle/update/BUILD.bazel
+++ b/v2/cmd/gazelle/update/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_gazelle_is_bazel_module//:defs.bzl", "GAZELLE_IS_BAZEL_MODULE", "GAZELLE_MODULE_VERSION")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
@@ -12,6 +13,10 @@ go_library(
     ],
     importpath = "github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle/update",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "BazelModuleVersion": GAZELLE_MODULE_VERSION,
+        "IsBazelModule": str(GAZELLE_IS_BAZEL_MODULE),
+    },
     deps = [
         "//config",
         "//flag",

--- a/v2/cmd/gazelle/update/update.go
+++ b/v2/cmd/gazelle/update/update.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -46,6 +47,19 @@ import (
 	"github.com/bazelbuild/buildtools/build"
 )
 
+// BazelModuleVersion is the version of the Gazelle Bazel module. It may be used
+// to change behavior across versions built from the same code.
+var BazelModuleVersion string
+
+// IsBazelModule is set to a value that parses to "true" if Gazelle was built by
+// Bazel in module mode.
+var IsBazelModule string
+
+// errVersion is a special value indicating the -version flag was set, and the
+// version was printed. Run recovers from this by doing nothing and
+// returning nil.
+var errVersion = errors.New("version printed")
+
 // updateConfig holds configuration information needed to run the fix and
 // update commands. This includes everything in config.Config, but it also
 // includes some additional fields that aren't relevant to other packages.
@@ -60,6 +74,7 @@ type updateConfig struct {
 	print0                 bool
 	profile                Profiler
 	removeNoopKeepComments bool
+	printVersion           bool
 }
 
 type emitFunc func(c *config.Config, f *rule.File) error
@@ -102,10 +117,25 @@ func (ucr *updateConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *conf
 	fs.Var(&gzflag.MultiFlag{Values: &ucr.knownImports}, "known_import", "import path for which external resolution is skipped (can specify multiple times)")
 	fs.StringVar(&ucr.repoConfigPath, "repo_config", "", "file where Gazelle should load repository configuration. Defaults to WORKSPACE.")
 	fs.BoolVar(&uc.removeNoopKeepComments, "remove_noop_keep_comments", false, "when set, gazelle will remove noop keep comments from BUILD files")
+	fs.BoolVar(&uc.printVersion, "version", false, "print gazelle's version and exit")
 }
 
 func (ucr *updateConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 	uc := getUpdateConfig(c)
+
+	if uc.printVersion {
+		if BazelModuleVersion == "" {
+			fmt.Printf("gazelle version unknown\n")
+		} else {
+			fmt.Printf("gazelle %s\n", BazelModuleVersion)
+		}
+		if moduleMode, _ := strconv.ParseBool(IsBazelModule); moduleMode {
+			fmt.Printf("built in module mode\n")
+		} else {
+			fmt.Printf("built in workspace mode\n")
+		}
+		return errVersion
+	}
 
 	var ok bool
 	uc.emit, ok = modeFromName[ucr.mode]
@@ -281,7 +311,10 @@ func Run(
 	}
 
 	c, err := newFixUpdateConfiguration(wd, args, cexts)
-	if err != nil {
+	if errors.Is(err, errVersion) {
+		// sentinel error; we already printed the version so just exit
+		return nil
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> v2/cmd/gazelle/update

**What does this PR do? Why is it needed?**

When set, Gazelle prints its version to stdout, then exits without doing anything else.

This flag is recognized by the fix/update commands, so usage can be 'gazelle -version' or 'gazelle update -version' but not 'gazelle update-repos -version'. It feels awkward for v1, but I didn't want to add a new 'version' subcommand because v2 doesn't have subcommands.

**Which issues(s) does this PR fix?**

For #2272
Fixes #2288

**Other notes for review**
