### PR TITLE
fix: use v2 testtools in generation tests

### DIFF
--- a/internal/generationtest/BUILD.bazel
+++ b/internal/generationtest/BUILD.bazel
@@ -26,7 +26,7 @@ go_library(
     srcs = ["generation_test.go"],
     visibility = ["//visibility:public"],
     deps = [
-        "//testtools",
+        "//v2/testtools",
         "@io_bazel_rules_go//go/runfiles",
     ],
 )

--- a/internal/generationtest/generation_test.go
+++ b/internal/generationtest/generation_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/bazel-contrib/bazel-gazelle/v2/testtools"
 	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 


### PR DESCRIPTION
The compatibility module already requires `github.com/bazel-contrib/bazel-gazelle/v2`, but `internal/generationtest` still depends on the legacy `//testtools` target and imports `github.com/bazelbuild/bazel-gazelle/testtools`.

This split makes generation tests resolve a different testtools package from the v2 dependency graph. Switch both the Bazel target and the Go import to the canonical v2 package so the generation-test helper and the module graph agree.

The change is limited to the existing generation-test BUILD dependency and import; it does not change production Gazelle behavior.