### PR TITLE
feat: don't require `# gazelle:` prefix in directive_file

### DIFF
--- a/gazelle-reference.md
+++ b/gazelle-reference.md
@@ -134,7 +134,7 @@ List of Go build tags Gazelle will defer to Bazel for evaluation. Gazelle applie
 
 **Directive:** `# gazelle:directive_file path`<br>
 **Default:** n/a<br>
-Loads additional Gazelle directives from an external file. The path is relative to the directory containing the build file. The external file uses the same `# gazelle:key value` format as build file directives. Blank lines and comment lines that do not match the directive pattern are ignored.
+Loads additional Gazelle directives from an external file. The path is relative to the directory containing the build file. The external file supports the same format as build file directives (`# gazelle:key value`) or a shorter `key value` format. Blank lines and comment lines that do not match the directive pattern are ignored.
 
 Directives from the external file are inserted at the position of the `directive_file` entry, so inline directives appearing after `directive_file` can override values from the file. This is useful for managing large numbers of directives (e.g., `resolve` overrides) in a separate, possibly generated file.
 

--- a/v2/rule/directives.go
+++ b/v2/rule/directives.go
@@ -76,11 +76,12 @@ func parseDirectives(stmt []bzl.Expr) []Directive {
 }
 
 var directiveRe = regexp.MustCompile(`^#\s*gazelle:(\w+)\s*(.*?)\s*$`)
+var fileDirectiveRe = regexp.MustCompile(`^(?:#\s*gazelle:)?(\w+)\s*(.*?)\s*$`)
 
 // ParseDirectivesFromFile reads a file and extracts Gazelle directives from it.
-// Each line is matched against the same pattern used for BUILD file comments
-// (# gazelle:key value). Blank lines and comment lines that don't match
-// the directive pattern are ignored.
+// Each line is matched against a permissive version of the pattern used
+// for BUILD file comments ("# gazelle:key value" or "key value"). Blank lines
+// and comment lines that don't match the directive pattern are ignored.
 func ParseDirectivesFromFile(filePath string) ([]Directive, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -92,9 +93,12 @@ func ParseDirectivesFromFile(filePath string) ([]Directive, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		match := directiveRe.FindStringSubmatch(line)
+		match := fileDirectiveRe.FindStringSubmatch(line)
 		if match == nil {
 			continue
+		}
+		if match[1] == "gazelle" {
+			return nil, fmt.Errorf("invalid directive: %q: directive must use format '# gazelle:key value' or 'key value'", line)
 		}
 		directives = append(directives, Directive{Key: match[1], Value: match[2]})
 	}

--- a/v2/rule/directives_test.go
+++ b/v2/rule/directives_test.go
@@ -77,7 +77,7 @@ func TestParseDirectivesFromFile(t *testing.T) {
 			want:    nil,
 		},
 		{
-			desc: "directives with hash prefix",
+			desc: "directives with '# gazelle:' prefix",
 			content: `# gazelle:resolve go example.com/foo //third_party:foo
 # gazelle:resolve proto google/api/annotations.proto @go_googleapis//google/api:annotations_proto
 `,
@@ -85,6 +85,32 @@ func TestParseDirectivesFromFile(t *testing.T) {
 				{"resolve", "go example.com/foo //third_party:foo"},
 				{"resolve", "proto google/api/annotations.proto @go_googleapis//google/api:annotations_proto"},
 			},
+		},
+		{
+			desc: "directives with no prefix",
+			content: `resolve go example.com/foo //third_party:foo
+resolve proto google/api/annotations.proto @go_googleapis//google/api:annotations_proto
+`,
+			want: []Directive{
+				{"resolve", "go example.com/foo //third_party:foo"},
+				{"resolve", "proto google/api/annotations.proto @go_googleapis//google/api:annotations_proto"},
+			},
+		},
+		{
+			desc: "directives with mixed prefixes",
+			content: `# gazelle:resolve go example.com/foo //third_party:foo
+exclude vendor
+`,
+			want: []Directive{
+				{"resolve", "go example.com/foo //third_party:foo"},
+				{"exclude", "vendor"},
+			},
+		},
+		{
+			desc:    "directives with 'gazelle:' prefix return error",
+			content: `gazelle:resolve go example.com/foo //third_party:foo`,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			desc: "blank lines and plain comments ignored",


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

This is a follow-up to #2314.

With the introduction of `directive_file`, directives in an external file still require the `# gazelle:` prefix. This harms readability as comments preceding directives are not visually distinguished from the directives themselves. With this PR, directives in external files can now be declared without the `# gazelle:` prefix, e.g.:

```
# Generate a single proto_library per file
proto file
```

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

`rule`

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
