### PR TITLE
Record GOROOT as a label in go.env

### DIFF
--- a/internal/go_repository_cache.bzl
+++ b/internal/go_repository_cache.bzl
@@ -57,7 +57,11 @@ def _go_repository_cache_impl(ctx):
             fail("GOCACHE must be set when GO_REPOSITORY_USE_HOST_CACHE is enabled.")
 
     cache_env = {
-        "GOROOT": go_root,
+        # Record the SDK repo's ROOT file as a label rather than an absolute
+        # path so that consumers are forced to add a dependency on the Go SDK.
+        # This avoids a class of staleness issues, both with and without repo
+        # content caches.
+        "GOROOT": str(go_sdk_label),
         "GOCACHE": go_cache,
 
         # Since Go v1.21.0, set GOTOOLCHAIN to "local" to use the current toolchain
@@ -118,6 +122,11 @@ def read_cache_env(ctx, path):
         if sep == "":
             fail("failed to parse cache environment")
         env[k] = v.strip("'")
+
+    # Resolve the GOROOT label (see _go_repository_cache_impl) to an absolute
+    # path and register a dependency by doing so.
+    if env.get("GOROOT"):
+        env["GOROOT"] = str(ctx.path(Label(env["GOROOT"])).dirname)
     return env
 
 # copied from rules_go. Keep in sync.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

`go_repository_cache` writes `GOROOT` into `go.env` as an absolute path into the output base that fetched it, and that path reaches every `go_repository` fetch as a plain string. This has two problems, all of which surface as non-deterministic failures of the form `fetch_repo: go mod download exec error: .../bin/go: no such file or directory`:

1. There is no dependency edge from a `go_repository` fetch to the Go SDK repo, so a fetch can execute `$GOROOT/bin/go` while the SDK repo is concurrently being refetched (its directory is deleted before re-extraction). This can be triggered by, for example, upgrading rules_go (invalidates the SDK repo) and gazelle (invalidates all `go_repository` repos via the watched `fetch_repo` binary) at the same time.
2. With Bazel's `--experimental_remote_repo_contents_cache`, an SDK repo served from the cache exists only in Bazel's in-memory overlay file system until something materializes it. Materialization is triggered by resolving a label into the repo, which only ever happened in `go_repository_cache` itself — a repo whose own cache hit skips exactly that code. `fetch_repo`, a host subprocess reading the real file system, then fails to exec `$GOROOT/bin/go`.

This PR records the label of the SDK repo's `ROOT` file in `go.env` instead and resolves it back to a path in `read_cache_env`, i.e. in the context of the consuming repository rule. The label resolution creates the missing dependency edge (fixing 1), goes through `getPathFromLabel` and thus materializes a remote repo contents cache hit before any subprocess reads it (fixing 2), and is independent of the output base that wrote `go.env` (avoids absolute paths in repo rule outputs).

**Which issues(s) does this PR fix?**

No issue filed; the failure mode is described above.

**Other notes for review**

Verified with `bazel test //internal:bazel_test --test_env=PATH`, which exercises the full `go_repository` fetch pipeline including `go.env` creation and consumption.
