### PR TITLE
fix(language/go): use rules_go apparent name in proto compilers

### DIFF
--- a/language/go/config.go
+++ b/language/go/config.go
@@ -523,6 +523,25 @@ func (*goLang) Configure(c *config.Config, rel string, f *rule.File) {
 			// The legacy name used in WORKSPACE.
 			gc.rulesGoRepoName = "io_bazel_rules_go"
 		}
+		if gc.rulesGoRepoName != "io_bazel_rules_go" {
+			reparent := func(compilers []string) []string {
+				out := make([]string, len(compilers))
+				for i, c := range compilers {
+					if after, ok := strings.CutPrefix(c, "@io_bazel_rules_go"); ok {
+						out[i] = fmt.Sprintf("@%s%s", gc.rulesGoRepoName, after)
+					} else {
+						out[i] = c
+					}
+				}
+				return out
+			}
+			if !gc.goProtoCompilersSet {
+				gc.goProtoCompilers = reparent(gc.goProtoCompilers)
+			}
+			if !gc.goGrpcCompilersSet {
+				gc.goGrpcCompilers = reparent(gc.goGrpcCompilers)
+			}
+		}
 
 		const message = `Gazelle may not be compatible with this version of rules_go.
 Update io_bazel_rules_go to a newer version in your WORKSPACE file.`

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -89,17 +89,13 @@ type goConfig struct {
 	// imports in external repositories with unknown naming conventions.
 	goNamingConventionExternal namingConvention
 
-	// goProtoCompilers is the protocol buffers compiler(s) to use for go code.
+	// goProtoCompilers is the protocol buffers compiler(s) to use for go code,
+	// or nil if not explicitly set.
 	goProtoCompilers []string
 
-	// goProtoCompilersSet indicates whether goProtoCompiler was set explicitly.
-	goProtoCompilersSet bool
-
-	// goGrpcCompilers is the gRPC compiler(s) to use for go code.
+	// goGrpcCompilers is the gRPC compiler(s) to use for go code,
+	// or nil if not explicitly set.
 	goGrpcCompilers []string
-
-	// goGrpcCompilersSet indicates whether goGrpcCompiler was set explicitly.
-	goGrpcCompilersSet bool
 
 	// goRepositoryMode is true if Gazelle was invoked by a go_repository rule.
 	// In this mode, we won't go out to the network to resolve external deps.
@@ -154,11 +150,6 @@ const (
 	fileTestMode
 )
 
-var (
-	defaultGoProtoCompilers = []string{"@io_bazel_rules_go//proto:go_proto"}
-	defaultGoGrpcCompilers  = []string{"@io_bazel_rules_go//proto:go_proto", "@io_bazel_rules_go//proto:go_grpc_v2"}
-)
-
 func (m testMode) String() string {
 	switch m {
 	case defaultTestMode:
@@ -183,9 +174,8 @@ func testModeFromString(s string) (testMode, error) {
 
 func newGoConfig() *goConfig {
 	gc := &goConfig{
-		goProtoCompilers: defaultGoProtoCompilers,
-		goGrpcCompilers:  defaultGoGrpcCompilers,
-		goGenerateProto:  true,
+		rulesGoRepoName: "io_bazel_rules_go", // the legacy name used in WORKSPACE
+		goGenerateProto: true,
 	}
 	if gc.genericTags == nil {
 		gc.genericTags = make(map[string]bool)
@@ -197,6 +187,13 @@ func newGoConfig() *goConfig {
 
 func getGoConfig(c *config.Config) *goConfig {
 	return c.Exts[goName].(*goConfig)
+}
+
+func (gc *goConfig) defaultGoGrpcCompilers() []string {
+	return []string{
+		fmt.Sprintf("@%s//proto:go_proto", gc.rulesGoRepoName),
+		fmt.Sprintf("@%s//proto:go_grpc_v2", gc.rulesGoRepoName),
+	}
 }
 
 func (gc *goConfig) clone() *goConfig {
@@ -418,11 +415,11 @@ func (*goLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 			"external",
 			"external: resolve external packages with go_repository\n\tvendored: resolve external packages as packages in vendor/")
 		fs.Var(
-			&gzflag.MultiFlag{Values: &gc.goProtoCompilers, IsSet: &gc.goProtoCompilersSet},
+			&gzflag.MultiFlag{Values: &gc.goProtoCompilers},
 			"go_proto_compiler",
 			"go_proto_library compiler to use (may be repeated)")
 		fs.Var(
-			&gzflag.MultiFlag{Values: &gc.goGrpcCompilers, IsSet: &gc.goGrpcCompilersSet},
+			&gzflag.MultiFlag{Values: &gc.goGrpcCompilers},
 			"go_grpc_compiler",
 			"go_proto_library compiler to use for gRPC (may be repeated)")
 		fs.BoolVar(
@@ -516,31 +513,8 @@ func (*goLang) Configure(c *config.Config, rel string, f *rule.File) {
 		moduleToApparentName, err := module.ExtractModuleToApparentNameMapping(c.RepoRoot)
 		if err != nil {
 			log.Print(err)
-		} else {
-			gc.rulesGoRepoName = moduleToApparentName("rules_go")
-		}
-		if gc.rulesGoRepoName == "" {
-			// The legacy name used in WORKSPACE.
-			gc.rulesGoRepoName = "io_bazel_rules_go"
-		}
-		if gc.rulesGoRepoName != "io_bazel_rules_go" {
-			reparent := func(compilers []string) []string {
-				out := make([]string, len(compilers))
-				for i, c := range compilers {
-					if after, ok := strings.CutPrefix(c, "@io_bazel_rules_go"); ok {
-						out[i] = fmt.Sprintf("@%s%s", gc.rulesGoRepoName, after)
-					} else {
-						out[i] = c
-					}
-				}
-				return out
-			}
-			if !gc.goProtoCompilersSet {
-				gc.goProtoCompilers = reparent(gc.goProtoCompilers)
-			}
-			if !gc.goGrpcCompilersSet {
-				gc.goGrpcCompilers = reparent(gc.goGrpcCompilers)
-			}
+		} else if name := moduleToApparentName("rules_go"); name != "" {
+			gc.rulesGoRepoName = name
 		}
 
 		const message = `Gazelle may not be compatible with this version of rules_go.
@@ -641,20 +615,16 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 			case "go_grpc_compilers":
 				// Special syntax (empty value) to reset directive.
 				if d.Value == "" {
-					gc.goGrpcCompilersSet = false
-					gc.goGrpcCompilers = defaultGoGrpcCompilers
+					gc.goGrpcCompilers = nil
 				} else {
-					gc.goGrpcCompilersSet = true
 					gc.goGrpcCompilers = splitValue(d.Value)
 				}
 
 			case "go_proto_compilers":
 				// Special syntax (empty value) to reset directive.
 				if d.Value == "" {
-					gc.goProtoCompilersSet = false
-					gc.goProtoCompilers = defaultGoProtoCompilers
+					gc.goProtoCompilers = nil
 				} else {
-					gc.goProtoCompilersSet = true
 					gc.goProtoCompilers = splitValue(d.Value)
 				}
 

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package golang
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -119,15 +118,8 @@ func TestDirectives(t *testing.T) {
 	if gc.importMapPrefixRel != "test" {
 		t.Errorf(`got importmapPrefixRel %q; want "test"`, gc.importMapPrefixRel)
 	}
-	if !gc.goGrpcCompilersSet {
-		t.Error("expected goGrpcCompilersSet to be set")
-	}
 	if diff := cmp.Diff([]string{"abc", "def"}, gc.goGrpcCompilers); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
-	}
-
-	if !gc.goProtoCompilersSet {
-		t.Error("expected goProtoCompilersSet to be set")
 	}
 	if diff := cmp.Diff(gc.goProtoCompilers, []string{"foo", "bar"}); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
@@ -145,67 +137,11 @@ func TestDirectives(t *testing.T) {
 		cext.Configure(c, "test/sub", f)
 	}
 	gc = getGoConfig(c)
-	if gc.goGrpcCompilersSet {
-		t.Error("expected goGrpcCompilersSet to be unset")
-	}
-	if diff := cmp.Diff(defaultGoGrpcCompilers, gc.goGrpcCompilers); diff != "" {
+	if diff := cmp.Diff([]string(nil), gc.goGrpcCompilers); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
 	}
-
-	if gc.goProtoCompilersSet {
-		t.Error("expected goProtoCompilersSet to be unset")
-	}
-	if diff := cmp.Diff(defaultGoProtoCompilers, gc.goProtoCompilers); diff != "" {
+	if diff := cmp.Diff([]string(nil), gc.goProtoCompilers); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
-	}
-
-}
-
-func TestProtoCompilersFromBzlmod(t *testing.T) {
-	for _, tc := range []struct {
-		desc, moduleContent string
-		wantProto, wantGrpc []string
-	}{
-		{
-			desc: "workspace_fallback",
-			// No MODULE.bazel: falls back to io_bazel_rules_go.
-			wantProto: defaultGoProtoCompilers,
-			wantGrpc:  defaultGoGrpcCompilers,
-		},
-		{
-			desc: "bzlmod_default_apparent_name",
-			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0")
-`,
-			wantProto: []string{"@rules_go//proto:go_proto"},
-			wantGrpc:  []string{"@rules_go//proto:go_proto", "@rules_go//proto:go_grpc_v2"},
-		},
-		{
-			desc: "bzlmod_custom_repo_name",
-			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "my_rules_go")
-`,
-			wantProto: []string{"@my_rules_go//proto:go_proto"},
-			wantGrpc:  []string{"@my_rules_go//proto:go_proto", "@my_rules_go//proto:go_grpc_v2"},
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			dir := t.TempDir()
-			if tc.moduleContent != "" {
-				if err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(tc.moduleContent), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-			c, _, cexts := testConfig(t, "-repo_root="+dir)
-			for _, cext := range cexts {
-				cext.Configure(c, "", nil)
-			}
-			gc := getGoConfig(c)
-			if diff := cmp.Diff(tc.wantProto, gc.goProtoCompilers); diff != "" {
-				t.Errorf("goProtoCompilers (-want, +got): %s", diff)
-			}
-			if diff := cmp.Diff(tc.wantGrpc, gc.goGrpcCompilers); diff != "" {
-				t.Errorf("goGrpcCompilers (-want, +got): %s", diff)
-			}
-		})
 	}
 }
 

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package golang
 
 import (
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -158,6 +159,54 @@ func TestDirectives(t *testing.T) {
 		t.Errorf("(-want, +got): %s", diff)
 	}
 
+}
+
+func TestProtoCompilersFromBzlmod(t *testing.T) {
+	for _, tc := range []struct {
+		desc, moduleContent string
+		wantProto, wantGrpc []string
+	}{
+		{
+			desc: "workspace_fallback",
+			// No MODULE.bazel: falls back to io_bazel_rules_go.
+			wantProto: defaultGoProtoCompilers,
+			wantGrpc:  defaultGoGrpcCompilers,
+		},
+		{
+			desc: "bzlmod_default_apparent_name",
+			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0")
+`,
+			wantProto: []string{"@rules_go//proto:go_proto"},
+			wantGrpc:  []string{"@rules_go//proto:go_proto", "@rules_go//proto:go_grpc_v2"},
+		},
+		{
+			desc: "bzlmod_custom_repo_name",
+			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "my_rules_go")
+`,
+			wantProto: []string{"@my_rules_go//proto:go_proto"},
+			wantGrpc:  []string{"@my_rules_go//proto:go_proto", "@my_rules_go//proto:go_grpc_v2"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.moduleContent != "" {
+				if err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(tc.moduleContent), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			c, _, cexts := testConfig(t, "-repo_root="+dir)
+			for _, cext := range cexts {
+				cext.Configure(c, "", nil)
+			}
+			gc := getGoConfig(c)
+			if diff := cmp.Diff(tc.wantProto, gc.goProtoCompilers); diff != "" {
+				t.Errorf("goProtoCompilers (-want, +got): %s", diff)
+			}
+			if diff := cmp.Diff(tc.wantGrpc, gc.goGrpcCompilers); diff != "" {
+				t.Errorf("goGrpcCompilers (-want, +got): %s", diff)
+			}
+		})
+	}
 }
 
 func TestVendorConfig(t *testing.T) {

--- a/language/go/fix.go
+++ b/language/go/fix.go
@@ -179,7 +179,7 @@ func migrateGrpcCompilers(c *config.Config, f *rule.File) {
 			continue
 		}
 		r.SetKind("go_proto_library")
-		r.SetAttr("compilers", defaultGoGrpcCompilers)
+		r.SetAttr("compilers", getGoConfig(c).defaultGoGrpcCompilers())
 	}
 }
 

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -612,8 +612,12 @@ func (g *generator) generateProto(mode proto.Mode, targets []protoTarget, import
 		}
 	}
 	if atLeastOneTargetHasServices {
-		goProtoLibrary.SetAttr("compilers", gc.goGrpcCompilers)
-	} else if gc.goProtoCompilersSet {
+		if gc.goGrpcCompilers != nil {
+			goProtoLibrary.SetAttr("compilers", gc.goGrpcCompilers)
+		} else {
+			goProtoLibrary.SetAttr("compilers", gc.defaultGoGrpcCompilers())
+		}
+	} else if gc.goProtoCompilers != nil {
 		goProtoLibrary.SetAttr("compilers", gc.goProtoCompilers)
 	}
 	if g.shouldSetVisibility {

--- a/language/go/generate_test.go
+++ b/language/go/generate_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package golang
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -422,5 +423,90 @@ func convertImportsAttrs(f *rule.File) {
 		if v != nil {
 			r.SetAttr(config.GazelleImportsKey, v)
 		}
+	}
+}
+
+func TestProtoLibraryCompilers(t *testing.T) {
+	for _, tc := range []struct {
+		desc          string
+		moduleContent string
+		rulesGoName   string
+	}{
+		{
+			desc:        "workspace_fallback",
+			rulesGoName: "io_bazel_rules_go",
+		},
+		{
+			desc:          "bzlmod_default_apparent_name",
+			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0")
+`,
+			rulesGoName:   "rules_go",
+		},
+		{
+			desc:          "bzlmod_custom_repo_name",
+			moduleContent: `bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "my_rules_go")
+`,
+			rulesGoName:   "my_rules_go",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.moduleContent != "" {
+				if err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(tc.moduleContent), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			svcDir := filepath.Join(dir, "svc")
+			if err := os.MkdirAll(svcDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(svcDir, "svc.proto"), []byte(`
+syntax = "proto2";
+option go_package = "example.com/repo/svc";
+service S {}
+`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			c, langs, cexts := testConfig(t,
+				"-go_prefix=example.com/repo",
+				"-repo_root="+dir)
+			for _, cext := range cexts {
+				cext.Configure(c, "", nil)
+			}
+
+			var got []string
+			walk.Walk(c, cexts, []string{dir}, walk.VisitAllUpdateSubdirsMode, func(walkDir, rel string, walkC *config.Config, _ bool, oldFile *rule.File, subdirs, regularFiles, genFiles []string) {
+				var empty, gen []*rule.Rule
+				for _, lang := range langs {
+					res := lang.GenerateRules(language.GenerateArgs{
+						Config:       walkC,
+						Dir:          walkDir,
+						Rel:          rel,
+						File:         oldFile,
+						Subdirs:      subdirs,
+						RegularFiles: regularFiles,
+						GenFiles:     genFiles,
+						OtherEmpty:   empty,
+						OtherGen:     gen,
+					})
+					empty = append(empty, res.Empty...)
+					gen = append(gen, res.Gen...)
+				}
+				for _, r := range gen {
+					if r.Kind() == "go_proto_library" {
+						got = r.AttrStrings("compilers")
+					}
+				}
+			})
+
+			want := []string{
+				fmt.Sprintf("@%s//proto:go_proto", tc.rulesGoName),
+				fmt.Sprintf("@%s//proto:go_grpc_v2", tc.rulesGoName),
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

In Bzlmod workspaces, the apparent name of the rules_go module defaults to `@rules_go` (or whatever `repo_name` is set to in `MODULE.bazel`).
The default proto compiler labels are hardcoded to `@io_bazel_rules_go`, causing Gazelle to always generate:
```py
go_proto_library(
    ...
    compilers = [
        "@io_bazel_rules_go//proto:go_proto",
        "@io_bazel_rules_go//proto:go_grpc_v2",
    ],
```
... in pure Bzlmod workspaces where `@io_bazel_rules_go` does not exist, this breaks the build.

**Which issues(s) does this PR fix?**

Fixes #2000

**Other notes for review**

Since `Configure()` already resolves `gc.rulesGoRepoName` from the `MODULE.bazel` apparent name mapping, the proposed fix consists in rebuilding the compiler lists from that resolved name whenever they have not been overridden via `# gazelle:go_proto_compilers` and `# gazelle:go_grpc_compilers` directives.