### PR TITLE
go_deps: allow inheriting host env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,12 @@ go_register_toolchains(version = "1.20.5")
 gazelle_dependencies()
 ```
 
-`gazelle_dependencies` supports optional argument `go_env` (dict-mapping)
-to set project specific go environment variables. If you are using a
+`gazelle_dependencies` supports optional arguments `go_env` (dict-mapping)
+to set project specific go environment variables and `go_env_inherit`
+(list of names) to copy selected variables from the host environment.
+This is useful when dependency fetching relies on runtime-provided
+authentication, proxy settings, or repository configuration that should
+not be checked into source control. If you are using a
 `WORKSPACE.bazel` file, you will need to specify that using:
 
 ```bzl

--- a/deps.bzl
+++ b/deps.bzl
@@ -43,7 +43,8 @@ go_repository = _go_repository
 def gazelle_dependencies(
         go_sdk = "",
         go_repository_default_config = "@//:WORKSPACE",
-        go_env = {}):
+        go_env = {},
+        go_env_inherit = []):
     _maybe(
         http_archive,
         name = "bazel_skylib",
@@ -93,6 +94,7 @@ def gazelle_dependencies(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_name = go_sdk,
             go_env = go_env,
+            go_env_inherit = go_env_inherit,
         )
     else:
         go_sdk_info = {}
@@ -111,6 +113,7 @@ def gazelle_dependencies(
             name = "bazel_gazelle_go_repository_cache",
             go_sdk_info = go_sdk_info,
             go_env = go_env,
+            go_env_inherit = go_env_inherit,
         )
 
     go_repository_tools(
@@ -121,6 +124,8 @@ def gazelle_dependencies(
     go_repository_config(
         name = "bazel_gazelle_go_repository_config",
         config = go_repository_default_config,
+        go_env = go_env,
+        go_env_inherit = go_env_inherit,
     )
 
     is_bazel_module(

--- a/extensions.md
+++ b/extensions.md
@@ -9,7 +9,7 @@
 <pre>
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.archive_override(<a href="#go_deps.archive_override-patch_strip">patch_strip</a>, <a href="#go_deps.archive_override-patches">patches</a>, <a href="#go_deps.archive_override-path">path</a>, <a href="#go_deps.archive_override-sha256">sha256</a>, <a href="#go_deps.archive_override-strip_prefix">strip_prefix</a>, <a href="#go_deps.archive_override-urls">urls</a>)
-go_deps.config(<a href="#go_deps.config-check_direct_dependencies">check_direct_dependencies</a>, <a href="#go_deps.config-debug_mode">debug_mode</a>, <a href="#go_deps.config-go_env">go_env</a>)
+go_deps.config(<a href="#go_deps.config-check_direct_dependencies">check_direct_dependencies</a>, <a href="#go_deps.config-debug_mode">debug_mode</a>, <a href="#go_deps.config-go_env">go_env</a>, <a href="#go_deps.config-go_env_inherit">go_env_inherit</a>)
 go_deps.from_file(<a href="#go_deps.from_file-fail_on_version_conflict">fail_on_version_conflict</a>, <a href="#go_deps.from_file-go_mod">go_mod</a>, <a href="#go_deps.from_file-go_work">go_work</a>)
 go_deps.gazelle_override(<a href="#go_deps.gazelle_override-build_extra_args">build_extra_args</a>, <a href="#go_deps.gazelle_override-build_file_generation">build_file_generation</a>, <a href="#go_deps.gazelle_override-directives">directives</a>, <a href="#go_deps.gazelle_override-path">path</a>)
 go_deps.gazelle_default_attributes(<a href="#go_deps.gazelle_default_attributes-build_extra_args">build_extra_args</a>, <a href="#go_deps.gazelle_default_attributes-build_file_generation">build_file_generation</a>, <a href="#go_deps.gazelle_default_attributes-directives">directives</a>)
@@ -53,6 +53,7 @@ Only the root module's config tag is used.
 | <a id="go_deps.config-check_direct_dependencies"></a>check_direct_dependencies |  The way in which warnings about version mismatches for direct dependencies and Go modules that are also Bazel modules are reported.   | String | optional |  `""`  |
 | <a id="go_deps.config-debug_mode"></a>debug_mode |  Whether or not to print stdout and stderr messages from gazelle   | Boolean | optional |  `False`  |
 | <a id="go_deps.config-go_env"></a>go_env |  The environment variables to use when fetching Go dependencies or running the `@rules_go//go` tool.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="go_deps.config-go_env_inherit"></a>go_env_inherit |  Host environment variable names to inherit when fetching Go dependencies or running the `@rules_go//go` tool.   | List of strings | optional |  `[]`  |
 
 <a id="go_deps.from_file"></a>
 

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//internal:common.bzl", "resolve_env")
 load("//internal:go_repository.bzl", "go_repository")
 load(
     ":default_gazelle_overrides.bzl",
@@ -248,6 +249,11 @@ def _process_archive_override(archive_override_tag):
     )
 
 def _go_repository_config_impl(ctx):
+    go_env = resolve_env(
+        ctx,
+        direct = ctx.attr.go_env,
+        inherit = ctx.attr.go_env_inherit,
+    )
     repos = []
     for name, importpath in sorted(ctx.attr.importpaths.items()):
         repos.append(format_rule_call(
@@ -260,14 +266,14 @@ def _go_repository_config_impl(ctx):
 
     ctx.file("WORKSPACE", "\n".join(repos))
     ctx.file("BUILD.bazel", "exports_files(['WORKSPACE', 'config.json', 'go_env.bzl', 'go_tools.bzl'])")
-    ctx.file("go_env.bzl", content = "GO_ENV = " + repr(ctx.attr.go_env))
+    ctx.file("go_env.bzl", content = "GO_ENV = " + repr(go_env))
     ctx.file("go_tools.bzl", content = "GO_TOOLS = {{k: Label(v) for k, v in {}.items()}}".format(
         repr(ctx.attr.tool_targets),
     ))
 
     # For use by @rules_go//go.
     ctx.file("config.json", content = json.encode_indent({
-        "go_env": ctx.attr.go_env,
+        "go_env": go_env,
         "dep_files": ctx.attr.dep_files,
     }))
 
@@ -279,6 +285,7 @@ _go_repository_config = repository_rule(
         "tool_targets": attr.string_dict(mandatory = True),
         "build_naming_conventions": attr.string_dict(mandatory = True),
         "go_env": attr.string_dict(mandatory = True),
+        "go_env_inherit": attr.string_list(),
         "dep_files": attr.string_list(),
     },
 )
@@ -364,6 +371,7 @@ def _go_deps_impl(module_ctx):
 
     outdated_direct_dep_printer = print
     go_env = {}
+    go_env_inherit = []
     dep_files = []
     modules_from_go_work = {}
     debug_mode = False
@@ -386,6 +394,7 @@ def _go_deps_impl(module_ctx):
             elif check_direct_deps == "error":
                 outdated_direct_dep_printer = fail
             go_env = mod_config.go_env
+            go_env_inherit = mod_config.go_env_inherit
             debug_mode = mod_config.debug_mode
 
         _process_overrides(module_ctx, module, "gazelle_override", gazelle_overrides, _process_gazelle_override)
@@ -817,6 +826,7 @@ Mismatch between versions requested for Go module {module}:
             for path, module in module_resolutions.items()
         }),
         go_env = go_env,
+        go_env_inherit = go_env_inherit,
         dep_files = dep_files,
     )
 
@@ -876,6 +886,9 @@ _config_tag = tag_class(
         ),
         "go_env": attr.string_dict(
             doc = "The environment variables to use when fetching Go dependencies or running the `@rules_go//go` tool.",
+        ),
+        "go_env_inherit": attr.string_list(
+            doc = "Host environment variable names to inherit when fetching Go dependencies or running the `@rules_go//go` tool.",
         ),
         "debug_mode": attr.bool(doc = "Whether or not to print stdout and stderr messages from gazelle", default = False),
     },

--- a/internal/common.bzl
+++ b/internal/common.bzl
@@ -51,3 +51,30 @@ def getenv(repo_ctx, name, default = ""):
     if hasattr(repo_ctx, "getenv"):
         return repo_ctx.getenv(name, default)
     return repo_ctx.os.environ.get(name, default)
+
+def resolve_env(ctx, direct = {}, inherit = [], reserved = []):
+    """Builds an environment map from explicit values and host env passthroughs."""
+    env = {}
+    reserved_keys = {key: True for key in reserved}
+    inherited_keys = {}
+    for key, value in direct.items():
+        if key in reserved_keys:
+            fail("{} cannot be set in go_env".format(key))
+        env[key] = value
+
+    for key in inherit:
+        if key in inherited_keys:
+            continue
+        inherited_keys[key] = True
+        if key in reserved_keys:
+            fail("{} cannot be set in go_env_inherit".format(key))
+        if key in env:
+            fail("{} cannot be set in both go_env and go_env_inherit".format(key))
+
+        # Use getenv when available so repository rules invalidate if the
+        # underlying host environment changes.
+        value = getenv(ctx, key, None)
+        if value != None:
+            env[key] = value
+
+    return env

--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//internal:common.bzl", "executable_extension", "getenv", "watch")
+load("//internal:common.bzl", "executable_extension", "getenv", "resolve_env", "watch")
 
 # Change to trigger cache invalidation: 1
 
@@ -75,10 +75,12 @@ def _go_repository_cache_impl(ctx):
     if go_mod_cache:
         cache_env["GOMODCACHE"] = go_mod_cache
 
-    for key, value in ctx.attr.go_env.items():
-        if key in cache_env:
-            fail("{} cannot be set in go_env".format(key))
-        cache_env[key] = value
+    cache_env.update(resolve_env(
+        ctx,
+        direct = ctx.attr.go_env,
+        inherit = ctx.attr.go_env_inherit,
+        reserved = cache_env.keys(),
+    ))
     env_content = "\n".join(["{k}='{v}'\n".format(k = k, v = v) for k, v in cache_env.items()])
 
     ctx.file("go.env", env_content)
@@ -90,11 +92,13 @@ go_repository_cache = repository_rule(
         "go_sdk_name": attr.string(),
         "go_sdk_info": attr.string_dict(),
         "go_env": attr.string_dict(),
+        "go_env_inherit": attr.string_list(),
     },
 )
 
 def read_go_env(ctx, go_tool, var):
     watch(ctx, go_tool)
+
     # watch var too if possible.
     getenv(ctx, var)
     res = ctx.execute([go_tool, "env", var])

--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//internal:common.bzl", "env_execute", "executable_extension", "watch")
+load("//internal:common.bzl", "env_execute", "executable_extension", "resolve_env", "watch")
 load("//internal:go_repository_cache.bzl", "read_cache_env")
 
 def _go_repository_config_impl(ctx):
+    go_env = resolve_env(
+        ctx,
+        direct = ctx.attr.go_env,
+        inherit = ctx.attr.go_env_inherit,
+    )
+
     # Locate and resolve configuration files. Gazelle reads directives and
     # known repositories from these files. Resolving them here forces the
     # go_repository_config rule to be invalidated when they change. Gazelle's cache
@@ -61,7 +67,7 @@ def _go_repository_config_impl(ctx):
     # add empty go_env.bzl and go_tools.bzl files for compatibility with bzlmod
     ctx.file(
         "go_env.bzl",
-        "GO_ENV = {}",
+        "GO_ENV = {}".format(repr(go_env)),
         False,
     )
     ctx.file(
@@ -81,5 +87,7 @@ go_repository_config = repository_rule(
     implementation = _go_repository_config_impl,
     attrs = {
         "config": attr.label(),
+        "go_env": attr.string_dict(),
+        "go_env_inherit": attr.string_list(),
     },
 )

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -75,6 +75,7 @@ gazelle_dependencies(
 		"GOPRIVATE": "example.com/m",
 		"GOSUMDB": "off",
 	},
+	go_env_inherit = ["GAZELLE_INHERITED_TOKEN"],
 )
 
 # gazelle:repo test
@@ -116,6 +117,9 @@ go_repository(
 }
 
 func TestMain(m *testing.M) {
+	if err := os.Setenv("GAZELLE_INHERITED_TOKEN", "top-secret-token"); err != nil {
+		panic(err)
+	}
 	bazel_testing.TestMain(m, testArgs)
 }
 
@@ -248,10 +252,23 @@ func TestRepoCacheContainsGoEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not read file %s: %v", goEnvPath, err)
 	}
-	for _, want := range []string{"GOPRIVATE='example.com/m'", "GOSUMDB='off'"} {
+	for _, want := range []string{
+		"GOPRIVATE='example.com/m'",
+		"GOSUMDB='off'",
+		"GAZELLE_INHERITED_TOKEN='top-secret-token'",
+	} {
 		if !strings.Contains(string(gotBytes), want) {
 			t.Fatalf("go.env did not contain %s", want)
 		}
+	}
+
+	goEnvBzlPath := filepath.Join(outputBase, "external/bazel_gazelle_go_repository_config", "go_env.bzl")
+	goEnvBzl, err := os.ReadFile(goEnvBzlPath)
+	if err != nil {
+		t.Fatalf("could not read file %s: %v", goEnvBzlPath, err)
+	}
+	if !strings.Contains(string(goEnvBzl), "\"GAZELLE_INHERITED_TOKEN\": \"top-secret-token\"") {
+		t.Fatalf("go_env.bzl did not contain inherited GAZELLE_INHERITED_TOKEN")
 	}
 }
 


### PR DESCRIPTION
This adds `go_env_inherit` to both `gazelle_dependencies` and
`go_deps.config`, so callers can forward selected host environment
variables into dependency fetching without checking literal values into
source control.

That is especially useful for BuildBuddy users whose workflows provide
repository authentication or other fetch-time settings through runtime
environment variables. With this change, those workflows can keep the
values in the runner environment and tell Gazelle which variable names
to inherit.

Bzlmod example:

```bzl
go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

go_deps.config(
    go_env = {
        "GOPRIVATE": "github.com/my-org/*",
    },
    go_env_inherit = [
        "REPO_USER",
        "REPO_TOKEN",
    ],
)
```
