### PR TITLE
fix: add Gazelle overrides for additional dependencies

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -32,6 +32,12 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:proto disable",
         "gazelle:go_naming_convention import_alias",
     ],
+    "github.com/argoproj/argo-rollouts": [
+        "gazelle:proto disable",
+    ],
+    "github.com/DataDog/datadog-api-client-go/v2": [
+        "gazelle:proto disable",
+    ],
     "github.com/authzed/cel-go": [
         "gazelle:go_naming_convention go_default_library",
     ],


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

//internal/bzlmod

**What does this PR do? Why is it needed?**

Adds `proto:disable` for two known transitive dependencies/usages where proto files don't allow for gazelle_overrides in transitive bazel modules.

**Which issues(s) does this PR fix?**

Fixes n/a

**Other notes for review**

One mitigation is to use `--experimental_isolated_extension_usages` and `... = use_extension("@gazelle//:extensions.bzl", "go_deps", isolate = True)`, but as that flag [amply informs](https://bazel.build/rules/lib/globals/module#parameters_13):
> This parameter is experimental and may change at any time. Please do not depend on it.

So until that's ready, this PR is one path to dealing with it.
