### PR TITLE
go_deps: allow overriding a module's Bazel repo name

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -15,7 +15,7 @@ go_deps.gazelle_override(<a href="#go_deps.gazelle_override-build_extra_args">bu
 go_deps.gazelle_default_attributes(<a href="#go_deps.gazelle_default_attributes-build_extra_args">build_extra_args</a>, <a href="#go_deps.gazelle_default_attributes-build_file_generation">build_file_generation</a>, <a href="#go_deps.gazelle_default_attributes-directives">directives</a>)
 go_deps.module(<a href="#go_deps.module-build_file_proto_mode">build_file_proto_mode</a>, <a href="#go_deps.module-build_naming_convention">build_naming_convention</a>, <a href="#go_deps.module-indirect">indirect</a>, <a href="#go_deps.module-local_path">local_path</a>, <a href="#go_deps.module-path">path</a>, <a href="#go_deps.module-sum">sum</a>,
                <a href="#go_deps.module-version">version</a>)
-go_deps.module_override(<a href="#go_deps.module_override-patch_cmds">patch_cmds</a>, <a href="#go_deps.module_override-patch_strip">patch_strip</a>, <a href="#go_deps.module_override-patches">patches</a>, <a href="#go_deps.module_override-path">path</a>)
+go_deps.module_override(<a href="#go_deps.module_override-patch_cmds">patch_cmds</a>, <a href="#go_deps.module_override-patch_strip">patch_strip</a>, <a href="#go_deps.module_override-patches">patches</a>, <a href="#go_deps.module_override-path">path</a>, <a href="#go_deps.module_override-repo_name">repo_name</a>)
 </pre>
 
 
@@ -125,7 +125,7 @@ Declare a single Go module dependency. Prefer using `from_file` instead.
 
 ### module_override
 
-Apply patches to a given Go module defined by other tags in this extension.
+Override the definition of a Go module defined by other tags in this extension, e.g. to apply patches or change its Bazel repository name.
 
 **Attributes**
 
@@ -135,5 +135,6 @@ Apply patches to a given Go module defined by other tags in this extension.
 | <a id="go_deps.module_override-patch_strip"></a>patch_strip |  The number of leading path segments to be stripped from the file name in the patches.   | Integer | optional |  `0`  |
 | <a id="go_deps.module_override-patches"></a>patches |  A list of patches to apply to the repository *after* gazelle runs.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="go_deps.module_override-path"></a>path |  The Go module path for the repository to be overridden.<br><br>This module path must be defined by other tags in this extension within this Bazel module.   | String | required |  |
+| <a id="go_deps.module_override-repo_name"></a>repo_name |  The Bazel repository name to use for this Go module.<br><br>By default, Gazelle derives the repository name from the module's import path. Two distinct modules whose import paths differ only by "/" vs "_" (or only by case) derive the same default name, which Gazelle rejects with an error. When both are pulled in transitively, dropping one from the go.mod is not always possible. Setting this attribute lets the root module assign a distinct repository name to one of the colliding modules so they can coexist. The collision check still runs on the resulting names.   | String | optional |  `""`  |
 
 

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -31,7 +31,10 @@ load(
     "with_replaced_or_new_fields",
 )
 
-visibility("//")
+visibility([
+    "//",
+    "//tests/bzlmod/...",
+])
 
 _HIGHEST_VERSION_SENTINEL = semver.to_comparable("999999.999999.999999")
 
@@ -173,6 +176,19 @@ def _repo_name(importpath):
     candidate_name = "_".join(segments).replace("-", "_")
     return "".join([c.lower() if c.isalnum() else "_" for c in candidate_name.elems()])
 
+def get_repo_name(importpath, module_overrides):
+    """Returns the Bazel repo name for a Go module path.
+
+    If a module_override for the path specifies a non-empty repo_name, that
+    value is used verbatim. Otherwise the name is derived from the import path
+    via _repo_name. This allows the root module to break collisions between two
+    modules whose import paths mangle to the same default repo name.
+    """
+    override = module_overrides.get(importpath)
+    if override and getattr(override, "repo_name", ""):
+        return override.repo_name
+    return _repo_name(importpath)
+
 def _is_dev_dependency(module_ctx, tag):
     if hasattr(tag, "_is_dev_dependency"):
         # Synthetic tags generated from go_deps.from_file have this "hidden" attribute.
@@ -241,6 +257,7 @@ def _process_module_override(module_override_tag):
         patches = module_override_tag.patches,
         patch_strip = module_override_tag.patch_strip,
         patch_cmds = module_override_tag.patch_cmds,
+        repo_name = module_override_tag.repo_name,
     )
 
 def _process_archive_override(archive_override_tag):
@@ -587,9 +604,9 @@ def _go_deps_impl(module_ctx):
                 module_tag.path not in modules_from_go_work):
                 root_versions[module_tag.path] = raw_version
                 if _is_dev_dependency(module_ctx, module_tag):
-                    root_module_direct_dev_deps[_repo_name(module_tag.path)] = None
+                    root_module_direct_dev_deps[get_repo_name(module_tag.path, module_overrides)] = None
                 else:
-                    root_module_direct_deps[_repo_name(module_tag.path)] = None
+                    root_module_direct_deps[get_repo_name(module_tag.path, module_overrides)] = None
 
             version = semver.to_comparable(raw_version)
             previous = paths.get(module_tag.path)
@@ -611,7 +628,7 @@ def _go_deps_impl(module_ctx):
                     local_path = replacement.local_path
 
                 module_resolutions[module_tag.path] = struct(
-                    repo_name = _repo_name(module_tag.path),
+                    repo_name = get_repo_name(module_tag.path, module_overrides),
                     version = version,
                     raw_version = raw_version,
                     to_path = to_path,
@@ -755,11 +772,11 @@ Mismatch between versions requested for Go module {module}:
         if hasattr(module, "module_name") or (getattr(module_ctx, "is_isolated", False) and path in _SHARED_REPOS):
             # Do not create a go_repository for a Go module provided by a bazel_go_module or one shared with the non-isolated
             # instance of go_deps.
-            root_module_direct_deps.pop(_repo_name(path), None)
-            root_module_direct_dev_deps.pop(_repo_name(path), None)
+            root_module_direct_deps.pop(get_repo_name(path, module_overrides), None)
+            root_module_direct_dev_deps.pop(get_repo_name(path, module_overrides), None)
             continue
         if module.repo_name in repos_processed:
-            fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle. Please ensure you only use one of these modules in your go.mod(s)".format(
+            fail("Go module {prev_path} and {path} will resolve to the same Bazel repo name: {name}. While Go allows modules to only differ in case, this isn't supported in Gazelle. Please ensure you only use one of these modules in your go.mod(s), or assign a distinct repo name to one of them via the \"repo_name\" attribute of a \"module_override\" tag.".format(
                 prev_path = repos_processed[module.repo_name],
                 path = path,
                 name = module.repo_name,
@@ -1058,8 +1075,20 @@ _module_override_tag = tag_class(
         "patch_cmds": attr.string_list(
             doc = "Commands to run in the repository after patches are applied.",
         ),
+        "repo_name": attr.string(
+            doc = """The Bazel repository name to use for this Go module.
+
+            By default, Gazelle derives the repository name from the module's
+            import path. Two distinct modules whose import paths differ only by
+            "/" vs "_" (or only by case) derive the same default name, which
+            Gazelle rejects with an error. When both are pulled in transitively,
+            dropping one from the go.mod is not always possible. Setting this
+            attribute lets the root module assign a distinct repository name to
+            one of the colliding modules so they can coexist. The collision
+            check still runs on the resulting names.""",
+        ),
     },
-    doc = "Apply patches to a given Go module defined by other tags in this extension.",
+    doc = "Override the definition of a Go module defined by other tags in this extension, e.g. to apply patches or change its Bazel repository name.",
 )
 
 go_deps = module_extension(

--- a/tests/bcr/fixtures/collision_slash/go.mod
+++ b/tests/bcr/fixtures/collision_slash/go.mod
@@ -1,0 +1,3 @@
+module example.org/collision/mangle
+
+go 1.21

--- a/tests/bcr/fixtures/collision_slash/mangle.go
+++ b/tests/bcr/fixtures/collision_slash/mangle.go
@@ -1,0 +1,8 @@
+// Package mangle is one half of a pair of fixture modules whose import paths
+// ("example.org/collision/mangle" and "example.org/collision_mangle") mangle to
+// the same default Bazel repo name (org_example_collision_mangle). It exercises
+// the module_override "repo_name" attribute, which lets the root module assign a
+// distinct repo name to one of them so both can coexist.
+package mangle
+
+const Name = "slash"

--- a/tests/bcr/fixtures/collision_underscore/collision_mangle.go
+++ b/tests/bcr/fixtures/collision_underscore/collision_mangle.go
@@ -1,0 +1,8 @@
+// Package collision_mangle is one half of a pair of fixture modules whose import
+// paths ("example.org/collision/mangle" and "example.org/collision_mangle")
+// mangle to the same default Bazel repo name (org_example_collision_mangle). It
+// exercises the module_override "repo_name" attribute, which lets the root
+// module assign a distinct repo name to one of them so both can coexist.
+package collision_mangle
+
+const Name = "underscore"

--- a/tests/bcr/fixtures/collision_underscore/go.mod
+++ b/tests/bcr/fixtures/collision_underscore/go.mod
@@ -1,0 +1,3 @@
+module example.org/collision_mangle
+
+go 1.21

--- a/tests/bcr/go_mod/MODULE.bazel
+++ b/tests/bcr/go_mod/MODULE.bazel
@@ -90,6 +90,14 @@ go_deps.module_override(
     path = "github.com/stretchr/testify",
 )
 
+# example.org/collision/mangle and example.org/collision_mangle mangle to the
+# same default Bazel repo name (org_example_collision_mangle). Assign a distinct
+# repo name to one of them via module_override so both can be depended on.
+go_deps.module_override(
+    path = "example.org/collision_mangle",
+    repo_name = "org_example_collision_mangle_alt",
+)
+
 # Test an archive override from a known archive.
 go_deps.gazelle_override(
     build_file_generation = "clean",
@@ -158,6 +166,8 @@ use_repo(
     "com_github_google_go_jsonnet",
     "com_github_google_safetext",
     "com_github_stretchr_testify",
+    "org_example_collision_mangle",
+    "org_example_collision_mangle_alt",
     "org_example_hello",
     "org_example_proto_compat",
     "org_golang_google_genproto",

--- a/tests/bcr/go_mod/go.mod
+++ b/tests/bcr/go_mod/go.mod
@@ -7,6 +7,8 @@ go 1.24.12
 replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar/v4 v4.9.1
 
 require (
+	example.org/collision/mangle v1.0.0
+	example.org/collision_mangle v1.0.0
 	example.org/hello v1.0.0
 	example.org/proto_compat v1.0.0
 	github.com/DataDog/sketches-go v1.4.1
@@ -54,6 +56,10 @@ require golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 replace example.org/hello => ../../fixtures/hello
 
 replace example.org/proto_compat => ../fixtures/proto_compat
+
+replace example.org/collision/mangle => ../fixtures/collision_slash
+
+replace example.org/collision_mangle => ../fixtures/collision_underscore
 
 tool (
 	honnef.co/go/tools/cmd/staticcheck

--- a/tests/bcr/go_mod/pkg/BUILD.bazel
+++ b/tests/bcr/go_mod/pkg/BUILD.bazel
@@ -62,6 +62,8 @@ go_test(
         "@com_github_google_safetext//yamltemplate",
         "@com_github_stretchr_testify//require:go_default_library",
         "@my_rules_go//go/runfiles",
+        "@org_example_collision_mangle//:mangle",
+        "@org_example_collision_mangle_alt//:collision_mangle",
         "@org_example_hello//:hello",
         "@org_example_proto_compat//:proto_compat",
     ],

--- a/tests/bcr/go_mod/pkg/pkg_test.go
+++ b/tests/bcr/go_mod/pkg/pkg_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"example.org/collision/mangle"
+	collision_underscore "example.org/collision_mangle"
 	"example.org/hello"
 	"example.org/proto_compat"
 	"github.com/DataDog/sketches-go/ddsketch"
@@ -80,6 +82,14 @@ func TestBazelDepUsedAsGoDep(t *testing.T) {
 func TestArchiveOverrideUsed(t *testing.T) {
 	label := labels.Parse("@com_github_bazelbuild_buildtools//labels:labels")
 	require.NotEmpty(t, label)
+}
+
+func TestRepoNameOverrideBreaksCollision(t *testing.T) {
+	// example.org/collision/mangle and example.org/collision_mangle mangle to the
+	// same default Bazel repo name. A module_override repo_name on the latter lets
+	// both coexist; being able to import and use both here proves it worked.
+	require.Equal(t, "slash", mangle.Name)
+	require.Equal(t, "underscore", collision_underscore.Name)
 }
 
 func TestArchiveOverrideWithPatch(t *testing.T) {

--- a/tests/bzlmod/BUILD.bazel
+++ b/tests/bzlmod/BUILD.bazel
@@ -1,6 +1,9 @@
+load(":go_deps_test.bzl", "go_deps_test_suite")
 load(":go_mod_test.bzl", "go_mod_test_suite")
 load(":semver_test.bzl", "semver_test_suite")
 load(":utils_test.bzl", "utils_test_suite")
+
+go_deps_test_suite(name = "go_deps_test")
 
 go_mod_test_suite(name = "go_mod_test")
 

--- a/tests/bzlmod/go_deps_test.bzl
+++ b/tests/bzlmod/go_deps_test.bzl
@@ -1,0 +1,63 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//internal/bzlmod:go_deps.bzl", "get_repo_name")
+
+def _get_repo_name_default_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Without any override, the repo name is derived from the import path.
+    asserts.equals(
+        env,
+        "com_example_foo_bar_baz",
+        get_repo_name("example.com/foo/bar/baz", {}),
+    )
+    asserts.equals(
+        env,
+        "com_example_foo_bar_baz",
+        get_repo_name("example.com/foo_bar_baz", {}),
+    )
+
+    # An override without a repo_name falls back to the derived name.
+    asserts.equals(
+        env,
+        "com_example_foo_bar_baz",
+        get_repo_name("example.com/foo/bar/baz", {
+            "example.com/foo/bar/baz": struct(repo_name = ""),
+        }),
+    )
+
+    # An override for a different path does not affect this one.
+    asserts.equals(
+        env,
+        "com_example_foo_bar_baz",
+        get_repo_name("example.com/foo/bar/baz", {
+            "example.com/other": struct(repo_name = "custom_name"),
+        }),
+    )
+
+    return unittest.end(env)
+
+get_repo_name_default_test = unittest.make(_get_repo_name_default_test_impl)
+
+def _get_repo_name_override_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # A non-empty repo_name override is used verbatim, breaking the collision
+    # with another module that mangles to the same default name.
+    asserts.equals(
+        env,
+        "com_example_foo_bar_baz_alt",
+        get_repo_name("example.com/foo_bar_baz", {
+            "example.com/foo_bar_baz": struct(repo_name = "com_example_foo_bar_baz_alt"),
+        }),
+    )
+
+    return unittest.end(env)
+
+get_repo_name_override_test = unittest.make(_get_repo_name_override_test_impl)
+
+def go_deps_test_suite(name):
+    unittest.suite(
+        name,
+        get_repo_name_default_test,
+        get_repo_name_override_test,
+    )


### PR DESCRIPTION
Two distinct Go modules whose import paths differ only by `/` vs `_` (or only by case) mangle to the same Bazel repo name, so go_deps hard-fails. When both are pulled in transitively, dropping one from the `go.mod` is not always actionable.

Add an optional `repo_name` attribute to the `gazelle_override` tag. When set, it is used as the Bazel repo name for that module instead of the mangled default, letting the root module break such collisions. The change is purely additive and root-module-only, like other gazelle_override attributes; the collision check still runs on the resulting names, and its error message now points at this attribute. `repo_name` is intentionally kept out of `_GAZELLE_ATTRS` so it cannot be set via `gazelle_default_attributes`, since a repo name is necessarily per-module.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

none. This is a new feature.

**What does this PR do? Why is it needed?**

See above.

**Which issues(s) does this PR fix?**

Fixes #2364

**Other notes for review**
