### PR TITLE
Prefer @repo over @repo//:repo

### DIFF
--- a/v2/label/label.go
+++ b/v2/label/label.go
@@ -175,6 +175,9 @@ func (l Label) String() string {
 	if path.Base(l.Pkg) == l.Name {
 		return repo + "//" + l.Pkg
 	}
+	if l.Pkg == "" && repo != "" && repo[1:] == l.Name {
+		return repo
+	}
 	return repo + "//" + l.Pkg + ":" + l.Name
 }
 

--- a/v2/label/label_test.go
+++ b/v2/label/label_test.go
@@ -46,6 +46,9 @@ func TestLabelString(t *testing.T) {
 		}, {
 			l:    Label{Repo: "@", Pkg: "foo/bar", Name: "baz"},
 			want: "@//foo/bar:baz",
+		}, {
+			l:    Label{Repo: "foo", Name: "foo"},
+			want: "@foo",
 		},
 	} {
 		if got, want := spec.l.String(), spec.want; got != want {
@@ -130,7 +133,7 @@ func TestParseStringRoundtrip(t *testing.T) {
 		{in: "//pkg:target"},
 		{in: "@repo//:target"},
 		{in: "@repo//pkg:target"},
-		{in: "@repo", out: "@repo//:repo"},
+		{in: "@repo"},
 		{in: "@//pkg:target"},
 		{in: "@@canonical~name//:target"},
 		{in: "@@//:target"},


### PR DESCRIPTION
**What type of PR is this?**

Other (slight improvement)

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

It changes formatting of `@foo//:foo` to `@foo` in `Label.String()`.

**Which issues(s) does this PR fix?**

Fixes #2340.

**Other notes for review**

Tested with a local repo with `gazelle_cc` and it did rename e.g. `@boost.geometry//:boost.geometry` to `@boost.geometry`.

(Disclaimer: I didn't test this PR directly, but directly applied the change to `external/gazelle+/label/label.go` because of an issue with Go when I tried the main `gazelle` branch with this commit).