### PR TITLE
go.mod: update v2 requirement to v2.0.0-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bazelbuild/bazel-gazelle
 go 1.24.12
 
 require (
-	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1
+	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52
 	github.com/bazelbuild/rules_go v0.59.0
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1 h1:Aney60tyjQn3ON+KPFQhEZ7saU1EtOhlCrGTKGkxiEI=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 h1:lSINS7DK4xjm0Z4CBd7onO63uIe6WUsEZ/0voExa+JY=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.53.0 h1:u160DT+RRb+Xb2aSO4piN8xhs4aZvWz2UDXCq48F4ao=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 ## workspace
-# github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1
+# github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2
 ## explicit; go 1.24.12
 # github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52
 ## explicit; go 1.20


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

go.mod

**What does this PR do? Why is it needed?**

Depends on a newer v2 tag, since we import v2 packages that aren't available on the old tag.

**Which issues(s) does this PR fix?**

For #2349

**Other notes for review**

I've tagged v2.0.0-2 as an alias for v0.51.0.

Once this change is merged, I'll create a release/v0.51 branch, cherry-pick it, and then tag v0.51.1.
