### PR TITLE
fix release script to use tzst as expected

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "",  
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tzst"
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
-      release_files: bazel-gazelle-*.tar.zst
+      release_files: bazel-gazelle-*.tzst
       prerelease: false
       tag_name: ${{ inputs.tag_name || github.ref_name }}
   publish:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset -o pipefail
 TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="bazel-gazelle-${TAG:1}"
-ARCHIVE="bazel-gazelle-$TAG.tar.zst"
+ARCHIVE="bazel-gazelle-$TAG.tzst"
 git archive --format=tar "${TAG}" | zstd >"$ARCHIVE"
 SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 


### PR DESCRIPTION
Fixing https://github.com/bazel-contrib/bazel-gazelle/issues/2376
.tzst is necessary because the pinned attestation workflow recognizes it