### PR TITLE
feat(go): support rc toolchains

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -259,7 +259,7 @@ def parse_go_mod(content, path):
         go = "1.16"
 
     # The go directive can contain patch and pre-release versions, but we omit them.
-    major, minor = go.split(".")[:2]
+    major, minor = go.split("rc")[0].split(".")[:2]
 
     return struct(
         module = module,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix / feature

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

If you try to use Gazelle today with a pre-release version of Go (e.g. `1.27rc1`), you receive an error:

```
	File "/Users/rafiksalama/Library/Caches/bazel/_bazel_rafiksalama/c4824d8210ee1e28e2bc4f237bdd53e8/external/gazelle+/internal/bzlmod/go_deps.bzl", line 479, column 95, in _go_deps_impl
		module_path, module_tags_from_go_mod, go_mod_replace_map, tools = deps_from_go_mod(module_ctx, from_file_tag.go_mod)
	File "/Users/rafiksalama/Library/Caches/bazel/_bazel_rafiksalama/c4824d8210ee1e28e2bc4f237bdd53e8/external/gazelle+/internal/bzlmod/go_mod.bzl", line 181, column 26, in deps_from_go_mod
		go_mod = parse_go_mod(go_mod_content, go_mod_path)
	File "/Users/rafiksalama/Library/Caches/bazel/_bazel_rafiksalama/c4824d8210ee1e28e2bc4f237bdd53e8/external/gazelle+/internal/bzlmod/go_mod.bzl", line 266, column 30, in parse_go_mod
		go = (int(major), int(minor)),
Error in int: invalid base-10 literal: "27rc1"
```

This change strips the strips all characters including and after `rc` from the go version string and parses major/minor from that. So, e.g. `1.27rc1` returns (1, 27) for major/minor.

**Which issues(s) does this PR fix?**

Fixes #

N/A. Original report in [Bazel slack](https://bazelbuild.slack.com/archives/CDBP88Z0D/p1783432998221279).
