### PR TITLE
feat: support variable references and list concatenation in REPO.bazel ignore_directories()

### DIFF
--- a/walk/config.go
+++ b/walk/config.go
@@ -273,6 +273,56 @@ func loadBazelIgnore(repoRoot string) (map[string]struct{}, error) {
 	return excludes, nil
 }
 
+// collectStringsFromExpr recursively evaluates a Starlark expression to extract
+// string values from list literals, binary concatenation (+), and variable
+// references (resolved against top-level assignments in the same file).
+func collectStringsFromExpr(expr bzl.Expr, vars map[string]bzl.Expr) ([]string, error) {
+	switch e := expr.(type) {
+	case *bzl.ListExpr:
+		var result []string
+		for _, item := range e.List {
+			if strExpr, isStr := item.(*bzl.StringExpr); isStr {
+				result = append(result, strExpr.Value)
+			}
+		}
+		return result, nil
+	case *bzl.BinaryExpr:
+		if e.Op != "+" {
+			return nil, fmt.Errorf("unsupported binary operator %q in ignore_directories()", e.Op)
+		}
+		left, err := collectStringsFromExpr(e.X, vars)
+		if err != nil {
+			return nil, err
+		}
+		right, err := collectStringsFromExpr(e.Y, vars)
+		if err != nil {
+			return nil, err
+		}
+		return append(left, right...), nil
+	case *bzl.Ident:
+		resolved, ok := vars[e.Name]
+		if !ok {
+			return nil, fmt.Errorf("unresolved variable %q in ignore_directories()", e.Name)
+		}
+		return collectStringsFromExpr(resolved, vars)
+	default:
+		return nil, fmt.Errorf("unsupported expression type %T in ignore_directories()", expr)
+	}
+}
+
+// buildVarMap extracts top-level variable assignments from a parsed REPO.bazel file.
+func buildVarMap(stmts []bzl.Expr) map[string]bzl.Expr {
+	vars := make(map[string]bzl.Expr)
+	for _, stmt := range stmts {
+		if assign, ok := stmt.(*bzl.AssignExpr); ok {
+			if ident, ok := assign.LHS.(*bzl.Ident); ok && assign.Op == "=" {
+				vars[ident.Name] = assign.RHS
+			}
+		}
+	}
+	return vars
+}
+
 func loadRepoDirectoryIgnore(repoRoot string) ([]string, error) {
 	repoFilePath := path.Join(repoRoot, "REPO.bazel")
 	repoFileContent, err := os.ReadFile(repoFilePath)
@@ -298,20 +348,17 @@ func loadRepoDirectoryIgnore(repoRoot string) ([]string, error) {
 					return nil, fmt.Errorf("REPO.bazel ignore_directories() expects one argument")
 				}
 
-				list, isList := call.List[0].(*bzl.ListExpr)
-				if !isList {
-					return nil, fmt.Errorf("REPO.bazel ignore_directories() unexpected argument type: %T", call.List[0])
+				vars := buildVarMap(ast.Stmt)
+				strs, err := collectStringsFromExpr(call.List[0], vars)
+				if err != nil {
+					return nil, fmt.Errorf("REPO.bazel ignore_directories(): %w", err)
 				}
-
-				for _, item := range list.List {
-					if strExpr, isStr := item.(*bzl.StringExpr); isStr {
-						if err := checkPathMatchPattern(strExpr.Value); err != nil {
-							log.Printf("the ignore_directories() pattern %q is not valid: %s", strExpr.Value, err)
-							continue
-						}
-
-						ignoreDirectories = append(ignoreDirectories, strExpr.Value)
+				for _, s := range strs {
+					if err := checkPathMatchPattern(s); err != nil {
+						log.Printf("the ignore_directories() pattern %q is not valid: %s", s, err)
+						continue
 					}
+					ignoreDirectories = append(ignoreDirectories, s)
 				}
 
 				// Only a single ignore_directories() is supported in REPO.bazel and searching can stop.

--- a/walk/config_test.go
+++ b/walk/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bmatcuk/doublestar/v4"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 func TestCheckPathMatchPattern(t *testing.T) {
@@ -78,5 +79,189 @@ func TestConfigurerDirectives(t *testing.T) {
 	want := []string{"x", "y"}
 	if !reflect.DeepEqual(c.ValidBuildFileNames, want) {
 		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, want)
+	}
+}
+
+func TestCollectStringsFromExpr(t *testing.T) {
+	testCases := []struct {
+		name    string
+		expr    bzl.Expr
+		vars    map[string]bzl.Expr
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "plain list",
+			expr: &bzl.ListExpr{
+				List: []bzl.Expr{
+					&bzl.StringExpr{Value: "dir1"},
+					&bzl.StringExpr{Value: "dir2"},
+				},
+			},
+			vars:    nil,
+			want:    []string{"dir1", "dir2"},
+			wantErr: false,
+		},
+		{
+			name: "variable reference",
+			expr: &bzl.Ident{Name: "_DIRS"},
+			vars: map[string]bzl.Expr{
+				"_DIRS": &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "vendor"},
+						&bzl.StringExpr{Value: "third_party"},
+					},
+				},
+			},
+			want:    []string{"vendor", "third_party"},
+			wantErr: false,
+		},
+		{
+			name: "binary concatenation of two lists",
+			expr: &bzl.BinaryExpr{
+				Op: "+",
+				X: &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir1"},
+					},
+				},
+				Y: &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir2"},
+					},
+				},
+			},
+			vars:    nil,
+			want:    []string{"dir1", "dir2"},
+			wantErr: false,
+		},
+		{
+			name: "variable concatenation pattern",
+			expr: &bzl.BinaryExpr{
+				Op:   "+",
+				X:    &bzl.Ident{Name: "_FOO"},
+				Y:    &bzl.Ident{Name: "_BAR"},
+			},
+			vars: map[string]bzl.Expr{
+				"_FOO": &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir1"},
+						&bzl.StringExpr{Value: "dir2"},
+					},
+				},
+				"_BAR": &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir3"},
+					},
+				},
+			},
+			want:    []string{"dir1", "dir2", "dir3"},
+			wantErr: false,
+		},
+		{
+			name:    "unresolved variable",
+			expr:    &bzl.Ident{Name: "_UNKNOWN"},
+			vars:    map[string]bzl.Expr{},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "unsupported binary operator",
+			expr: &bzl.BinaryExpr{
+				Op: "-",
+				X: &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir1"},
+					},
+				},
+				Y: &bzl.ListExpr{
+					List: []bzl.Expr{
+						&bzl.StringExpr{Value: "dir2"},
+					},
+				},
+			},
+			vars:    nil,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := collectStringsFromExpr(tc.expr, tc.vars)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("collectStringsFromExpr() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if !tc.wantErr && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("collectStringsFromExpr() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRepoDirectoryIgnoreWithVariables(t *testing.T) {
+	dir, err := os.MkdirTemp(os.Getenv("TEST_TEMPDIR"), "repo_ignore_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repoContent := []byte(`
+_GENERATED = ["generated1", "generated2"]
+_VENDOR = ["vendor"]
+
+ignore_directories(_GENERATED + _VENDOR)
+`)
+	if err := os.WriteFile(filepath.Join(dir, "REPO.bazel"), repoContent, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadRepoDirectoryIgnore(dir)
+	if err != nil {
+		t.Fatalf("loadRepoDirectoryIgnore() error: %v", err)
+	}
+
+	want := []string{"generated1", "generated2", "vendor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadRepoDirectoryIgnore() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildVarMap(t *testing.T) {
+	stmts := []bzl.Expr{
+		&bzl.AssignExpr{
+			LHS: &bzl.Ident{Name: "_FOO"},
+			Op:  "=",
+			RHS: &bzl.ListExpr{
+				List: []bzl.Expr{
+					&bzl.StringExpr{Value: "a"},
+				},
+			},
+		},
+		&bzl.AssignExpr{
+			LHS: &bzl.Ident{Name: "_BAR"},
+			Op:  "=",
+			RHS: &bzl.ListExpr{
+				List: []bzl.Expr{
+					&bzl.StringExpr{Value: "b"},
+				},
+			},
+		},
+	}
+
+	vars := buildVarMap(stmts)
+	if len(vars) != 2 {
+		t.Fatalf("buildVarMap() returned %d entries, want 2", len(vars))
+	}
+	if _, ok := vars["_FOO"]; !ok {
+		t.Error("buildVarMap() missing _FOO")
+	}
+	if _, ok := vars["_BAR"]; !ok {
+		t.Error("buildVarMap() missing _BAR")
 	}
 }


### PR DESCRIPTION
## Summary

Gazelle's `loadRepoDirectoryIgnore` (added in #2039) only handles a bare `*bzl.ListExpr` as the argument to `ignore_directories()`. But Bazel's own Starlark evaluator supports expressions like variable references and list concatenation. A common pattern in large repos is:

```python
_FOO = ["dir1", "dir2"]
_BAR = ["dir3"]
ignore_directories(_FOO + _BAR)
```

This produces a `*bzl.BinaryExpr` which Gazelle rejects with "unexpected argument type".

Fixes #1994

## Changes Made

- Added `collectStringsFromExpr` helper that recursively evaluates an expression, handling:
  - `*bzl.ListExpr` (plain list literals)
  - `*bzl.BinaryExpr` (for `+` concatenation)
  - `*bzl.Ident` (variable references resolved from top-level assignments)
- Added `buildVarMap` helper that extracts top-level variable assignments from the parsed file
- Updated `loadRepoDirectoryIgnore` to use these helpers instead of directly asserting `*bzl.ListExpr`

## Testing

- Added unit tests for `collectStringsFromExpr` covering all expression types and error cases
- Added integration test `TestLoadRepoDirectoryIgnoreWithVariables` that writes a REPO.bazel with variable concatenation and verifies the directories are correctly parsed
- Added unit test for `buildVarMap`

## Motivation

Large repositories often organize their `ignore_directories()` lists into named variables for readability and maintainability. For example, a monorepo might group ignored directories by category (generated code, vendored deps, legacy code) and concatenate them. Without this change, Gazelle fails to parse such REPO.bazel files.