### PR TITLE
Simplify gazelle_binary

### DIFF
--- a/cmd/gazelle/langs.go
+++ b/cmd/gazelle/langs.go
@@ -22,8 +22,10 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 )
 
-var languages = []language.Language{
-	visibility.NewLanguage(),
-	proto.NewLanguage(),
-	golang.NewLanguage(),
+func init() {
+	languages = []language.Language{
+		visibility.NewLanguage(),
+		proto.NewLanguage(),
+		golang.NewLanguage(),
+	}
 }

--- a/cmd/gazelle/main.go
+++ b/cmd/gazelle/main.go
@@ -30,6 +30,8 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/language"
 )
 
+var languages []language.Language
+
 type command int
 
 const (

--- a/def.bzl
+++ b/def.bzl
@@ -34,7 +34,7 @@ load(
 )
 load(
     "//internal:gazelle_binary.bzl",
-    _gazelle_binary = "gazelle_binary_wrapper",
+    _gazelle_binary = "gazelle_binary",
 )
 load(
     "//internal:go_repository.bzl",

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -34,15 +34,17 @@ import (
 	{lang_imports}
 )
 
-var languages = []language.Language{{
-	{lang_calls},
+func init() {{
+	languages = []language.Language{{
+		{lang_calls},
+	}}
 }}
 """
     lang_imports = [format_import(d[GoArchive].data.importpath) for d in ctx.attr.languages]
     lang_calls = [format_call(d[GoArchive].data.importpath) for d in ctx.attr.languages]
     langs_content = langs_content_tpl.format(
         lang_imports = "\n\t".join(lang_imports),
-        lang_calls = ",\n\t".join(lang_calls),
+        lang_calls = ",\n\t\t".join(lang_calls),
     )
     ctx.actions.write(langs_file, langs_content)
     return DefaultInfo(files = depset([langs_file]))

--- a/internal/gazelle_binary.bzl
+++ b/internal/gazelle_binary.bzl
@@ -20,27 +20,11 @@ load(
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "GoArchive",
-    "go_context",
-    "new_go_info",
-)
-load(
-    "@io_bazel_rules_go//go/private:context.bzl",
-    "CGO_ATTRS",
-    "CGO_FRAGMENTS",
-    "CGO_TOOLCHAINS",
+    "go_binary",
 )
 
-def _gazelle_binary_impl(ctx):
-    go = go_context(ctx)
-
-    version = ctx.attr.version
-    if version == 0:
-        version = _get_gazelle_major_version()
-    srcs = ctx.attr._srcs_v2 if version == 2 else ctx.attr._srcs_v1
-
-    # Generate a source file with a list of languages. This will get compiled
-    # with the rest of the sources in the main package.
-    langs_file = go.declare_file(go, "langs.go")
+def _gazelle_main_impl(ctx):
+    langs_file = ctx.actions.declare_file(ctx.label.name + ".go")
     langs_content_tpl = """
 package main
 
@@ -60,50 +44,12 @@ var languages = []language.Language{{
         lang_imports = "\n\t".join(lang_imports),
         lang_calls = ",\n\t".join(lang_calls),
     )
-    go.actions.write(langs_file, langs_content)
+    ctx.actions.write(langs_file, langs_content)
+    return DefaultInfo(files = depset([langs_file]))
 
-    # Build the gazelle binary.
-    attr = struct(
-        srcs = [struct(files = [langs_file])],
-        deps = ctx.attr.languages,
-        embed = [srcs],
-    )
-    go_info = new_go_info(go, attr, is_main = True)
-
-    archive, executable, runfiles = go.binary(
-        go,
-        name = ctx.label.name,
-        source = go_info,
-        version_file = ctx.version_file,
-        info_file = ctx.info_file,
-    )
-
-    return [
-        go_info,
-        archive,
-        OutputGroupInfo(compilation_outputs = [archive.data.file]),
-        DefaultInfo(
-            files = depset([executable]),
-            runfiles = runfiles,
-            executable = executable,
-        ),
-    ]
-
-_gazelle_binary_kwargs = {
-    "implementation": _gazelle_binary_impl,
-    "doc": """The `gazelle_binary` rule builds a Go binary that incorporates a list of
-language extensions. This requires generating a small amount of code that
-must be compiled into Gazelle's main package, so the normal [go_binary]
-rule is not used.
-
-When the binary runs, each language extension is run sequentially. This affects
-the order that rules appear in generated build files. Metadata may be produced
-by an earlier extension and consumed by a later extension. For example, the
-proto extension stores metadata in hidden attributes of generated
-`proto_library` rules. The Go extension uses this metadata to generate
-`go_proto_library` rules.
-""",
-    "attrs": {
+gazelle_main = rule(
+    implementation = _gazelle_main_impl,
+    attrs = {
         "languages": attr.label_list(
             doc = """A list of language extensions the Gazelle binary will use.
 
@@ -114,40 +60,31 @@ proto extension stores metadata in hidden attributes of generated
             mandatory = True,
             allow_empty = False,
         ),
-        "version": attr.int(
-            default = 0,
-            values = [0, 1, 2],
-            doc = """The major version of Gazelle to build for
+    },
+)
 
-            - 0 (default): the version is chosen automatically, based on the
-              module version.
-            - 1: legacy CLI behavior. Includes update-repos subcommand for Go.
-            - 2: new CLI behavior.
-            """,
-        ),
-        "_go_context_data": attr.label(default = "@io_bazel_rules_go//:go_context_data"),
-        # _stdlib is needed for rules_go versions before v0.23.0. After that,
-        # _go_context_data includes a dependency on stdlib.
-        "_stdlib": attr.label(default = "@io_bazel_rules_go//:stdlib"),
-        "_srcs_v1": attr.label(
-            default = "//cmd/gazelle:gazelle_lib",
-        ),
-        "_srcs_v2": attr.label(
-            default = "//v2/cmd/gazelle:gazelle_lib",
-        ),
-    } | CGO_ATTRS,
-    "executable": True,
-    "fragments": CGO_FRAGMENTS,
-    "toolchains": ["@io_bazel_rules_go//go:toolchain"] + CGO_TOOLCHAINS,
-}
+def gazelle_binary(name, languages, version = 0, **kwargs):
+    """Builds a Gazelle binary with the requested language extensions."""
 
-gazelle_binary = rule(**_gazelle_binary_kwargs)
+    if version not in (0, 1, 2):
+        fail("gazelle_binary version must be 0, 1, or 2")
+    if version == 0:
+        version = _get_gazelle_major_version()
 
-def gazelle_binary_wrapper(**kwargs):
-    for key in ("goos", "goarch", "static", "msan", "race", "pure", "strip", "debug", "linkmode", "gotags"):
-        if key in kwargs:
-            fail("gazelle_binary attribute '%s' is no longer supported (https://github.com/bazelbuild/bazel-gazelle/issues/803)" % key)
-    gazelle_binary(**kwargs)
+    main_name = name + "_main"
+    gazelle_main(
+        name = main_name,
+        languages = languages,
+        testonly = kwargs.get("testonly", False),
+        visibility = ["//visibility:private"],
+    )
+    go_binary(
+        name = name,
+        srcs = [main_name],
+        deps = languages,
+        embed = [Label("//v2/cmd/gazelle:gazelle_lib") if version == 2 else Label("//cmd/gazelle:gazelle_lib")],
+        **kwargs
+    )
 
 def _import_alias(importpath):
     return importpath.replace("/", "_").replace(".", "_").replace("-", "_") + "_"

--- a/reference.md
+++ b/reference.md
@@ -41,9 +41,9 @@ Builds a Gazelle binary with the requested language extensions.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| name |  <p> - </p>   |  none |
-| languages |  <p> - </p>   |  none |
-| version |  <p> - </p>   |  `0` |
+| <a id="gazelle_binary-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="gazelle_binary-languages"></a>languages |  <p align="center"> - </p>   |  none |
+| <a id="gazelle_binary-version"></a>version |  <p align="center"> - </p>   |  `0` |
 | <a id="gazelle_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/reference.md
+++ b/reference.md
@@ -31,16 +31,19 @@ gazelle(<a href="#gazelle-name">name</a>, <a href="#gazelle-testonly">testonly</
 <pre>
 load("@gazelle//:def.bzl", "gazelle_binary")
 
-gazelle_binary(<a href="#gazelle_binary-kwargs">**kwargs</a>)
+gazelle_binary(<a href="#gazelle_binary-name">name</a>, <a href="#gazelle_binary-languages">languages</a>, <a href="#gazelle_binary-version">version</a>, <a href="#gazelle_binary-kwargs">**kwargs</a>)
 </pre>
 
-
+Builds a Gazelle binary with the requested language extensions.
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
+| name |  <p> - </p>   |  none |
+| languages |  <p> - </p>   |  none |
+| version |  <p> - </p>   |  `0` |
 | <a id="gazelle_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
@@ -321,5 +324,4 @@ http_archive(
 | <a id="http_archive-strip_prefix"></a>strip_prefix |  A directory prefix to strip. See [http_archive.strip_prefix].   | String | optional |  `""`  |
 | <a id="http_archive-type"></a>type |  One of `"zip"`, `"tar.gz"`, `"tgz"`, `"tar.bz2"`, `"tar.xz"`.<br><br>The file format of the repository archive. This is normally inferred from the downloaded file name.   | String | optional |  `""`  |
 | <a id="http_archive-urls"></a>urls |  A list of HTTP(S) URLs where the project can be downloaded. Bazel will attempt to download the first URL; the others are mirrors.   | List of strings | optional |  `[]`  |
-
 

--- a/reference.md
+++ b/reference.md
@@ -325,3 +325,4 @@ http_archive(
 | <a id="http_archive-type"></a>type |  One of `"zip"`, `"tar.gz"`, `"tgz"`, `"tar.bz2"`, `"tar.xz"`.<br><br>The file format of the repository archive. This is normally inferred from the downloaded file name.   | String | optional |  `""`  |
 | <a id="http_archive-urls"></a>urls |  A list of HTTP(S) URLs where the project can be downloaded. Bazel will attempt to download the first URL; the others are mirrors.   | List of strings | optional |  `[]`  |
 
+

--- a/v2/cmd/gazelle/langs.go
+++ b/v2/cmd/gazelle/langs.go
@@ -22,8 +22,10 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 )
 
-var languages = []language.Language{
-	visibility.NewLanguage(),
-	proto.NewLanguage(),
-	golang.NewLanguage(),
+func init() {
+	languages = []language.Language{
+		visibility.NewLanguage(),
+		proto.NewLanguage(),
+		golang.NewLanguage(),
+	}
 }

--- a/v2/cmd/gazelle/main.go
+++ b/v2/cmd/gazelle/main.go
@@ -25,7 +25,10 @@ import (
 	"os/signal"
 
 	"github.com/bazel-contrib/bazel-gazelle/v2/cmd/gazelle/update"
+	"github.com/bazelbuild/bazel-gazelle/language"
 )
+
+var languages []language.Language
 
 func main() {
 	log.SetPrefix("gazelle: ")


### PR DESCRIPTION
**What type of PR is this?**

Refactor

**What package or component does this PR mostly affect?**
cmd/gazelle

**What does this PR do? Why is it needed?**
Simplifies how gazelle generates the main.go for the binary to avoid relying on the go context's `actions` which is a bit of an unfortunate public interface.

Hopefully other rule authors with similar needs can use this as inspiration to simplify their setup and future-proof themselves against rules_go internal changes that end up leaking.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
