### PR TITLE
gazelle_binary needs cc toolchain

### DIFF
--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -131,7 +131,10 @@ proto extension stores metadata in hidden attributes of generated
         ),
     },
     "executable": True,
-    "toolchains": ["@io_bazel_rules_go//go:toolchain"],
+    "toolchains": [
+        "@io_bazel_rules_go//go:toolchain",
+        config_common.toolchain_type("@bazel_tools//tools/cpp:toolchain_type", mandatory = False),
+    ],
 }
 
 gazelle_binary = rule(**_gazelle_binary_kwargs)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
rules_go has become stricter in requiring rules to declare their cc toolchain (the previous ways predated toolchain resolution and could lead to incorrect toolchains being selected for multiplatform builds)

**Which issues(s) does this PR fix?**

https://github.com/bazel-contrib/rules_go/issues/4626

**Other notes for review**
