### PR TITLE
Respect caller GOAUTH when building content

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -225,6 +225,7 @@ def _go_repository_impl(ctx):
         # not go out to the network at all. This means *the build*
         # goes out to the network. We tolerate this for downloading
         # archives, but finding module roots is a bit much.
+        "GOAUTH",
         "GONOPROXY",
         "GONOSUMDB",
         "GOPRIVATE",


### PR DESCRIPTION


**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
 go_repository

**What does this PR do? Why is it needed?**

Pass the user's GOAUTH env var (alongside GOPROXY) when invoking go. If both GOAUTH and GOPROXY are set, the go toolchain will use GOAUTH to generate access tokens that will be passed to GOPROXY. [See here for documentation](https://pkg.go.dev/cmd/go@master#hdr-GOAUTH_environment_variable) on the GOAUTH environment variable.

GOAUTH was introduced in go1.24 which explains why it wasn't in the original list of env vars. Now that the go toolchain supports it, gazelle should support it as well.

**Which issues(s) does this PR fix?**

Fixes #2334

**Other notes for review**
