### PR TITLE
fix releases for immutable GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,15 +10,25 @@ permissions:
   contents: write
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.0
     with:
       release_files: bazel-gazelle-*.tar.gz
       prerelease: false
-      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      # Keep the release mutable while publish.yaml uploads BCR attestations.
+      draft: true
+      tag_name: ${{ github.ref_name }}
   publish:
     needs: release
     uses: ./.github/workflows/publish.yaml
     with:
-      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      tag_name: ${{ github.ref_name }}
     secrets:
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+  finalize:
+    # Publish the draft only after BCR publishing succeeds.
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
This updates the release workflow to support immutable [GitHub releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases). Releases are now created as drafts so the BCR publishing workflow can attach its attestations before the assets are locked, then published only after BCR publishing succeeds.

This follows the release sequence used by [bazel-contrib/rules-template] (https://github.com/bazel-contrib/rules-template/blob/main/.github/workflows/release.yaml). It does not change release archive format.