### PR TITLE
Allow placement of `go.work` in a nested (non-root) package

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -26,7 +26,7 @@ def _validate_go_version(path, state, tokens, line_no):
     if len(tokens) > 2:
         fail("{}:{}: unexpected token '{}' after '{}'".format(path, line_no, tokens[2], tokens[1]))
 
-def use_spec_to_label(repo_name, use_directive):
+def use_spec_to_label(go_work_label, use_directive):
     if use_directive.startswith("../") or "/../" in use_directive or use_directive.endswith("/.."):
         fail("go.work use directive: '{}' contains '..' which is not currently supported.".format(use_directive))
 
@@ -42,7 +42,11 @@ def use_spec_to_label(repo_name, use_directive):
     if use_directive == ".":
         use_directive = ""
 
-    return Label("@@{}//{}:go.mod".format(repo_name, use_directive))
+    label_package = go_work_label.package
+    if use_directive:
+        label_package = go_work_label.package + "/" + use_directive if go_work_label.package else use_directive
+
+    return Label("@@{}//{}:go.mod".format(go_work_label.repo_name, label_package))
 
 def go_work_from_label(module_ctx, go_work_label):
     """Loads deps from a go.work file"""
@@ -112,7 +116,7 @@ def parse_go_work(content, go_work_label):
 
     major, minor = go.split(".")[:2]
 
-    go_mods = [use_spec_to_label(go_work_label.repo_name, use) for use in state["use"]]
+    go_mods = [use_spec_to_label(go_work_label, use) for use in state["use"]]
     from_file_tags = [struct(go_mod = go_mod, _is_dev_dependency = False, _from_go_work = True) for go_mod in go_mods]
 
     module_tags = [struct(version = mod.version, path = mod.to_path, _parent_label = go_work_label, local_path = mod.local_path, indirect = False) for mod in state["replace"].values()]

--- a/tests/bzlmod/go_mod_test.bzl
+++ b/tests/bzlmod/go_mod_test.bzl
@@ -75,9 +75,14 @@ _EXPECTED_GO_MOD_21_PARSE_RESULT = struct(
 def _use_spec_to_label_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    asserts.equals(env, Label("@@org_example//go_mod_one:go.mod"), use_spec_to_label("org_example", "./go_mod_one"))
-    asserts.equals(env, Label("@@org_example//go_mod_one:go.mod"), use_spec_to_label("org_example", "./go_mod_one/"))
-    asserts.equals(env, Label("@@org_example//bar/go_mod_one:go.mod"), use_spec_to_label("org_example", "./bar/go_mod_one"))
+    root_go_work = Label("@@org_example//:go.work")
+    asserts.equals(env, Label("@@org_example//go_mod_one:go.mod"), use_spec_to_label(root_go_work, "./go_mod_one"))
+    asserts.equals(env, Label("@@org_example//go_mod_one:go.mod"), use_spec_to_label(root_go_work, "./go_mod_one/"))
+    asserts.equals(env, Label("@@org_example//bar/go_mod_one:go.mod"), use_spec_to_label(root_go_work, "./bar/go_mod_one"))
+
+    package_go_work = Label("@@org_example//go:go.work")
+    asserts.equals(env, Label("@@org_example//go/foo/bar:go.mod"), use_spec_to_label(package_go_work, "./foo/bar"))
+    asserts.equals(env, Label("@@org_example//go:go.mod"), use_spec_to_label(package_go_work, "."))
 
     return unittest.end(env)
 
@@ -217,6 +222,34 @@ def _go_work_godebug_test_impl(ctx):
 
 go_work_godebug_test = unittest.make(_go_work_godebug_test_impl)
 
+_GO_WORK_IN_PACKAGE_CONTENT = """go 1.24
+use (
+    ./foo/bar
+    .
+)
+"""
+
+_EXPECTED_GO_WORK_IN_PACKAGE_PARSE_RESULT = struct(
+    go = (1, 24),
+    from_file_tags = [
+        struct(go_mod = Label("//go/foo/bar:go.mod"), _is_dev_dependency = False, _from_go_work = True),
+        struct(go_mod = Label("//go:go.mod"), _is_dev_dependency = False, _from_go_work = True),
+    ],
+    module_tags = [],
+    replace_map = {},
+    use = [
+        "./foo/bar",
+        ".",
+    ],
+)
+
+def _go_work_in_package_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, _EXPECTED_GO_WORK_IN_PACKAGE_PARSE_RESULT, parse_go_work(_GO_WORK_IN_PACKAGE_CONTENT, Label("@@//go:go.work")))
+    return unittest.end(env)
+
+go_work_in_package_test = unittest.make(_go_work_in_package_test_impl)
+
 def go_mod_test_suite(name):
     unittest.suite(
         name,
@@ -226,5 +259,6 @@ def go_mod_test_suite(name):
         go_sum_test,
         go_work_test,
         go_work_godebug_test,
+        go_work_in_package_test,
         use_spec_test,
     )


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> bzlmod, go.work support

**What does this PR do? Why is it needed?**

Allows an arbitrary location of `go.work` within a Bazel module

**Which issues(s) does this PR fix?**

Fixes #2332

**Other notes for review**

Disclosure: I used an AI agent to make this change. I reviewed it myself and then manually ran full build and test suite.

I also tested it in our (private) monorepo by using `archive_override` and verified that it works with the `go.work` relocated into a subfolder.