### PR TITLE
Fix: stop adding prefix to proto imports

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -263,7 +263,7 @@ func generateProto(pc *ProtoConfig, rel string, pkg *Package, shouldSetVisibilit
 	imports := make([]string, 0, len(pkg.Imports))
 	for i := range pkg.Imports {
 		// If the proto import is a self import (an import between the same package), skip it
-		if _, ok := pkg.Files[path.Base(i)]; ok && getPrefix(pc, path.Dir(i)) == getPrefix(pc, rel) {
+		if _, ok := pkg.Files[path.Base(i)]; ok && path.Dir(i) == getPrefix(pc, rel) {
 			delete(pkg.Imports, i)
 			continue
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/proto

**What does this PR do? Why is it needed?**
The imports parsed from proto file is already a full qualified import path, as proto files don't allow relative imports. Caling `getPrefix()` on top of the imports will make the custom prefix from `gazelle:proto_import_prefix` appear twice, breaking the self-import detection logic.

