### PR TITLE
Add gazelle:include to counter exclude as an option for sub-inclusion

### DIFF
--- a/gazelle-reference.md
+++ b/gazelle-reference.md
@@ -136,6 +136,10 @@ List of Go build tags Gazelle will defer to Bazel for evaluation. Gazelle applie
 **Default:** n/a<br>
 Prevents Gazelle from processing a file or directory if the given [`doublestar.Match`](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4#Match) pattern matches. If the pattern refers to a source file, Gazelle won't include it in any rules. If the pattern refers to a directory, Gazelle won't recurse into it. This directive may be repeated to exclude multiple patterns, one per line.
 
+**Directive:** `# gazelle:include pattern`<br>
+**Default:** n/a<br>
+Re-includes a file or directory path prefix previously excluded by an earlier `# gazelle:exclude` directive. The given [`doublestar.Match`](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4#Match) pattern uses the same path matching semantics as `# gazelle:exclude`, so a directory pattern may re-open traversal into that subtree. When multiple `# gazelle:exclude` and `# gazelle:include` directives match the same path, later directives win.
+
 **Directive:** `# gazelle:follow pattern`<br>
 **Default:** n/a<br>
 Instructs Gazelle to follow a symbolic link to a directory within the repository if the given [`doublestar.Match`](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4#Match) pattern matches. Normally, Gazelle does not follow symbolic links unless they point outside of the repository root. Care must be taken to avoid visiting a directory more than once. The `# gazelle:exclude` directive may be used to prevent Gazelle from recursing into a directory.

--- a/how-gazelle-works.md
+++ b/how-gazelle-works.md
@@ -34,7 +34,7 @@ All of Gazelle's language-specific functionality is implemented in plugins calle
 
 When Gazelle starts, it begins traversing the directory tree. This process runs in parallel with later stages as an optimization.
 
-In each directory it visits, Gazelle parses the `BUILD` or `BUILD.bazel` file if present and makes a list of files and subdirectories, excluding those matched by `# gazelle:exclude` directives or `.bazelignore` files. This metadata is cached in memory so that later stages may access it quickly without requiring additional I/O.
+In each directory it visits, Gazelle parses the `BUILD` or `BUILD.bazel` file if present and makes a list of files and subdirectories, excluding those matched by `# gazelle:exclude` directives or `.bazelignore` files, except for paths later re-added by `# gazelle:include`. This metadata is cached in memory so that later stages may access it quickly without requiring additional I/O.
 
 Gazelle may or may not visit a directory based on directives and command line flags.
 
@@ -43,7 +43,7 @@ Gazelle may or may not visit a directory based on directives and command line fl
 - If eager indexing is enabled (with `-index=all`, enabled by default), Gazelle visits *all* directories.
 - If lazy indexing is enabled (with `-index=lazy`), Gazelle visits directories requested by language extensions in [`GenerateResult.RelsToIndex`](https://pkg.go.dev/github.com/bazelbuild/bazel-gazelle/language#GenerateResult.RelsToIndex). These directories are loaded lazily during the *Generate* stage.
 - If indexing is disabled (with `-index=none`), Gazelle does not visit additional directories.
-- Gazelle visits parent directories within the repository in addition to other directories it visits. This is necessary to apply `# gazelle:exclude` directives, which may tell Gazelle to act as if a subdirectory does not exist.
+- Gazelle visits parent directories within the repository in addition to other directories it visits. This is necessary to apply `# gazelle:exclude` and `# gazelle:include` directives, which may tell Gazelle to act as if a subdirectory does not exist or to re-add a path beneath one.
 
 The Load stage is implemented in [`walk.walker.populateCache`](https://github.com/bazel-contrib/bazel-gazelle/blob/028c500e9f911a73683b6ec390f3e59e8f31fccc/walk/dirinfo.go#L104), which is called from [`walk.Walk2`](https://pkg.go.dev/github.com/bazelbuild/bazel-gazelle/walk#Walk2). No extension methods are called during this stage.
 

--- a/walk/cache.go
+++ b/walk/cache.go
@@ -106,21 +106,18 @@ func GetDirInfo(rel string) (DirInfo, error) {
 	}
 	rel = path.Clean(rel)
 
-	// Ensure all ancestors are loaded before loading rel itself, since their
-	// configuration may exclude rel.
-	var prevCfg *walkConfig = nil
+	// Ensure all ancestors are loaded before loading rel itself, since any of
+	// them may stop traversal to rel.
 	var di DirInfo
 	var d string
 	var err error
 	pathtools.Prefixes(rel)(func(prefix string) bool {
 		d = prefix
-		if prevCfg != nil && prevCfg.isExcludedDir(prefix) {
+		di, err = globalWalker.cache.get(prefix, globalWalker.loadDirInfo)
+		if err == nil && !di.traversable {
 			di = DirInfo{}
 			err = fmt.Errorf("directory %q is excluded", prefix)
-			return false
 		}
-		di, err = globalWalker.cache.get(prefix, globalWalker.loadDirInfo)
-		prevCfg = di.config
 		return err == nil
 	})
 
@@ -128,6 +125,10 @@ func GetDirInfo(rel string) (DirInfo, error) {
 		if d != rel {
 			di = DirInfo{}
 		}
+	}
+	if vi, ok := globalWalker.visits[rel]; ok && vi.finalized {
+		di.RegularFiles = vi.regularFiles
+		di.Subdirs = vi.subdirs
 	}
 
 	return di, err

--- a/walk/config.go
+++ b/walk/config.go
@@ -54,10 +54,22 @@ const (
 type walkConfig struct {
 	updateOnly          bool
 	ignoreFilter        *ignoreFilter
-	excludes            []string
+	pathDirectives      []pathDirective
 	ignore              bool
 	follow              []string
 	validBuildFileNames []string // to be copied to config.Config
+}
+
+type pathDirectiveKind int
+
+const (
+	pathDirectiveExclude pathDirectiveKind = iota
+	pathDirectiveInclude
+)
+
+type pathDirective struct {
+	kind    pathDirectiveKind
+	pattern string
 }
 
 const (
@@ -71,20 +83,46 @@ func getWalkConfig(c *config.Config) *walkConfig {
 
 func (wc *walkConfig) clone() *walkConfig {
 	wcCopy := *wc
-	// Trim cap of exclude and follow. We may append to these slices in multiple
-	// goroutines. Doing so should allocate a copy of the backing array.
+	// Trim cap of path directives and follow. We may append to these slices in
+	// multiple goroutines. Doing so should allocate a copy of the backing array.
 	// Other slices are either immutable or replaced when written.
-	wcCopy.excludes = wcCopy.excludes[:len(wcCopy.excludes):len(wcCopy.excludes)]
+	wcCopy.pathDirectives = wcCopy.pathDirectives[:len(wcCopy.pathDirectives):len(wcCopy.pathDirectives)]
 	wcCopy.follow = wcCopy.follow[:len(wcCopy.follow):len(wcCopy.follow)]
 	return &wcCopy
 }
 
 func (wc *walkConfig) isExcludedDir(p string) bool {
-	return path.Base(p) == ".git" || wc.ignoreFilter.isDirectoryIgnored(p) || matchAnyGlob(wc.excludes, p)
+	return path.Base(p) == ".git" || wc.ignoreFilter.isDirectoryIgnored(p) || wc.isExcludedByPathDirectives(p)
 }
 
 func (wc *walkConfig) isExcludedFile(p string) bool {
-	return wc.ignoreFilter.isFileIgnored(p) || matchAnyGlob(wc.excludes, p)
+	return wc.ignoreFilter.isFileIgnored(p) || wc.isExcludedByPathDirectives(p)
+}
+
+func (wc *walkConfig) isExcludedByPathDirectives(p string) bool {
+	excluded := false
+	for _, d := range wc.pathDirectives {
+		if !d.matchesPath(p) {
+			continue
+		}
+		excluded = d.kind == pathDirectiveExclude
+	}
+	return excluded
+}
+
+func (d pathDirective) matchesPath(p string) bool {
+	for prefix := p; ; {
+		if doublestar.MatchUnvalidated(d.pattern, prefix) {
+			return true
+		}
+		if prefix == "" {
+			return false
+		}
+		prefix = path.Dir(prefix)
+		if prefix == "." {
+			prefix = ""
+		}
+	}
 }
 
 func (wc *walkConfig) shouldFollow(p string) bool {
@@ -128,10 +166,17 @@ func (cr *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {
 	}
 
 	ignoreFilter := newIgnoreFilter(c.RepoRoot)
+	pathDirectives := make([]pathDirective, 0, len(cr.cliExcludes))
+	for _, pattern := range cr.cliExcludes {
+		pathDirectives = append(pathDirectives, pathDirective{
+			kind:    pathDirectiveExclude,
+			pattern: pattern,
+		})
+	}
 
 	wc := &walkConfig{
 		ignoreFilter:        ignoreFilter,
-		excludes:            cr.cliExcludes,
+		pathDirectives:      pathDirectives,
 		validBuildFileNames: c.ValidBuildFileNames,
 	}
 	c.Exts[walkName] = wc
@@ -139,7 +184,7 @@ func (cr *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {
 }
 
 func (*Configurer) KnownDirectives() []string {
-	return []string{"build_file_name", "generation_mode", "exclude", "follow", "ignore"}
+	return []string{"build_file_name", "generation_mode", "exclude", "include", "follow", "ignore"}
 }
 
 func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
@@ -179,12 +224,24 @@ func configureForWalk(parent *walkConfig, rel string, f *rule.File) *walkConfig 
 					log.Fatalf("unknown generation_mode %q in //%s", d.Value, f.Pkg)
 					continue
 				}
-			case "exclude":
-				if err := checkPathMatchPattern(path.Join(rel, d.Value)); err != nil {
-					log.Printf("the exclusion pattern is not valid %q: %s", path.Join(rel, d.Value), err)
+			case "exclude", "include":
+				pattern := path.Join(rel, d.Value)
+				if err := checkPathMatchPattern(pattern); err != nil {
+					kind := "exclusion"
+					if d.Key == "include" {
+						kind = "inclusion"
+					}
+					log.Printf("the %s pattern is not valid %q: %s", kind, pattern, err)
 					continue
 				}
-				wc.excludes = append(wc.excludes, path.Join(rel, d.Value))
+				kind := pathDirectiveExclude
+				if d.Key == "include" {
+					kind = pathDirectiveInclude
+				}
+				wc.pathDirectives = append(wc.pathDirectives, pathDirective{
+					kind:    kind,
+					pattern: pattern,
+				})
 			case "follow":
 				if err := checkPathMatchPattern(path.Join(rel, d.Value)); err != nil {
 					log.Printf("the follow pattern is not valid %q: %s", path.Join(rel, d.Value), err)

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -2,6 +2,7 @@ package walk
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,6 +19,13 @@ type DirInfo struct {
 	// of targets in the directory's build file.
 	// The content of these slices must not be modified.
 	Subdirs, RegularFiles, GenFiles []string
+
+	// traversalSubdirs holds subdirectories that should be traversed, including
+	// excluded directories that may contain explicitly included files.
+	traversalSubdirs []string
+
+	// traversable reports whether this directory should be visited at all.
+	traversable bool
 
 	// File is the directory's build File. May be nil if the build File doesn't
 	// exist or contains errors.
@@ -69,7 +77,10 @@ func (w *walker) loadDirInfo(rel string) (DirInfo, error) {
 	}
 
 	info.config = configureForWalk(parentConfig, rel, info.File)
-	if info.config.isExcludedDir(rel) {
+	// A directory may be excluded from its parent's visible Subdirs but still
+	// need traversal if a later include re-adds something below it.
+	info.traversable = w.shouldTraverseDir(info.config, dir, rel, entries, info.File, make(map[string]struct{}))
+	if !info.traversable {
 		// Build file excludes the current directory. Ignore contents.
 		entries = nil
 	}
@@ -77,8 +88,11 @@ func (w *walker) loadDirInfo(rel string) (DirInfo, error) {
 	for _, e := range entries {
 		entryRel := path.Join(rel, e.Name())
 		e = maybeResolveSymlink(info.config, dir, entryRel, e)
-		if e.IsDir() && !info.config.isExcludedDir(entryRel) {
-			info.Subdirs = append(info.Subdirs, e.Name())
+		if e.IsDir() && w.shouldTraverseDir(info.config, filepath.Join(dir, e.Name()), entryRel, nil, nil, make(map[string]struct{})) {
+			info.traversalSubdirs = append(info.traversalSubdirs, e.Name())
+			if !info.config.isExcludedDir(entryRel) {
+				info.Subdirs = append(info.Subdirs, e.Name())
+			}
 		} else if !e.IsDir() && !info.config.isExcludedFile(entryRel) {
 			info.RegularFiles = append(info.RegularFiles, e.Name())
 		}
@@ -92,8 +106,64 @@ func (w *walker) loadDirInfo(rel string) (DirInfo, error) {
 	info.RegularFiles = info.RegularFiles[:len(info.RegularFiles):len(info.RegularFiles)]
 	info.Subdirs = info.Subdirs[:len(info.Subdirs):len(info.Subdirs)]
 	info.GenFiles = info.GenFiles[:len(info.GenFiles):len(info.GenFiles)]
+	info.traversalSubdirs = info.traversalSubdirs[:len(info.traversalSubdirs):len(info.traversalSubdirs)]
 
 	return info, errors.Join(errs...)
+}
+
+// shouldTraverseDir reports whether rel must be visited at all.
+//
+// This is intentionally different from "is rel itself visible?".
+// An excluded directory still needs traversal when ordered path directives
+// re-include a descendant beneath it. In that case, rel stays out of the
+// public Subdirs list, but it remains in traversalSubdirs so the walker can
+// reach the included descendant.
+func (w *walker) shouldTraverseDir(wc *walkConfig, dir, rel string, entries []fs.DirEntry, file *rule.File, seen map[string]struct{}) bool {
+	if path.Base(rel) == ".git" || wc.ignoreFilter.isDirectoryIgnored(rel) {
+		return false
+	}
+	// Visible directories are always traversed.
+	if !wc.isExcludedByPathDirectives(rel) {
+		return true
+	}
+	if _, ok := seen[rel]; ok {
+		return false
+	}
+	seen[rel] = struct{}{}
+	defer delete(seen, rel)
+
+	if entries == nil {
+		var err error
+		entries, err = os.ReadDir(dir)
+		if err != nil {
+			return false
+		}
+	}
+	if file == nil {
+		file, _ = loadBuildFile(wc, w.rootConfig.ReadBuildFilesDir, rel, dir, entries)
+	}
+	// Generated outputs make the directory observable even when the directory
+	// path itself is excluded.
+	if len(findGenFiles(wc, file)) > 0 {
+		return true
+	}
+
+	// Search excluded subtrees for any descendant that survives the ordered
+	// include/exclude directives.
+	for _, e := range entries {
+		entryRel := path.Join(rel, e.Name())
+		e = maybeResolveSymlink(wc, dir, entryRel, e)
+		if e.IsDir() {
+			if w.shouldTraverseDir(wc, filepath.Join(dir, e.Name()), entryRel, nil, nil, seen) {
+				return true
+			}
+			continue
+		}
+		if !wc.isExcludedFile(entryRel) {
+			return true
+		}
+	}
+	return false
 }
 
 // populateCache loads directory information in a parallel tree traversal.
@@ -121,7 +191,7 @@ func (w *walker) populateCache(mode Mode) {
 			return
 		}
 
-		for _, subdir := range info.Subdirs {
+		for _, subdir := range info.traversalSubdirs {
 			subdirRel := path.Join(rel, subdir)
 
 			// Navigate to the subdirectory if it should be visited.

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -320,6 +320,8 @@ type visitInfo struct {
 	// contain a build file. The parent directory may use regularFiles
 	// and subdirs.
 	containedByParent bool
+	visibleToParent   bool
+	finalized         bool
 
 	c                     *config.Config
 	regularFiles, subdirs []string
@@ -426,9 +428,10 @@ func (w *walker) visit(mode Mode, c *config.Config, rel string, updateParent boo
 	hasBuildFileError := err != nil
 	wc := info.config
 
-	if wc.isExcludedDir(rel) {
+	if !info.traversable {
 		return
 	}
+	selfExcluded := wc.isExcludedDir(rel)
 
 	containedByParent := info.File == nil && wc.updateOnly
 
@@ -438,24 +441,33 @@ func (w *walker) visit(mode Mode, c *config.Config, rel string, updateParent boo
 		configure(w.cexts, w.knownDirectives, c, rel, info.File, info.config)
 	}
 
-	regularFiles := info.RegularFiles
-	subdirs := info.Subdirs
+	regularFiles := append([]string(nil), info.RegularFiles...)
 	shouldUpdate := w.shouldUpdate(mode, rel, updateParent)
 	w.visits[rel] = visitInfo{
 		c:                 c,
 		containedByParent: containedByParent,
-		regularFiles:      regularFiles,
-		subdirs:           subdirs,
 	}
 
 	// Visit subdirectories, as needed.
-	for _, subdir := range subdirs {
+	for _, subdir := range info.traversalSubdirs {
 		subdirRel := path.Join(rel, subdir)
 		if w.shouldVisit(mode, subdirRel, shouldUpdate) {
 			w.visit(mode, c.Clone(), subdirRel, shouldUpdate)
 			if c.Strict && len(w.errs) > 0 {
 				return
 			}
+		}
+	}
+
+	subdirs := make([]string, 0, len(info.traversalSubdirs))
+	for _, subdir := range info.traversalSubdirs {
+		subdirRel := path.Join(rel, subdir)
+		if !wc.isExcludedDir(subdirRel) {
+			subdirs = append(subdirs, subdir)
+			continue
+		}
+		if vi, ok := w.visits[subdirRel]; ok && vi.visibleToParent {
+			subdirs = append(subdirs, subdir)
 		}
 	}
 
@@ -482,33 +494,54 @@ func (w *walker) visit(mode Mode, c *config.Config, rel string, updateParent boo
 			collect(path.Join(rel, subdir), subdir)
 		}
 
-		// Call the callback to update this directory.
-		update := !wc.ignore && shouldUpdate && !hasBuildFileError
-		result := w.wf(Walk2FuncArgs{
-			Dir:          dir,
-			Rel:          rel,
-			Config:       c,
-			Update:       update,
-			File:         info.File,
-			Subdirs:      subdirs,
-			RegularFiles: regularFiles,
-			GenFiles:     info.GenFiles,
-		})
-		if result.Err != nil {
-			w.errs = append(w.errs, result.Err)
+		shouldProcessSelf := !selfExcluded || len(regularFiles) > 0 || len(info.GenFiles) > 0
+		w.visits[rel] = visitInfo{
+			c:                 c,
+			containedByParent: containedByParent,
+			visibleToParent:   shouldProcessSelf,
+			finalized:         true,
+			regularFiles:      regularFiles,
+			subdirs:           subdirs,
 		}
-		for _, relToVisit := range result.RelsToVisit {
-			// Normalize RelsToVisit to clean relative paths and convert root "."
-			// to an empty string.
-			relToVisit = path.Clean(relToVisit)
-			if relToVisit == "." {
-				relToVisit = ""
-			}
 
-			if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
-				w.relsToVisit = append(w.relsToVisit, relToVisit)
-				w.relsToVisitSeen[relToVisit] = struct{}{}
+		// Call the callback to update this directory.
+		if shouldProcessSelf {
+			update := !wc.ignore && shouldUpdate && !hasBuildFileError
+			result := w.wf(Walk2FuncArgs{
+				Dir:          dir,
+				Rel:          rel,
+				Config:       c,
+				Update:       update,
+				File:         info.File,
+				Subdirs:      subdirs,
+				RegularFiles: regularFiles,
+				GenFiles:     info.GenFiles,
+			})
+			if result.Err != nil {
+				w.errs = append(w.errs, result.Err)
 			}
+			for _, relToVisit := range result.RelsToVisit {
+				// Normalize RelsToVisit to clean relative paths and convert root "."
+				// to an empty string.
+				relToVisit = path.Clean(relToVisit)
+				if relToVisit == "." {
+					relToVisit = ""
+				}
+
+				if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
+					w.relsToVisit = append(w.relsToVisit, relToVisit)
+					w.relsToVisitSeen[relToVisit] = struct{}{}
+				}
+			}
+		}
+	} else {
+		w.visits[rel] = visitInfo{
+			c:                 c,
+			containedByParent: containedByParent,
+			visibleToParent:   len(regularFiles) > 0 || len(subdirs) > 0,
+			finalized:         true,
+			regularFiles:      regularFiles,
+			subdirs:           subdirs,
 		}
 	}
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -463,6 +463,124 @@ a.file
 	})
 }
 
+func TestIncludeFiles(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:exclude blocked
+# gazelle:include blocked/sub/keep.go
+# gazelle:exclude readded.go
+# gazelle:include readded.go
+# gazelle:include ordered.go
+# gazelle:exclude ordered.go
+`,
+		},
+		{Path: "blocked/sub/keep.go"},
+		{Path: "blocked/sub/drop.go"},
+		{Path: "blocked/peer.go"},
+		{Path: "readded.go"},
+		{Path: "ordered.go"},
+	})
+	defer cleanup()
+
+	check := func(t *testing.T, rels, files []string) {
+		t.Helper()
+		wantRels := []string{"blocked/sub", ""}
+		if diff := cmp.Diff(wantRels, rels); diff != "" {
+			t.Errorf("Walk relative paths (-want +got):\n%s", diff)
+		}
+		wantFiles := []string{"blocked/sub/keep.go", "BUILD.bazel", "readded.go"}
+		if diff := cmp.Diff(wantFiles, files); diff != "" {
+			t.Errorf("Walk files (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels, files []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, regularFiles, _ []string) {
+			rels = append(rels, rel)
+			for _, f := range regularFiles {
+				files = append(files, path.Join(rel, f))
+			}
+		})
+		check(t, rels, files)
+	})
+
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels, files []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			rels = append(rels, args.Rel)
+			for _, f := range args.RegularFiles {
+				files = append(files, path.Join(args.Rel, f))
+			}
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, rels, files)
+	})
+}
+
+func TestIncludeFilesUpdateOnly(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:generation_mode update_only
+# gazelle:exclude blocked
+# gazelle:include blocked/keep.go
+`,
+		},
+		{Path: "blocked/keep.go"},
+		{Path: "blocked/drop.go"},
+	})
+	defer cleanup()
+
+	check := func(t *testing.T, rels, files []string) {
+		t.Helper()
+		wantRels := []string{""}
+		if diff := cmp.Diff(wantRels, rels); diff != "" {
+			t.Errorf("Walk relative paths (-want +got):\n%s", diff)
+		}
+		wantFiles := []string{"BUILD.bazel", "blocked/keep.go"}
+		if diff := cmp.Diff(wantFiles, files); diff != "" {
+			t.Errorf("Walk files (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels, files []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, regularFiles, _ []string) {
+			rels = append(rels, rel)
+			for _, f := range regularFiles {
+				files = append(files, path.Join(rel, f))
+			}
+		})
+		check(t, rels, files)
+	})
+
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels, files []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			rels = append(rels, args.Rel)
+			for _, f := range args.RegularFiles {
+				files = append(files, path.Join(args.Rel, f))
+			}
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, rels, files)
+	})
+}
+
 func TestExcludeSelf(t *testing.T) {
 	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
 		{
@@ -847,6 +965,76 @@ func TestGetDirInfoSubdir(t *testing.T) {
 
 		if _, err := GetDirInfo("x/y"); err == nil {
 			t.Errorf("x/y: unexpected success")
+		}
+		return Walk2FuncResult{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetDirInfoIncludedSubdir(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:exclude blocked
+# gazelle:include blocked/sub
+`,
+		},
+		{
+			Path: "blocked/sub/keep.go",
+		},
+		{
+			Path: "blocked/sub/drop.go",
+		},
+		{
+			Path: "blocked/peer.go",
+		},
+	})
+	defer cleanup()
+
+	c, cexts := testConfig(t, dir)
+	err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+		if args.Rel != "blocked/sub" {
+			return Walk2FuncResult{}
+		}
+		info, err := GetDirInfo("blocked/sub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff([]string{"drop.go", "keep.go"}, info.RegularFiles); diff != "" {
+			t.Errorf("blocked/sub: regular files (-want, +got):\n%s", diff)
+		}
+		return Walk2FuncResult{}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetDirInfoIncludeBeforeExcludeDoesNotTraverse(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+# gazelle:include blocked/sub
+# gazelle:exclude blocked
+`,
+		},
+		{
+			Path: "blocked/sub/keep.go",
+		},
+	})
+	defer cleanup()
+
+	c, cexts := testConfig(t, dir)
+	err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+		if args.Rel != "" {
+			return Walk2FuncResult{}
+		}
+		if _, err := GetDirInfo("blocked/sub"); err == nil {
+			t.Errorf("blocked/sub: unexpected success")
 		}
 		return Walk2FuncResult{}
 	})


### PR DESCRIPTION
Feature implementation of https://github.com/bazel-contrib/bazel-gazelle/issues/2308 

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

gazelle:exclude is currently one-way: once a path or subtree is excluded, there is no directive to selectively add part of it back.

**Which issues(s) does this PR fix?**

https://github.com/bazel-contrib/bazel-gazelle/issues/2308